### PR TITLE
  ci: include lines with at least three characters in report

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -55,9 +55,7 @@ jobs:
 
       - name: Run Pytest with Coverage
         id: coverage
-        run: |
-          pip install coverage pytest pytest-random-order pytest-cov
-          pytest --random-order --cov --cov-config=pyproject.toml --cov-branch --cov-report=xml --no-cov-on-fail tests/unit_tests/
+        run: pytest --random-order --cov --cov-config=pyproject.toml --cov-branch --cov-report=xml --no-cov-on-fail tests/unit_tests/
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dev = [
     "pytest-timeout~=2.2",
     "pytest-xvfb~=3.0",
     "pytest~=8.0",
+    "pytest-cov~=6.1.1",
 ]
 
 [project.urls]
@@ -113,6 +114,6 @@ exclude_lines = [
     "if TYPE_CHECKING:",
     "return NotImplemented",
     "raise NotImplementedError",
-    "...",
+    "\\.\\.\\.",
     'if __name__ == "__main__":',
 ]


### PR DESCRIPTION
in https://github.com/bec-project/bec_widgets/commit/01870f9cdaa42cf418740833adeb14a2f014e498 the *regex* `"..."` was excluded from the coverage report, rather than the literal