### PR TITLE
ci: add codecov upload and skip duplicate steps

### DIFF
--- a/.github/workflows/check_pr.yml
+++ b/.github/workflows/check_pr.yml
@@ -1,0 +1,27 @@
+on:
+  workflow_call:
+    outputs:
+      branch-pr:
+        description: The PR number if the branch is in one
+        value: ${{ jobs.pr.outputs.branch-pr }}
+
+jobs:
+  pr:
+    runs-on: "ubuntu-latest"
+    outputs:
+      branch-pr: ${{ steps.script.outputs.result }}
+    steps:
+      - uses: actions/github-script@v7
+        id: script
+        if: github.event_name == 'push'
+        with:
+          script: |
+            const prs = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head: context.repo.owner + ':${{ github.ref_name }}'
+            })
+            if (prs.data.length) {
+              console.log(`::notice ::Skipping CI on branch push as it is already run in PR #${prs.data[0]["number"]}`)
+              return prs.data[0]["number"]
+            }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ jobs:
 
   unit-test:
     uses: ./.github/workflows/pytest.yml
-    with:
-        pr_number: ${{ github.event.pull_request.number }}
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   unit-test-matrix:
     uses: ./.github/workflows/pytest-matrix.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,16 +5,27 @@ permissions:
   pull-requests: write
 
 jobs:
+  check_pr_status:
+    uses: ./.github/workflows/check_pr.yml
+
   formatter:
+    needs: check_pr_status
+    if: needs.check_pr_status.outputs.branch-pr == ''
     uses: ./.github/workflows/formatter.yml
 
   unit-test:
+    needs: check_pr_status
+    if: needs.check_pr_status.outputs.branch-pr == ''
     uses: ./.github/workflows/pytest.yml
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   unit-test-matrix:
+    needs: check_pr_status
+    if: needs.check_pr_status.outputs.branch-pr == ''
     uses: ./.github/workflows/pytest-matrix.yml
 
   end2end-test:
+    needs: check_pr_status
+    if: needs.check_pr_status.outputs.branch-pr == ''
     uses: ./.github/workflows/end2end-conda.yml

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,11 +1,15 @@
 name: Run Pytest with Coverage
 on: 
   workflow_call:
-      inputs:
-        pr_number:
-          description: 'Pull request number'
-          required: false
-          type: number
+    inputs:
+      pr_number:
+        description: 'Pull request number'
+        required: false
+        type: number
+    secrets:
+      CODECOV_TOKEN:
+        required: true
+
 
 
 permissions:
@@ -52,44 +56,11 @@ jobs:
       - name: Run Pytest with Coverage
         id: coverage
         run: |
-          pip install coverage pytest pytest-random-order
-          coverage run --source=./bec_widgets -m pytest -v --junitxml=report.xml --maxfail=2 --random-order --full-trace ./tests/unit_tests
+          pip install coverage pytest pytest-random-order pytest-cov
+          pytest --cov --random-order --cov-branch --cov-report=xml tests/unit_tests/
 
-          full_report=$(coverage report)
-          coverage xml -i -o coverage.cobertura.xml
-
-            # Extract total coverage %
-          COVERAGE=$(echo "$full_report" | grep TOTAL | awk '{print $4}' | sed 's/%//')
-          echo "coverage=$COVERAGE" >> $GITHUB_OUTPUT
-
-      - name: Code Coverage Summary Report
-        uses: irongut/CodeCoverageSummary@v1.3.0
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
         with:
-          filename: coverage.cobertura.xml
-          format: 'markdown'
-          output: 'both'
-
-      - name: Format Coverage Report
-        shell: bash
-        run: |
-          tmpfile=$(cat code-coverage-results.md)
-          echo "## Code Coverage Report" > code-coverage-results-formatted.md
-          echo "![Coverage Badge](https://img.shields.io/badge/coverage-${{ steps.coverage.outputs.coverage }}%25-brightgreen)" >> code-coverage-results-formatted.md
-          echo "<details>" >> code-coverage-results-formatted.md
-          echo "<summary>Code Coverage</summary>" >> code-coverage-results-formatted.md
-          echo >> code-coverage-results-formatted.md
-          echo >> code-coverage-results-formatted.md
-          echo "$tmpfile" >> code-coverage-results-formatted.md
-          echo "</details>" >> code-coverage-results-formatted.md
-
-      - name: Add Coverage PR Comment
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: marocchino/sticky-pull-request-comment@v2
-        with:
-          number: ${{ github.event.pull_request.number }}
-          recreate: true
-          path: code-coverage-results-formatted.md
-
-      - name: Write Coverage to Job Summary
-        shell: bash
-        run: cat code-coverage-results.md >> $GITHUB_STEP_SUMMARY
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: bec-project/bec_widgets


### PR DESCRIPTION
- Replace the coverage report comment CI step with uploading a coverage report to Codecov
- Copy the logic from https://github.com/DiamondLightSource/python-copier-template/blob/main/.github/workflows/_check.yml to avoid running workflows for both PR and push when there is a PR for the branch