### PR TITLE
fix(entry_validator): device signals retrieved from ._info instead of .describe(), close #570

### DIFF
--- a/bec_widgets/utils/entry_validator.py
+++ b/bec_widgets/utils/entry_validator.py
@@ -17,13 +17,23 @@ class EntryValidator:
             raise ValueError(f"Device '{name}' not found in current BEC session")
 
         device = self.devices[name]
-        description = device.describe()
+
+        # Build list of available signal entries from device._info['signals']
+        signals_dict = getattr(device, "_info", {}).get("signals", {})
+        available_entries = [
+            sig.get("obj_name") for sig in signals_dict.values() if sig.get("obj_name")
+        ]
+
+        # If no signals are found, means device is a signal, use the device name as the entry
+        if not available_entries:
+            available_entries = [name]
 
         if entry is None or entry == "":
             entry = next(iter(device._hints), name) if hasattr(device, "_hints") else name
-        if entry not in description:
+        if entry not in available_entries:
             raise ValueError(
-                f"Entry '{entry}' not found in device '{name}' signals. Available signals: {description.keys()}"
+                f"Entry '{entry}' not found in device '{name}' signals. "
+                f"Available signals: '{available_entries}'"
             )
 
         return entry


### PR DESCRIPTION
Change in entry validation to use ._info, can be used for validation of nested devices.

closes #570