### PR TITLE
ci: use uv for test env setup

### DIFF
--- a/.github/workflows/pytest-matrix.yml
+++ b/.github/workflows/pytest-matrix.yml
@@ -37,10 +37,11 @@ jobs:
           echo -e "\033[35;1m Using branch $OPHYD_DEVICES_BRANCH of OPHYD_DEVICES \033[0;m";
           git clone --branch $OPHYD_DEVICES_BRANCH https://github.com/bec-project/ophyd_devices.git
           export OHPYD_DEVICES_PATH=$PWD/ophyd_devices
-          pip install -e ./ophyd_devices
-          pip install -e ./bec/bec_lib[dev]
-          pip install -e ./bec/bec_ipython_client
-          pip install -e .[dev,pyside6]
+          pip install uv
+          uv pip install --system -e ./ophyd_devices
+          uv pip install --system -e ./bec/bec_lib[dev]
+          uv pip install --system -e ./bec/bec_ipython_client
+          uv pip install --system -e .[dev,pyside6]
 
       - name: Run Pytest
         run: |

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -48,10 +48,11 @@ jobs:
           echo -e "\033[35;1m Using branch $OPHYD_DEVICES_BRANCH of OPHYD_DEVICES \033[0;m";
           git clone --branch $OPHYD_DEVICES_BRANCH https://github.com/bec-project/ophyd_devices.git
           export OHPYD_DEVICES_PATH=$PWD/ophyd_devices
-          pip install -e ./ophyd_devices
-          pip install -e ./bec/bec_lib[dev]
-          pip install -e ./bec/bec_ipython_client
-          pip install -e .[dev,pyside6]
+          pip install uv
+          uv pip install --system -e ./ophyd_devices
+          uv pip install --system -e ./bec/bec_lib[dev]
+          uv pip install --system -e ./bec/bec_ipython_client
+          uv pip install --system -e .[dev,pyside6]
 
       - name: Run Pytest with Coverage
         id: coverage


### PR DESCRIPTION
- uses `uv pip install` instead of `pip install` for setting up the test environment in CI
- looks to save 40-50 seconds per unit test run, regardless of python version, in the `Clone and install dependencies` step, see:
  - before: https://github.com/bec-project/bec_widgets/actions/runs/15116995913/job/42490149348
  - after: https://github.com/bec-project/bec_widgets/actions/runs/15133079569/job/42538524498