### PR TITLE
Fix/signal line edit

### DIFF
--- a/bec_widgets/cli/client.py
+++ b/bec_widgets/cli/client.py
@@ -51,6 +51,8 @@ _Widgets = {
     "RingProgressBar": "RingProgressBar",
     "ScanControl": "ScanControl",
     "ScatterWaveform": "ScatterWaveform",
+    "SignalComboBox": "SignalComboBox",
+    "SignalLineEdit": "SignalLineEdit",
     "StopButton": "StopButton",
     "TextBox": "TextBox",
     "VSCodeEditor": "VSCodeEditor",
@@ -939,9 +941,22 @@ class DeviceComboBox(RPCBase):
     """Combobox widget for device input with autocomplete for device names."""
 
     @rpc_call
-    def remove(self):
+    def set_device(self, device: "str"):
         """
-        Cleanup the BECConnector
+        Set the device.
+
+        Args:
+            device (str): Default name.
+        """
+
+    @property
+    @rpc_call
+    def devices(self) -> "list[str]":
+        """
+        Get the list of devices for the applied filters.
+
+        Returns:
+            list[str]: List of devices.
         """
 
 
@@ -959,9 +974,32 @@ class DeviceLineEdit(RPCBase):
     """Line edit widget for device input with autocomplete for device names."""
 
     @rpc_call
-    def remove(self):
+    def set_device(self, device: "str"):
         """
-        Cleanup the BECConnector
+        Set the device.
+
+        Args:
+            device (str): Default name.
+        """
+
+    @property
+    @rpc_call
+    def devices(self) -> "list[str]":
+        """
+        Get the list of devices for the applied filters.
+
+        Returns:
+            list[str]: List of devices.
+        """
+
+    @property
+    @rpc_call
+    def _is_valid_input(self) -> bool:
+        """
+        Check if the current value is a valid device name.
+
+        Returns:
+            bool: True if the current value is a valid device name, False otherwise.
         """
 
 
@@ -3344,6 +3382,80 @@ class ScatterWaveform(RPCBase):
     def clear_all(self):
         """
         Clear all the curves from the plot.
+        """
+
+
+class SignalComboBox(RPCBase):
+    """Line edit widget for device input with autocomplete for device names."""
+
+    @rpc_call
+    def set_signal(self, signal: str):
+        """
+        Set the signal.
+
+        Args:
+            signal (str): signal name.
+        """
+
+    @rpc_call
+    def set_device(self, device: str | None):
+        """
+        Set the device. If device is not valid, device will be set to None which happpens
+
+        Args:
+            device(str): device name.
+        """
+
+    @property
+    @rpc_call
+    def signals(self) -> list[str]:
+        """
+        Get the list of device signals for the applied filters.
+
+        Returns:
+            list[str]: List of device signals.
+        """
+
+
+class SignalLineEdit(RPCBase):
+    """Line edit widget for device input with autocomplete for device names."""
+
+    @property
+    @rpc_call
+    def _is_valid_input(self) -> bool:
+        """
+        Check if the current value is a valid device name.
+
+        Returns:
+            bool: True if the current value is a valid device name, False otherwise.
+        """
+
+    @rpc_call
+    def set_signal(self, signal: str):
+        """
+        Set the signal.
+
+        Args:
+            signal (str): signal name.
+        """
+
+    @rpc_call
+    def set_device(self, device: str | None):
+        """
+        Set the device. If device is not valid, device will be set to None which happpens
+
+        Args:
+            device(str): device name.
+        """
+
+    @property
+    @rpc_call
+    def signals(self) -> list[str]:
+        """
+        Get the list of device signals for the applied filters.
+
+        Returns:
+            list[str]: List of device signals.
         """
 
 

--- a/bec_widgets/cli/client.py
+++ b/bec_widgets/cli/client.py
@@ -3400,7 +3400,7 @@ class SignalComboBox(RPCBase):
     @rpc_call
     def set_device(self, device: str | None):
         """
-        Set the device. If device is not valid, device will be set to None which happpens
+        Set the device. If device is not valid, device will be set to None which happens
 
         Args:
             device(str): device name.
@@ -3442,7 +3442,7 @@ class SignalLineEdit(RPCBase):
     @rpc_call
     def set_device(self, device: str | None):
         """
-        Set the device. If device is not valid, device will be set to None which happpens
+        Set the device. If device is not valid, device will be set to None which happens
 
         Args:
             device(str): device name.

--- a/bec_widgets/tests/utils.py
+++ b/bec_widgets/tests/utils.py
@@ -200,7 +200,13 @@ class DMMock:
         self.devices = DeviceContainer()
         self.enabled_devices = [device for device in self.devices if device.enabled]
 
-    def add_devives(self, devices: list):
+    def add_devices(self, devices: list):
+        """
+        Add devices to the DeviceContainer.
+
+        Args:
+            devices (list): List of device instances to add.
+        """
         for device in devices:
             self.devices[device.name] = device
 

--- a/bec_widgets/widgets/control/device_input/base_classes/device_signal_input_base.py
+++ b/bec_widgets/widgets/control/device_input/base_classes/device_signal_input_base.py
@@ -79,7 +79,7 @@ class DeviceSignalInputBase(BECWidget):
     @Slot(str)
     def set_device(self, device: str | None):
         """
-        Set the device. If device is not valid, device will be set to None which happpens
+        Set the device. If device is not valid, device will be set to None which happens
 
         Args:
             device(str): device name.

--- a/bec_widgets/widgets/control/device_input/base_classes/device_signal_input_base.py
+++ b/bec_widgets/widgets/control/device_input/base_classes/device_signal_input_base.py
@@ -112,9 +112,12 @@ class DeviceSignalInputBase(BECWidget):
         # See above convention for Signals and ComputedSignals
         if isinstance(device, Signal):
             self._signals = [self._device]
-            FilterIO.set_selection(widget=self, selection=[self._device])
+            self._hinted_signals = [self._device]
+            self._normal_signals = []
+            self._config_signals = []
+            FilterIO.set_selection(widget=self, selection=self._signals)
             return
-        device_info = device._info["signals"]
+        device_info = device._info.get("signals", {})
 
         def _update(kind: Kind):
             return [

--- a/bec_widgets/widgets/control/device_input/device_combobox/device_combobox.py
+++ b/bec_widgets/widgets/control/device_input/device_combobox/device_combobox.py
@@ -22,6 +22,8 @@ class DeviceComboBox(DeviceInputBase, QComboBox):
         config: Device input configuration.
         gui_id: GUI ID.
         device_filter: Device filter, name of the device class from BECDeviceFilter and BECReadoutPriority. Check DeviceInputBase for more details.
+        readout_priority_filter: Readout priority filter, name of the readout priority class from BECDeviceFilter and BECReadoutPriority. Check DeviceInputBase for more details.
+        available_devices: List of available devices, if passed, it sets apply filters to false and device/readout priority filters will not be applied.
         default: Default device name.
         arg_name: Argument name, can be used for the other widgets which has to call some other function in bec using correct argument names.
     """

--- a/bec_widgets/widgets/control/device_input/device_combobox/device_combobox.py
+++ b/bec_widgets/widgets/control/device_input/device_combobox/device_combobox.py
@@ -26,6 +26,8 @@ class DeviceComboBox(DeviceInputBase, QComboBox):
         arg_name: Argument name, can be used for the other widgets which has to call some other function in bec using correct argument names.
     """
 
+    USER_ACCESS = ["set_device", "devices"]
+
     ICON_NAME = "list_alt"
     PLUGIN = True
 

--- a/bec_widgets/widgets/control/device_input/device_line_edit/device_line_edit.py
+++ b/bec_widgets/widgets/control/device_input/device_line_edit/device_line_edit.py
@@ -24,7 +24,9 @@ class DeviceLineEdit(DeviceInputBase, QLineEdit):
         client: BEC client object.
         config: Device input configuration.
         gui_id: GUI ID.
-        device_filter: Device filter, name of the device class from BECDeviceFilter and ReadoutPriority. Check DeviceInputBase for more details.
+        device_filter: Device filter, name of the device class from BECDeviceFilter and BECReadoutPriority. Check DeviceInputBase for more details.
+        readout_priority_filter: Readout priority filter, name of the readout priority class from BECDeviceFilter and BECReadoutPriority. Check DeviceInputBase for more details.
+        available_devices: List of available devices, if passed, it sets apply filters to false and device/readout priority filters will not be applied.
         default: Default device name.
         arg_name: Argument name, can be used for the other widgets which has to call some other function in bec using correct argument names.
     """

--- a/bec_widgets/widgets/control/device_input/device_line_edit/device_line_edit.py
+++ b/bec_widgets/widgets/control/device_input/device_line_edit/device_line_edit.py
@@ -29,6 +29,8 @@ class DeviceLineEdit(DeviceInputBase, QLineEdit):
         arg_name: Argument name, can be used for the other widgets which has to call some other function in bec using correct argument names.
     """
 
+    USER_ACCESS = ["set_device", "devices", "_is_valid_input"]
+
     device_selected = Signal(str)
     device_config_update = Signal()
 
@@ -51,7 +53,7 @@ class DeviceLineEdit(DeviceInputBase, QLineEdit):
         **kwargs,
     ):
         self._callback_id = None
-        self._is_valid_input = False
+        self.__is_valid_input = False
         self._accent_colors = get_accent_colors()
         super().__init__(parent=parent, client=client, gui_id=gui_id, config=config, **kwargs)
         self.completer = QCompleter(self)
@@ -94,6 +96,20 @@ class DeviceLineEdit(DeviceInputBase, QLineEdit):
         self.device_config_update.connect(self.update_devices_from_filters)
         self.textChanged.connect(self.check_validity)
         self.check_validity(self.text())
+
+    @property
+    def _is_valid_input(self) -> bool:
+        """
+        Check if the current value is a valid device name.
+
+        Returns:
+            bool: True if the current value is a valid device name, False otherwise.
+        """
+        return self.__is_valid_input
+
+    @_is_valid_input.setter
+    def _is_valid_input(self, value: bool) -> None:
+        self.__is_valid_input = value
 
     def on_device_update(self, action: str, content: dict) -> None:
         """

--- a/bec_widgets/widgets/control/device_input/signal_combobox/signal_combobox.py
+++ b/bec_widgets/widgets/control/device_input/signal_combobox/signal_combobox.py
@@ -23,8 +23,11 @@ class SignalComboBox(DeviceSignalInputBase, QComboBox):
         arg_name: Argument name, can be used for the other widgets which has to call some other function in bec using correct argument names.
     """
 
+    USER_ACCESS = ["set_signal", "set_device", "signals"]
+
     ICON_NAME = "list_alt"
     PLUGIN = True
+    RPC = True
 
     device_signal_changed = Signal(str)
 

--- a/bec_widgets/widgets/control/device_input/signal_line_edit/signal_line_edit.py
+++ b/bec_widgets/widgets/control/device_input/signal_line_edit/signal_line_edit.py
@@ -24,9 +24,12 @@ class SignalLineEdit(DeviceSignalInputBase, QLineEdit):
         arg_name: Argument name, can be used for the other widgets which has to call some other function in bec using correct argument names.
     """
 
+    USER_ACCESS = ["_is_valid_input", "set_signal", "set_device", "signals"]
+
     device_signal_changed = Signal(str)
 
     PLUGIN = True
+    RPC = True
     ICON_NAME = "vital_signs"
 
     def __init__(
@@ -41,7 +44,7 @@ class SignalLineEdit(DeviceSignalInputBase, QLineEdit):
         arg_name: str | None = None,
         **kwargs,
     ):
-        self._is_valid_input = False
+        self.__is_valid_input = False
         super().__init__(parent=parent, client=client, gui_id=gui_id, config=config, **kwargs)
         self._accent_colors = get_accent_colors()
         self.completer = QCompleter(self)
@@ -67,6 +70,20 @@ class SignalLineEdit(DeviceSignalInputBase, QLineEdit):
             self.set_signal(default)
         self.textChanged.connect(self.check_validity)
         self.check_validity(self.text())
+
+    @property
+    def _is_valid_input(self) -> bool:
+        """
+        Check if the current value is a valid device name.
+
+        Returns:
+            bool: True if the current value is a valid device name, False otherwise.
+        """
+        return self.__is_valid_input
+
+    @_is_valid_input.setter
+    def _is_valid_input(self, value: bool) -> None:
+        self.__is_valid_input = value
 
     def get_current_device(self) -> object:
         """

--- a/bec_widgets/widgets/control/device_input/signal_line_edit/signal_line_edit.py
+++ b/bec_widgets/widgets/control/device_input/signal_line_edit/signal_line_edit.py
@@ -65,8 +65,8 @@ class SignalLineEdit(DeviceSignalInputBase, QLineEdit):
             self.set_device(device)
         if default is not None:
             self.set_signal(default)
-        self.textChanged.connect(self.validate_device)
-        self.validate_device(self.text())
+        self.textChanged.connect(self.check_validity)
+        self.check_validity(self.text())
 
     def get_current_device(self) -> object:
         """
@@ -131,6 +131,9 @@ if __name__ == "__main__":  # pragma: no cover
     from qtpy.QtWidgets import QApplication, QVBoxLayout, QWidget
 
     from bec_widgets.utils.colors import set_theme
+    from bec_widgets.widgets.control.device_input.device_combobox.device_combobox import (
+        DeviceComboBox,
+    )
 
     app = QApplication([])
     set_theme("dark")
@@ -138,6 +141,12 @@ if __name__ == "__main__":  # pragma: no cover
     widget.setFixedSize(200, 200)
     layout = QVBoxLayout()
     widget.setLayout(layout)
-    layout.addWidget(SignalLineEdit(device="samx"))
+    device_line_edit = DeviceComboBox()
+    device_line_edit.filter_to_positioner = True
+    signal_line_edit = SignalLineEdit()
+    device_line_edit.device_selected.connect(signal_line_edit.set_device)
+
+    layout.addWidget(device_line_edit)
+    layout.addWidget(signal_line_edit)
     widget.show()
     app.exec_()

--- a/tests/end-2-end/user_interaction/test_user_interaction_e2e.py
+++ b/tests/end-2-end/user_interaction/test_user_interaction_e2e.py
@@ -258,7 +258,10 @@ def test_widgets_e2e_device_combo_box(qtbot, connected_client_gui_obj, random_ge
     dock: client.BECDock
     widget: client.DeviceComboBox
 
-    # No rpc calls to check so far, maybe set_device should be exposed
+    assert "samx" in widget.devices
+    assert "bpm4i" in widget.devices
+
+    widget.set_device("samx")
 
     # Test removing the widget, or leaving it open for the next test
     maybe_remove_dock_area(qtbot, gui=gui, random_int_gen=random_generator_from_seed)
@@ -274,10 +277,64 @@ def test_widgets_e2e_device_line_edit(qtbot, connected_client_gui_obj, random_ge
     dock: client.BECDock
     widget: client.DeviceLineEdit
 
-    # No rpc calls to check so far
-    # Should probably have a set_device method
+    assert widget._is_valid_input is False
+    assert "samx" in widget.devices
+    assert "bpm4i" in widget.devices
 
-    # No rpc calls to check so far, maybe set_device should be exposed
+    widget.set_device("samx")
+    assert widget._is_valid_input is True
+
+    # Test removing the widget, or leaving it open for the next test
+    maybe_remove_dock_area(qtbot, gui=gui, random_int_gen=random_generator_from_seed)
+
+
+@pytest.mark.timeout(PYTEST_TIMEOUT)
+def test_widgets_e2e_signal_line_edit(qtbot, connected_client_gui_obj, random_generator_from_seed):
+    """Test the DeviceSignalLineEdit widget."""
+    gui = connected_client_gui_obj
+    bec = gui._client
+    # Create dock_area, dock, widget
+    dock, widget = create_widget(qtbot, gui, gui.available_widgets.SignalLineEdit)
+    dock: client.BECDock
+    widget: client.SignalLineEdit
+
+    widget.set_device("samx")
+    assert widget._is_valid_input is False
+    assert widget.signals == [
+        "readback",
+        "setpoint",
+        "motor_is_moving",
+        "velocity",
+        "acceleration",
+        "tolerance",
+    ]
+    widget.set_signal("readback")
+    assert widget._is_valid_input is True
+
+    # Test removing the widget, or leaving it open for the next test
+    maybe_remove_dock_area(qtbot, gui=gui, random_int_gen=random_generator_from_seed)
+
+
+@pytest.mark.timeout(PYTEST_TIMEOUT)
+def test_widgets_e2e_signal_combobox(qtbot, connected_client_gui_obj, random_generator_from_seed):
+    """Test the DeviceSignalComboBox widget."""
+    gui = connected_client_gui_obj
+    bec = gui._client
+    # Create dock_area, dock, widget
+    dock, widget = create_widget(qtbot, gui, gui.available_widgets.SignalComboBox)
+    dock: client.BECDock
+    widget: client.SignalComboBox
+
+    widget.set_device("samx")
+    assert widget.signals == [
+        "readback",
+        "setpoint",
+        "motor_is_moving",
+        "velocity",
+        "acceleration",
+        "tolerance",
+    ]
+    widget.set_signal("readback")
 
     # Test removing the widget, or leaving it open for the next test
     maybe_remove_dock_area(qtbot, gui=gui, random_int_gen=random_generator_from_seed)

--- a/tests/unit_tests/client_mocks.py
+++ b/tests/unit_tests/client_mocks.py
@@ -30,7 +30,7 @@ def mocked_client(bec_dispatcher):
     # Mock the device_manager.devices attribute
     client.connector = connector
     client.device_manager = DMMock()
-    client.device_manager.add_devives(DEVICES)
+    client.device_manager.add_devices(DEVICES)
 
     def mock_mv(*args, relative=False):
         # Extracting motor and value pairs

--- a/tests/unit_tests/test_device_signal_input.py
+++ b/tests/unit_tests/test_device_signal_input.py
@@ -1,8 +1,10 @@
 from unittest import mock
 
 import pytest
+from bec_lib.device import Signal
 from qtpy.QtWidgets import QWidget
 
+from bec_widgets.tests.utils import FakeDevice
 from bec_widgets.utils.ophyd_kind_util import Kind
 from bec_widgets.widgets.control.device_input.base_classes.device_input_base import BECDeviceFilter
 from bec_widgets.widgets.control.device_input.base_classes.device_signal_input_base import (
@@ -16,6 +18,10 @@ from bec_widgets.widgets.control.device_input.signal_line_edit.signal_line_edit 
 
 from .client_mocks import mocked_client
 from .conftest import create_widget
+
+
+class FakeSignal(Signal):
+    """Fake signal to test the DeviceSignalInputBase."""
 
 
 class DeviceInputWidget(DeviceSignalInputBase, QWidget):
@@ -107,6 +113,14 @@ def test_signal_combobox(qtbot, device_signal_combobox):
     assert device_signal_combobox.signals == ["readback", "setpoint", "velocity"]
     qtbot.wait(100)
     assert container == ["samx"]
+    # Set the type of class from the FakeDevice to Signal
+    fake_signal = FakeSignal(name="fake_signal")
+    device_signal_combobox.client.device_manager.add_devices([fake_signal])
+    device_signal_combobox.set_device("fake_signal")
+    assert device_signal_combobox.signals == ["fake_signal"]
+    assert device_signal_combobox._config_signals == []
+    assert device_signal_combobox._normal_signals == []
+    assert device_signal_combobox._hinted_signals == ["fake_signal"]
 
 
 def test_signal_lineeidt(device_signal_line_edit):

--- a/tests/unit_tests/test_device_signal_input.py
+++ b/tests/unit_tests/test_device_signal_input.py
@@ -119,3 +119,8 @@ def test_signal_lineeidt(device_signal_line_edit):
     assert device_signal_line_edit.signals == []
     device_signal_line_edit.set_device("samx")
     assert device_signal_line_edit.signals == ["readback", "setpoint", "velocity"]
+    device_signal_line_edit.set_signal("readback")
+    assert device_signal_line_edit.text() == "readback"
+    assert device_signal_line_edit._is_valid_input is True
+    device_signal_line_edit.setText("invalid")
+    assert device_signal_line_edit._is_valid_input is False


### PR DESCRIPTION
# Summary

This MR adds a test for the InputWidgets that checks the expected behavior with the demo config (e2e test), and fixes a bug for the signal validation for SignalLineEdit. 
For the e2e test, the RPC user_access was extended for the input widgets.

## Issues

- closes #609 
- closes #610 

## Documentation
- [x] up-to-date