### PR TITLE
Tidy up CI

### DIFF
--- a/.github/workflows/check_pr.yml
+++ b/.github/workflows/check_pr.yml
@@ -1,3 +1,4 @@
+name: Check PR status for branch
 on:
   workflow_call:
     outputs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,18 +14,18 @@ jobs:
     uses: ./.github/workflows/formatter.yml
 
   unit-test:
-    needs: check_pr_status
+    needs: [check_pr_status, formatter]
     if: needs.check_pr_status.outputs.branch-pr == ''
     uses: ./.github/workflows/pytest.yml
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   unit-test-matrix:
-    needs: check_pr_status
+    needs: [check_pr_status, formatter]
     if: needs.check_pr_status.outputs.branch-pr == ''
     uses: ./.github/workflows/pytest-matrix.yml
 
   end2end-test:
-    needs: check_pr_status
+    needs: [check_pr_status, formatter]
     if: needs.check_pr_status.outputs.branch-pr == ''
     uses: ./.github/workflows/end2end-conda.yml

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -57,7 +57,7 @@ jobs:
         id: coverage
         run: |
           pip install coverage pytest pytest-random-order pytest-cov
-          pytest --cov --random-order --cov-branch --cov-report=xml tests/unit_tests/
+          pytest --random-order --cov --cov-config=pyproject.toml --cov-branch --cov-report=xml --no-cov-on-fail tests/unit_tests/
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,3 +105,14 @@ env = "GL_TOKEN"
 [tool.semantic_release.publish]
 dist_glob_patterns = ["dist/*"]
 upload_to_vcs_release = true
+
+[tool.coverage.report]
+skip_empty = true # exclude empty *files*, e.g. __init__.py, from the report
+exclude_lines = [
+    "pragma: no cover",
+    "if TYPE_CHECKING:",
+    "return NotImplemented",
+    "raise NotImplementedError",
+    "...",
+    'if __name__ == "__main__":',
+]


### PR DESCRIPTION
- Don't submit coverage if tests fail
- Tidy up the names of workflows
- Only run expensive test jobs if the linter passes
- Exclude common things (e.g. `TYPE_CHECKING`, `if __name__ == "__main__"`) from coverage by default