### PR TITLE
ImageBase class

### DIFF
--- a/bec_widgets/cli/client.py
+++ b/bec_widgets/cli/client.py
@@ -1252,16 +1252,16 @@ class Image(RPCBase):
 
     @property
     @rpc_call
-    def vrange(self) -> "tuple":
+    def v_range(self) -> "QPointF":
         """
-        Get the vrange of the image.
+        Set the v_range of the main image.
         """
 
-    @vrange.setter
+    @v_range.setter
     @rpc_call
-    def vrange(self) -> "tuple":
+    def v_range(self) -> "QPointF":
         """
-        Get the vrange of the image.
+        Set the v_range of the main image.
         """
 
     @property

--- a/bec_widgets/widgets/plots/image/image.py
+++ b/bec_widgets/widgets/plots/image/image.py
@@ -145,7 +145,7 @@ class Image(ImageBase):
             popups=popups,
             **kwargs,
         )
-
+        self.layer_removed.connect(self._on_layer_removed)
         self.scan_id = None
 
         # Default Color map to plasma
@@ -479,14 +479,31 @@ class Image(ImageBase):
     # Clean up
     ################################################################################
 
+    @SafeSlot(str)
+    def _on_layer_removed(self, layer_name: str):
+        """
+        Handle the removal of a layer by disconnecting the monitor.
+
+        Args:
+            layer_name(str): The name of the layer that was removed.
+        """
+        if layer_name not in self.subscriptions:
+            return
+        config = self.subscriptions[layer_name]
+        if config.monitor is not None:
+            self.disconnect_monitor(config.monitor)
+            config.monitor = None
+
     def cleanup(self):
         """
         Disconnect the image update signals and clean up the image.
         """
-        # Main Image cleanup
-        if self.subscriptions["main"].monitor is not None:
-            self.disconnect_monitor(self.subscriptions["main"].monitor)
-            self.subscriptions["main"].monitor = None
+        for layer_name in list(self.subscriptions.keys()):
+            config = self.subscriptions[layer_name]
+            if config.monitor is not None:
+                self.disconnect_monitor(config.monitor)
+            del self.subscriptions[layer_name]
+        self.subscriptions.clear()
 
         # Toolbar cleanup
         self.toolbar.widgets["monitor"].widget.close()

--- a/bec_widgets/widgets/plots/image/image.py
+++ b/bec_widgets/widgets/plots/image/image.py
@@ -174,7 +174,7 @@ class Image(ImageBase):
     @property
     def main_image(self) -> ImageItem:
         """Access the main image item."""
-        return self.layers["main"].image
+        return self.layer_manager["main"].image
 
     ################################################################################
     # High Level methods for API

--- a/bec_widgets/widgets/plots/image/image.py
+++ b/bec_widgets/widgets/plots/image/image.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
+from collections import defaultdict
 from typing import Literal
 
 import numpy as np
 from bec_lib import bec_logger
 from bec_lib.endpoints import MessageEndpoints
-from pydantic import Field, field_validator
+from pydantic import BaseModel, Field, field_validator
 from qtpy.QtWidgets import QWidget
 
 from bec_widgets.utils import ConnectionConfig
@@ -31,6 +32,14 @@ class ImageConfig(ConnectionConfig):
 
     model_config: dict = {"validate_assignment": True}
     _validate_color_map = field_validator("color_map")(Colors.validate_color_map)
+
+
+class ImageLayerConfig(BaseModel):
+    monitor: str | None = Field(None, description="The name of the monitor.")
+    monitor_type: Literal["1d", "2d", "auto"] = Field("auto", description="The type of monitor.")
+    source: Literal["device_monitor_1d", "device_monitor_2d", "auto"] = Field(
+        "auto", description="The source of the image data."
+    )
 
 
 class Image(ImageBase):
@@ -124,6 +133,9 @@ class Image(ImageBase):
             config = ImageConfig(widget_class=self.__class__.__name__)
         self.gui_id = config.gui_id
         self._color_bar = None
+        self.subscriptions: defaultdict[str, ImageLayerConfig] = defaultdict(
+            lambda: ImageLayerConfig(monitor=None, monitor_type="auto", source="auto")
+        )
         super().__init__(
             parent=parent,
             main_image=ImageItem(parent_image=self),
@@ -147,7 +159,7 @@ class Image(ImageBase):
         """
         The name of the monitor to use for the image.
         """
-        return self.main_image.config.monitor
+        return self.subscriptions["main"].monitor or ""
 
     @monitor.setter
     def monitor(self, value: str):
@@ -157,7 +169,7 @@ class Image(ImageBase):
         Args:
             value(str): The name of the monitor to set.
         """
-        if self.main_image.config.monitor == value:
+        if self.subscriptions["main"].monitor == value:
             return
         try:
             self.entry_validator.validate_monitor(value)
@@ -196,23 +208,23 @@ class Image(ImageBase):
             ImageItem: The image object.
         """
 
-        if self.main_image.config.monitor is not None:
-            self.disconnect_monitor(self.main_image.config.monitor)
+        if self.subscriptions["main"].monitor:
+            self.disconnect_monitor(self.subscriptions["main"].monitor)
         self.entry_validator.validate_monitor(monitor)
-        self.main_image.config.monitor = monitor
+        self.subscriptions["main"].monitor = monitor
 
         if monitor_type == "1d":
-            self.main_image.config.source = "device_monitor_1d"
-            self.main_image.config.monitor_type = "1d"
+            self.subscriptions["main"].source = "device_monitor_1d"
+            self.subscriptions["main"].monitor_type = "1d"
         elif monitor_type == "2d":
-            self.main_image.config.source = "device_monitor_2d"
-            self.main_image.config.monitor_type = "2d"
+            self.subscriptions["main"].source = "device_monitor_2d"
+            self.subscriptions["main"].monitor_type = "2d"
         elif monitor_type == "auto":
-            self.main_image.config.source = "auto"
+            self.subscriptions["main"].source = "auto"
             logger.warning(
                 f"Updates for '{monitor}' will be fetch from both 1D and 2D monitor endpoints."
             )
-            self.main_image.config.monitor_type = "auto"
+            self.subscriptions["main"].monitor_type = "auto"
 
         self.set_image_update(monitor=monitor, type=monitor_type)
         if color_map is not None:
@@ -230,14 +242,15 @@ class Image(ImageBase):
         """
         Synchronize the device selection with the current monitor.
         """
-        if self.main_image.config.monitor is not None:
+        config = self.subscriptions["main"]
+        if config.monitor is not None:
             for combo in (
                 self.selection_bundle.device_combo_box,
                 self.selection_bundle.dim_combo_box,
             ):
                 combo.blockSignals(True)
-            self.selection_bundle.device_combo_box.set_device(self.main_image.config.monitor)
-            self.selection_bundle.dim_combo_box.setCurrentText(self.main_image.config.monitor_type)
+            self.selection_bundle.device_combo_box.set_device(config.monitor)
+            self.selection_bundle.dim_combo_box.setCurrentText(config.monitor_type)
             for combo in (
                 self.selection_bundle.device_combo_box,
                 self.selection_bundle.dim_combo_box,
@@ -361,8 +374,8 @@ class Image(ImageBase):
             self.bec_dispatcher.connect_slot(
                 self.on_image_update_2d, MessageEndpoints.device_monitor_2d(monitor)
             )
-        print(f"Connected to {monitor} with type {type}")
-        self.main_image.config.monitor = monitor
+        logger.info(f"Connected to {monitor} with type {type}")
+        self.subscriptions["main"].monitor = monitor
 
     def disconnect_monitor(self, monitor: str):
         """
@@ -377,7 +390,7 @@ class Image(ImageBase):
         self.bec_dispatcher.disconnect_slot(
             self.on_image_update_2d, MessageEndpoints.device_monitor_2d(monitor)
         )
-        self.main_image.config.monitor = None
+        self.subscriptions["main"].monitor = None
         self._sync_device_selection()
 
     ########################################
@@ -471,9 +484,9 @@ class Image(ImageBase):
         Disconnect the image update signals and clean up the image.
         """
         # Main Image cleanup
-        if self.main_image.config.monitor is not None:
-            self.disconnect_monitor(self.main_image.config.monitor)
-            self.main_image.config.monitor = None
+        if self.subscriptions["main"].monitor is not None:
+            self.disconnect_monitor(self.subscriptions["main"].monitor)
+            self.subscriptions["main"].monitor = None
 
         # Toolbar cleanup
         self.toolbar.widgets["monitor"].widget.close()

--- a/bec_widgets/widgets/plots/image/image.py
+++ b/bec_widgets/widgets/plots/image/image.py
@@ -3,32 +3,16 @@ from __future__ import annotations
 from typing import Literal
 
 import numpy as np
-import pyqtgraph as pg
 from bec_lib import bec_logger
 from bec_lib.endpoints import MessageEndpoints
-from pydantic import Field, ValidationError, field_validator
-from qtpy.QtCore import QPointF, Signal
-from qtpy.QtWidgets import QDialog, QVBoxLayout, QWidget
+from pydantic import Field, field_validator
+from qtpy.QtWidgets import QWidget
 
 from bec_widgets.utils import ConnectionConfig
 from bec_widgets.utils.colors import Colors
 from bec_widgets.utils.error_popups import SafeProperty, SafeSlot
-from bec_widgets.utils.side_panel import SidePanel
-from bec_widgets.utils.toolbar import MaterialIconAction, SwitchableToolBarAction
+from bec_widgets.widgets.plots.image.image_base import ImageBase
 from bec_widgets.widgets.plots.image.image_item import ImageItem
-from bec_widgets.widgets.plots.image.image_roi_plot import ImageROIPlot
-from bec_widgets.widgets.plots.image.setting_widgets.image_roi_tree import ROIPropertyTree
-from bec_widgets.widgets.plots.image.toolbar_bundles.image_selection import (
-    MonitorSelectionToolbarBundle,
-)
-from bec_widgets.widgets.plots.image.toolbar_bundles.processing import ImageProcessingToolbarBundle
-from bec_widgets.widgets.plots.plot_base import PlotBase
-from bec_widgets.widgets.plots.roi.image_roi import (
-    BaseROI,
-    CircularROI,
-    RectangularROI,
-    ROIController,
-)
 
 logger = bec_logger.logger
 
@@ -49,7 +33,7 @@ class ImageConfig(ConnectionConfig):
     _validate_color_map = field_validator("color_map")(Colors.validate_color_map)
 
 
-class Image(PlotBase):
+class Image(ImageBase):
     """
     Image widget for displaying 2D data.
     """
@@ -93,8 +77,8 @@ class Image(PlotBase):
         # ImageView Specific Settings
         "color_map",
         "color_map.setter",
-        "vrange",
-        "vrange.setter",
+        "v_range",
+        "v_range.setter",
         "v_min",
         "v_min.setter",
         "v_max",
@@ -126,8 +110,6 @@ class Image(PlotBase):
         "remove_roi",
         "rois",
     ]
-    sync_colorbar_with_autorange = Signal()
-    image_updated = Signal()
 
     def __init__(
         self,
@@ -142,614 +124,20 @@ class Image(PlotBase):
             config = ImageConfig(widget_class=self.__class__.__name__)
         self.gui_id = config.gui_id
         self._color_bar = None
-        self._main_image = ImageItem()
-        self.roi_controller = ROIController(colormap="viridis")
-        self.x_roi = None
-        self.y_roi = None
         super().__init__(
-            parent=parent, config=config, client=client, gui_id=gui_id, popups=popups, **kwargs
+            parent=parent,
+            main_image=ImageItem(parent_image=self),
+            config=config,
+            client=client,
+            gui_id=gui_id,
+            popups=popups,
+            **kwargs,
         )
-        self._main_image = ImageItem(parent_image=self)
 
-        self.plot_item.addItem(self._main_image)
         self.scan_id = None
 
         # Default Color map to plasma
         self.color_map = "plasma"
-
-        # Initialize ROI plots and side panels
-        self._add_roi_plots()
-
-        self.roi_manager_dialog = None
-
-        # Refresh theme for ROI plots
-        self._update_theme()
-
-    ################################################################################
-    # Widget Specific GUI interactions
-    ################################################################################
-    def apply_theme(self, theme: str):
-        super().apply_theme(theme)
-        if self.x_roi is not None and self.y_roi is not None:
-            self.x_roi.apply_theme(theme)
-            self.y_roi.apply_theme(theme)
-
-    def _init_toolbar(self):
-
-        # add to the first position
-        self.selection_bundle = MonitorSelectionToolbarBundle(
-            bundle_id="selection", target_widget=self
-        )
-        self.toolbar.add_bundle(bundle=self.selection_bundle, target_widget=self)
-
-        super()._init_toolbar()
-
-        # Image specific changes to PlotBase toolbar
-        self.toolbar.widgets["reset_legend"].action.setVisible(False)
-
-        # ROI Bundle replacement with switchable crosshair
-        self.toolbar.remove_bundle("roi")
-        crosshair = MaterialIconAction(
-            icon_name="point_scan", tooltip="Show Crosshair", checkable=True
-        )
-        crosshair_roi = MaterialIconAction(
-            icon_name="my_location",
-            tooltip="Show Crosshair with ROI plots",
-            checkable=True,
-            parent=self,
-        )
-        crosshair_roi.action.toggled.connect(self.toggle_roi_panels)
-        crosshair.action.toggled.connect(self.toggle_crosshair)
-        switch_crosshair = SwitchableToolBarAction(
-            actions={"crosshair_simple": crosshair, "crosshair_roi": crosshair_roi},
-            initial_action="crosshair_simple",
-            tooltip="Crosshair",
-            checkable=True,
-            parent=self,
-        )
-        self.toolbar.add_action(
-            action_id="switch_crosshair", action=switch_crosshair, target_widget=self
-        )
-
-        # Lock aspect ratio button
-        self.lock_aspect_ratio_action = MaterialIconAction(
-            icon_name="aspect_ratio", tooltip="Lock Aspect Ratio", checkable=True, parent=self
-        )
-        self.toolbar.add_action_to_bundle(
-            bundle_id="mouse_interaction",
-            action_id="lock_aspect_ratio",
-            action=self.lock_aspect_ratio_action,
-            target_widget=self,
-        )
-        self.lock_aspect_ratio_action.action.toggled.connect(
-            lambda checked: self.setProperty("lock_aspect_ratio", checked)
-        )
-        self.lock_aspect_ratio_action.action.setChecked(True)
-
-        self._init_autorange_action()
-        self._init_colorbar_action()
-
-        # Processing Bundle
-        self.processing_bundle = ImageProcessingToolbarBundle(
-            bundle_id="processing", target_widget=self
-        )
-        self.toolbar.add_bundle(self.processing_bundle, target_widget=self)
-
-    def _init_autorange_action(self):
-
-        self.autorange_mean_action = MaterialIconAction(
-            icon_name="hdr_auto", tooltip="Enable Auto Range (Mean)", checkable=True, parent=self
-        )
-        self.autorange_max_action = MaterialIconAction(
-            icon_name="hdr_auto",
-            tooltip="Enable Auto Range (Max)",
-            checkable=True,
-            filled=True,
-            parent=self,
-        )
-
-        self.autorange_switch = SwitchableToolBarAction(
-            actions={
-                "auto_range_mean": self.autorange_mean_action,
-                "auto_range_max": self.autorange_max_action,
-            },
-            initial_action="auto_range_mean",
-            tooltip="Enable Auto Range",
-            checkable=True,
-            parent=self,
-        )
-
-        self.toolbar.add_action(
-            action_id="autorange_image", action=self.autorange_switch, target_widget=self
-        )
-
-        self.autorange_mean_action.action.toggled.connect(
-            lambda checked: self.toggle_autorange(checked, mode="mean")
-        )
-        self.autorange_max_action.action.toggled.connect(
-            lambda checked: self.toggle_autorange(checked, mode="max")
-        )
-
-        self.autorange = True
-        self.autorange_mode = "mean"
-
-    def _init_colorbar_action(self):
-        self.full_colorbar_action = MaterialIconAction(
-            icon_name="edgesensor_low", tooltip="Enable Full Colorbar", checkable=True, parent=self
-        )
-        self.simple_colorbar_action = MaterialIconAction(
-            icon_name="smartphone", tooltip="Enable Simple Colorbar", checkable=True, parent=self
-        )
-
-        self.colorbar_switch = SwitchableToolBarAction(
-            actions={
-                "full_colorbar": self.full_colorbar_action,
-                "simple_colorbar": self.simple_colorbar_action,
-            },
-            initial_action="full_colorbar",
-            tooltip="Enable Full Colorbar",
-            checkable=True,
-            parent=self,
-        )
-
-        self.toolbar.add_action(
-            action_id="switch_colorbar", action=self.colorbar_switch, target_widget=self
-        )
-
-        self.simple_colorbar_action.action.toggled.connect(
-            lambda checked: self.enable_colorbar(checked, style="simple")
-        )
-        self.full_colorbar_action.action.toggled.connect(
-            lambda checked: self.enable_colorbar(checked, style="full")
-        )
-
-    ########################################
-    # ROI Gui Manager
-    def add_side_menus(self):
-        super().add_side_menus()
-
-        roi_mgr = ROIPropertyTree(parent=self, image_widget=self)
-        self.side_panel.add_menu(
-            action_id="roi_mgr",
-            icon_name="view_list",
-            tooltip="ROI Manager",
-            widget=roi_mgr,
-            title="ROI Manager",
-        )
-
-    def add_popups(self):
-        super().add_popups()  # keep Axis Settings
-
-        roi_action = MaterialIconAction(
-            icon_name="view_list", tooltip="ROI Manager", checkable=True, parent=self
-        )
-        # self.popup_bundle.add_action("roi_mgr", roi_action)
-        self.toolbar.add_action_to_bundle(
-            bundle_id="popup_bundle", action_id="roi_mgr", action=roi_action, target_widget=self
-        )
-        self.toolbar.widgets["roi_mgr"].action.triggered.connect(self.show_roi_manager_popup)
-
-    def show_roi_manager_popup(self):
-        roi_action = self.toolbar.widgets["roi_mgr"].action
-        if self.roi_manager_dialog is None or not self.roi_manager_dialog.isVisible():
-            self.roi_mgr = ROIPropertyTree(parent=self, image_widget=self)
-            self.roi_manager_dialog = QDialog(modal=False)
-            self.roi_manager_dialog.layout = QVBoxLayout(self.roi_manager_dialog)
-            self.roi_manager_dialog.layout.addWidget(self.roi_mgr)
-            self.roi_manager_dialog.finished.connect(self._roi_mgr_closed)
-            self.roi_manager_dialog.show()
-            roi_action.setChecked(True)
-        else:
-            self.roi_manager_dialog.raise_()
-            self.roi_manager_dialog.activateWindow()
-            roi_action.setChecked(True)
-
-    def _roi_mgr_closed(self):
-        self.roi_mgr.close()
-        self.roi_mgr.deleteLater()
-        self.roi_manager_dialog.close()
-        self.roi_manager_dialog.deleteLater()
-        self.roi_manager_dialog = None
-        self.toolbar.widgets["roi_mgr"].action.setChecked(False)
-
-    def enable_colorbar(
-        self,
-        enabled: bool,
-        style: Literal["full", "simple"] = "full",
-        vrange: tuple[int, int] | None = None,
-    ):
-        """
-        Enable the colorbar and switch types of colorbars.
-
-        Args:
-            enabled(bool): Whether to enable the colorbar.
-            style(Literal["full", "simple"]): The type of colorbar to enable.
-            vrange(tuple): The range of values to use for the colorbar.
-        """
-        autorange_state = self._main_image.autorange
-        if enabled:
-            if self._color_bar:
-                if self.config.color_bar == "full":
-                    self.cleanup_histogram_lut_item(self._color_bar)
-                self.plot_widget.removeItem(self._color_bar)
-                self._color_bar = None
-
-            if style == "simple":
-                self._color_bar = pg.ColorBarItem(colorMap=self.config.color_map)
-                self._color_bar.setImageItem(self._main_image)
-                self._color_bar.sigLevelsChangeFinished.connect(
-                    lambda: self.setProperty("autorange", False)
-                )
-
-            elif style == "full":
-                self._color_bar = pg.HistogramLUTItem()
-                self._color_bar.setImageItem(self._main_image)
-                self._color_bar.gradient.loadPreset(self.config.color_map)
-                self._color_bar.sigLevelsChanged.connect(
-                    lambda: self.setProperty("autorange", False)
-                )
-
-            self.plot_widget.addItem(self._color_bar, row=0, col=1)
-            self.config.color_bar = style
-        else:
-            if self._color_bar:
-                self.plot_widget.removeItem(self._color_bar)
-                self._color_bar = None
-            self.config.color_bar = None
-
-        self.autorange = autorange_state
-        self._sync_colorbar_actions()
-
-        if vrange:  # should be at the end to disable the autorange if defined
-            self.v_range = vrange
-
-    ################################################################################
-    # Static rois with roi manager
-
-    def add_roi(
-        self,
-        kind: Literal["rect", "circle"] = "rect",
-        name: str | None = None,
-        line_width: int | None = 5,
-        pos: tuple[float, float] | None = (10, 10),
-        size: tuple[float, float] | None = (50, 50),
-        **pg_kwargs,
-    ) -> RectangularROI | CircularROI:
-        """
-        Add a ROI to the image.
-
-        Args:
-            kind(str): The type of ROI to add. Options are "rect" or "circle".
-            name(str): The name of the ROI.
-            line_width(int): The line width of the ROI.
-            pos(tuple): The position of the ROI.
-            size(tuple): The size of the ROI.
-            **pg_kwargs: Additional arguments for the ROI.
-
-        Returns:
-            RectangularROI | CircularROI: The created ROI object.
-        """
-        if name is None:
-            name = f"ROI_{len(self.roi_controller.rois) + 1}"
-        if kind == "rect":
-            roi = RectangularROI(
-                pos=pos,
-                size=size,
-                parent_image=self,
-                line_width=line_width,
-                label=name,
-                **pg_kwargs,
-            )
-        elif kind == "circle":
-            roi = CircularROI(
-                pos=pos,
-                size=size,
-                parent_image=self,
-                line_width=line_width,
-                label=name,
-                **pg_kwargs,
-            )
-        else:
-            raise ValueError("kind must be 'rect' or 'circle'")
-
-        # Add to plot and controller (controller assigns color)
-        self.plot_item.addItem(roi)
-        self.roi_controller.add_roi(roi)
-        roi.add_scale_handle()
-        return roi
-
-    def remove_roi(self, roi: int | str):
-        """Remove an ROI by index or label via the ROIController."""
-        if isinstance(roi, int):
-            self.roi_controller.remove_roi_by_index(roi)
-        elif isinstance(roi, str):
-            self.roi_controller.remove_roi_by_name(roi)
-        else:
-            raise ValueError("roi must be an int index or str name")
-
-    def _add_roi_plots(self):
-        """
-        Initialize the ROI plots and side panels.
-        """
-        # Create ROI plot widgets
-        self.x_roi = ImageROIPlot(parent=self)
-        self.y_roi = ImageROIPlot(parent=self)
-        self.x_roi.apply_theme("dark")
-        self.y_roi.apply_theme("dark")
-
-        # Set titles for the plots
-        self.x_roi.plot_item.setTitle("X ROI")
-        self.y_roi.plot_item.setTitle("Y ROI")
-
-        # Create side panels
-        self.side_panel_x = SidePanel(
-            parent=self, orientation="bottom", panel_max_width=200, show_toolbar=False
-        )
-        self.side_panel_y = SidePanel(
-            parent=self, orientation="left", panel_max_width=200, show_toolbar=False
-        )
-
-        # Add ROI plots to side panels
-        self.x_panel_index = self.side_panel_x.add_menu(widget=self.x_roi)
-        self.y_panel_index = self.side_panel_y.add_menu(widget=self.y_roi)
-
-        # # Add side panels to the layout
-        self.layout_manager.add_widget_relative(
-            self.side_panel_x, self.round_plot_widget, position="bottom", shift_direction="down"
-        )
-        self.layout_manager.add_widget_relative(
-            self.side_panel_y, self.round_plot_widget, position="left", shift_direction="right"
-        )
-
-    def toggle_roi_panels(self, checked: bool):
-        """
-        Show or hide the ROI panels based on the test action toggle state.
-
-        Args:
-            checked (bool): Whether the test action is checked.
-        """
-        if checked:
-            # Show the ROI panels
-            self.hook_crosshair()
-            self.side_panel_x.show_panel(self.x_panel_index)
-            self.side_panel_y.show_panel(self.y_panel_index)
-            self.crosshair.coordinatesChanged2D.connect(self.update_image_slices)
-            self.image_updated.connect(self.update_image_slices)
-        else:
-            self.unhook_crosshair()
-            # Hide the ROI panels
-            self.side_panel_x.hide_panel()
-            self.side_panel_y.hide_panel()
-            self.image_updated.disconnect(self.update_image_slices)
-
-    @SafeSlot()
-    def update_image_slices(self, coordinates: tuple[int, int, int] = None):
-        """
-        Update the image slices based on the crosshair position.
-
-        Args:
-            coordinates(tuple): The coordinates of the crosshair.
-        """
-        if coordinates is None:
-            # Try to get coordinates from crosshair position (like in crosshair mouse_moved)
-            if (
-                hasattr(self, "crosshair")
-                and hasattr(self.crosshair, "v_line")
-                and hasattr(self.crosshair, "h_line")
-            ):
-                x = int(round(self.crosshair.v_line.value()))
-                y = int(round(self.crosshair.h_line.value()))
-            else:
-                return
-        else:
-            x = coordinates[1]
-            y = coordinates[2]
-        image = self._main_image.image
-        if image is None:
-            return
-        max_row, max_col = image.shape[0] - 1, image.shape[1] - 1
-        row, col = x, y
-        if not (0 <= row <= max_row and 0 <= col <= max_col):
-            return
-        # Horizontal slice
-        h_slice = image[:, col]
-        x_axis = np.arange(h_slice.shape[0])
-        self.x_roi.plot_item.clear()
-        self.x_roi.plot_item.plot(x_axis, h_slice, pen=pg.mkPen(self.x_roi.curve_color, width=3))
-        # Vertical slice
-        v_slice = image[row, :]
-        y_axis = np.arange(v_slice.shape[0])
-        self.y_roi.plot_item.clear()
-        self.y_roi.plot_item.plot(v_slice, y_axis, pen=pg.mkPen(self.y_roi.curve_color, width=3))
-
-    ################################################################################
-    # Widget Specific Properties
-    ################################################################################
-    ################################################################################
-    # Rois
-
-    @property
-    def rois(self) -> list[BaseROI]:
-        """
-        Get the list of ROIs.
-        """
-        return self.roi_controller.rois
-
-    ################################################################################
-    # Colorbar toggle
-
-    @SafeProperty(bool)
-    def enable_simple_colorbar(self) -> bool:
-        """
-        Enable the simple colorbar.
-        """
-        enabled = False
-        if self.config.color_bar == "simple":
-            enabled = True
-        return enabled
-
-    @enable_simple_colorbar.setter
-    def enable_simple_colorbar(self, value: bool):
-        """
-        Enable the simple colorbar.
-
-        Args:
-            value(bool): Whether to enable the simple colorbar.
-        """
-        self.enable_colorbar(enabled=value, style="simple")
-
-    @SafeProperty(bool)
-    def enable_full_colorbar(self) -> bool:
-        """
-        Enable the full colorbar.
-        """
-        enabled = False
-        if self.config.color_bar == "full":
-            enabled = True
-        return enabled
-
-    @enable_full_colorbar.setter
-    def enable_full_colorbar(self, value: bool):
-        """
-        Enable the full colorbar.
-
-        Args:
-            value(bool): Whether to enable the full colorbar.
-        """
-        self.enable_colorbar(enabled=value, style="full")
-
-    ################################################################################
-    # Appearance
-
-    @SafeProperty(str)
-    def color_map(self) -> str:
-        """
-        Set the color map of the image.
-        """
-        return self.config.color_map
-
-    @color_map.setter
-    def color_map(self, value: str):
-        """
-        Set the color map of the image.
-
-        Args:
-            value(str): The color map to set.
-        """
-        try:
-            self.config.color_map = value
-            self._main_image.color_map = value
-
-            if self._color_bar:
-                if self.config.color_bar == "simple":
-                    self._color_bar.setColorMap(value)
-                elif self.config.color_bar == "full":
-                    self._color_bar.gradient.loadPreset(value)
-        except ValidationError:
-            return
-
-    # v_range is for designer, vrange is for RPC
-    @SafeProperty("QPointF")
-    def v_range(self) -> QPointF:
-        """
-        Set the v_range of the main image.
-        """
-        vmin, vmax = self._main_image.v_range
-        return QPointF(vmin, vmax)
-
-    @v_range.setter
-    def v_range(self, value: tuple | list | QPointF):
-        """
-        Set the v_range of the main image.
-
-        Args:
-            value(tuple | list | QPointF): The range of values to set.
-        """
-        if isinstance(value, (tuple, list)):
-            value = self._tuple_to_qpointf(value)
-
-        vmin, vmax = value.x(), value.y()
-
-        self._main_image.v_range = (vmin, vmax)
-
-        # propagate to colorbar if exists
-        if self._color_bar:
-            if self.config.color_bar == "simple":
-                self._color_bar.setLevels(low=vmin, high=vmax)
-            elif self.config.color_bar == "full":
-                self._color_bar.setLevels(min=vmin, max=vmax)
-                self._color_bar.setHistogramRange(vmin - 0.1 * vmin, vmax + 0.1 * vmax)
-
-        self.autorange_switch.set_state_all(False)
-
-    @property
-    def vrange(self) -> tuple:
-        """
-        Get the vrange of the image.
-        """
-        return (self.v_range.x(), self.v_range.y())
-
-    @vrange.setter
-    def vrange(self, value):
-        """
-        Set the vrange of the image.
-
-        Args:
-            value(tuple):
-        """
-        self.v_range = value
-
-    @property
-    def v_min(self) -> float:
-        """
-        Get the minimum value of the v_range.
-        """
-        return self.v_range.x()
-
-    @v_min.setter
-    def v_min(self, value: float):
-        """
-        Set the minimum value of the v_range.
-
-        Args:
-            value(float): The minimum value to set.
-        """
-        self.v_range = (value, self.v_range.y())
-
-    @property
-    def v_max(self) -> float:
-        """
-        Get the maximum value of the v_range.
-        """
-        return self.v_range.y()
-
-    @v_max.setter
-    def v_max(self, value: float):
-        """
-        Set the maximum value of the v_range.
-
-        Args:
-            value(float): The maximum value to set.
-        """
-        self.v_range = (self.v_range.x(), value)
-
-    @SafeProperty(bool)
-    def lock_aspect_ratio(self) -> bool:
-        """
-        Whether the aspect ratio is locked.
-        """
-        return self.config.lock_aspect_ratio
-
-    @lock_aspect_ratio.setter
-    def lock_aspect_ratio(self, value: bool):
-        """
-        Set the aspect ratio lock.
-
-        Args:
-            value(bool): Whether to lock the aspect ratio.
-        """
-        self.config.lock_aspect_ratio = bool(value)
-        self.plot_item.setAspectLocked(value)
 
     ################################################################################
     # Data Acquisition
@@ -759,7 +147,7 @@ class Image(PlotBase):
         """
         The name of the monitor to use for the image.
         """
-        return self._main_image.config.monitor
+        return self.main_image.config.monitor
 
     @monitor.setter
     def monitor(self, value: str):
@@ -769,7 +157,7 @@ class Image(PlotBase):
         Args:
             value(str): The name of the monitor to set.
         """
-        if self._main_image.config.monitor == value:
+        if self.main_image.config.monitor == value:
             return
         try:
             self.entry_validator.validate_monitor(value)
@@ -780,175 +168,7 @@ class Image(PlotBase):
     @property
     def main_image(self) -> ImageItem:
         """Access the main image item."""
-        return self._main_image
-
-    ################################################################################
-    # Autorange + Colorbar sync
-
-    @SafeProperty(bool)
-    def autorange(self) -> bool:
-        """
-        Whether autorange is enabled.
-        """
-        return self._main_image.autorange
-
-    @autorange.setter
-    def autorange(self, enabled: bool):
-        """
-        Set autorange.
-
-        Args:
-            enabled(bool): Whether to enable autorange.
-        """
-        self._main_image.autorange = enabled
-        if enabled and self._main_image.raw_data is not None:
-            self._main_image.apply_autorange()
-            self._sync_colorbar_levels()
-        self._sync_autorange_switch()
-
-    @SafeProperty(str)
-    def autorange_mode(self) -> str:
-        """
-        Autorange mode.
-
-        Options:
-            - "max": Use the maximum value of the image for autoranging.
-            - "mean": Use the mean value of the image for autoranging.
-
-        """
-        return self._main_image.autorange_mode
-
-    @autorange_mode.setter
-    def autorange_mode(self, mode: str):
-        """
-        Set the autorange mode.
-
-        Args:
-            mode(str): The autorange mode. Options are "max" or "mean".
-        """
-        # for qt Designer
-        if mode not in ["max", "mean"]:
-            return
-        self._main_image.autorange_mode = mode
-
-        self._sync_autorange_switch()
-
-    @SafeSlot(bool, str, bool)
-    def toggle_autorange(self, enabled: bool, mode: str):
-        """
-        Toggle autorange.
-
-        Args:
-            enabled(bool): Whether to enable autorange.
-            mode(str): The autorange mode. Options are "max" or "mean".
-        """
-        if self._main_image is not None:
-            self._main_image.autorange = enabled
-            self._main_image.autorange_mode = mode
-            if enabled:
-                self._main_image.apply_autorange()
-            self._sync_colorbar_levels()
-
-    def _sync_autorange_switch(self):
-        """
-        Synchronize the autorange switch with the current autorange state and mode if changed from outside.
-        """
-        self.autorange_switch.block_all_signals(True)
-        self.autorange_switch.set_default_action(f"auto_range_{self._main_image.autorange_mode}")
-        self.autorange_switch.set_state_all(self._main_image.autorange)
-        self.autorange_switch.block_all_signals(False)
-
-    def _sync_colorbar_levels(self):
-        """Immediately propagate current levels to the active colorbar."""
-        vrange = self._main_image.v_range
-        if self._color_bar:
-            self._color_bar.blockSignals(True)
-            self.v_range = vrange
-            self._color_bar.blockSignals(False)
-
-    def _sync_colorbar_actions(self):
-        """
-        Synchronize the colorbar actions with the current colorbar state.
-        """
-        self.colorbar_switch.block_all_signals(True)
-        if self._color_bar is not None:
-            self.colorbar_switch.set_default_action(f"{self.config.color_bar}_colorbar")
-            self.colorbar_switch.set_state_all(True)
-        else:
-            self.colorbar_switch.set_state_all(False)
-        self.colorbar_switch.block_all_signals(False)
-
-    ################################################################################
-    # Post Processing
-    ################################################################################
-
-    @SafeProperty(bool)
-    def fft(self) -> bool:
-        """
-        Whether FFT postprocessing is enabled.
-        """
-        return self._main_image.fft
-
-    @fft.setter
-    def fft(self, enable: bool):
-        """
-        Set FFT postprocessing.
-
-        Args:
-            enable(bool): Whether to enable FFT postprocessing.
-        """
-        self._main_image.fft = enable
-
-    @SafeProperty(bool)
-    def log(self) -> bool:
-        """
-        Whether logarithmic scaling is applied.
-        """
-        return self._main_image.log
-
-    @log.setter
-    def log(self, enable: bool):
-        """
-        Set logarithmic scaling.
-
-        Args:
-            enable(bool): Whether to enable logarithmic scaling.
-        """
-        self._main_image.log = enable
-
-    @SafeProperty(int)
-    def num_rotation_90(self) -> int:
-        """
-        The number of 90° rotations to apply counterclockwise.
-        """
-        return self._main_image.num_rotation_90
-
-    @num_rotation_90.setter
-    def num_rotation_90(self, value: int):
-        """
-        Set the number of 90° rotations to apply counterclockwise.
-
-        Args:
-            value(int): The number of 90° rotations to apply.
-        """
-        self._main_image.num_rotation_90 = value
-
-    @SafeProperty(bool)
-    def transpose(self) -> bool:
-        """
-        Whether the image is transposed.
-        """
-        return self._main_image.transpose
-
-    @transpose.setter
-    def transpose(self, enable: bool):
-        """
-        Set the image to be transposed.
-
-        Args:
-            enable(bool): Whether to enable transposing the image.
-        """
-        self._main_image.transpose = enable
+        return self.layers["main"].image
 
     ################################################################################
     # High Level methods for API
@@ -976,27 +196,27 @@ class Image(PlotBase):
             ImageItem: The image object.
         """
 
-        if self._main_image.config.monitor is not None:
-            self.disconnect_monitor(self._main_image.config.monitor)
+        if self.main_image.config.monitor is not None:
+            self.disconnect_monitor(self.main_image.config.monitor)
         self.entry_validator.validate_monitor(monitor)
-        self._main_image.config.monitor = monitor
+        self.main_image.config.monitor = monitor
 
         if monitor_type == "1d":
-            self._main_image.config.source = "device_monitor_1d"
-            self._main_image.config.monitor_type = "1d"
+            self.main_image.config.source = "device_monitor_1d"
+            self.main_image.config.monitor_type = "1d"
         elif monitor_type == "2d":
-            self._main_image.config.source = "device_monitor_2d"
-            self._main_image.config.monitor_type = "2d"
+            self.main_image.config.source = "device_monitor_2d"
+            self.main_image.config.monitor_type = "2d"
         elif monitor_type == "auto":
-            self._main_image.config.source = "auto"
+            self.main_image.config.source = "auto"
             logger.warning(
                 f"Updates for '{monitor}' will be fetch from both 1D and 2D monitor endpoints."
             )
-            self._main_image.config.monitor_type = "auto"
+            self.main_image.config.monitor_type = "auto"
 
         self.set_image_update(monitor=monitor, type=monitor_type)
         if color_map is not None:
-            self._main_image.color_map = color_map
+            self.main_image.color_map = color_map
         if color_bar is not None:
             self.enable_colorbar(True, color_bar)
         if vrange is not None:
@@ -1004,20 +224,20 @@ class Image(PlotBase):
 
         self._sync_device_selection()
 
-        return self._main_image
+        return self.main_image
 
     def _sync_device_selection(self):
         """
         Synchronize the device selection with the current monitor.
         """
-        if self._main_image.config.monitor is not None:
+        if self.main_image.config.monitor is not None:
             for combo in (
                 self.selection_bundle.device_combo_box,
                 self.selection_bundle.dim_combo_box,
             ):
                 combo.blockSignals(True)
-            self.selection_bundle.device_combo_box.set_device(self._main_image.config.monitor)
-            self.selection_bundle.dim_combo_box.setCurrentText(self._main_image.config.monitor_type)
+            self.selection_bundle.device_combo_box.set_device(self.main_image.config.monitor)
+            self.selection_bundle.dim_combo_box.setCurrentText(self.main_image.config.monitor_type)
             for combo in (
                 self.selection_bundle.device_combo_box,
                 self.selection_bundle.dim_combo_box,
@@ -1036,6 +256,78 @@ class Image(PlotBase):
                 self.selection_bundle.dim_combo_box,
             ):
                 combo.blockSignals(False)
+
+    ################################################################################
+    # Post Processing
+    ################################################################################
+
+    @SafeProperty(bool)
+    def fft(self) -> bool:
+        """
+        Whether FFT postprocessing is enabled.
+        """
+        return self.main_image.fft
+
+    @fft.setter
+    def fft(self, enable: bool):
+        """
+        Set FFT postprocessing.
+
+        Args:
+            enable(bool): Whether to enable FFT postprocessing.
+        """
+        self.main_image.fft = enable
+
+    @SafeProperty(bool)
+    def log(self) -> bool:
+        """
+        Whether logarithmic scaling is applied.
+        """
+        return self.main_image.log
+
+    @log.setter
+    def log(self, enable: bool):
+        """
+        Set logarithmic scaling.
+
+        Args:
+            enable(bool): Whether to enable logarithmic scaling.
+        """
+        self.main_image.log = enable
+
+    @SafeProperty(int)
+    def num_rotation_90(self) -> int:
+        """
+        The number of 90° rotations to apply counterclockwise.
+        """
+        return self.main_image.num_rotation_90
+
+    @num_rotation_90.setter
+    def num_rotation_90(self, value: int):
+        """
+        Set the number of 90° rotations to apply counterclockwise.
+
+        Args:
+            value(int): The number of 90° rotations to apply.
+        """
+        self.main_image.num_rotation_90 = value
+
+    @SafeProperty(bool)
+    def transpose(self) -> bool:
+        """
+        Whether the image is transposed.
+        """
+        return self.main_image.transpose
+
+    @transpose.setter
+    def transpose(self, enable: bool):
+        """
+        Set the image to be transposed.
+
+        Args:
+            enable(bool): Whether to enable transposing the image.
+        """
+        self.main_image.transpose = enable
 
     ################################################################################
     # Image Update Methods
@@ -1070,7 +362,7 @@ class Image(PlotBase):
                 self.on_image_update_2d, MessageEndpoints.device_monitor_2d(monitor)
             )
         print(f"Connected to {monitor} with type {type}")
-        self._main_image.config.monitor = monitor
+        self.main_image.config.monitor = monitor
 
     def disconnect_monitor(self, monitor: str):
         """
@@ -1085,7 +377,7 @@ class Image(PlotBase):
         self.bec_dispatcher.disconnect_slot(
             self.on_image_update_2d, MessageEndpoints.device_monitor_2d(monitor)
         )
-        self._main_image.config.monitor = None
+        self.main_image.config.monitor = None
         self._sync_device_selection()
 
     ########################################
@@ -1107,13 +399,13 @@ class Image(PlotBase):
             return
         if current_scan_id != self.scan_id:
             self.scan_id = current_scan_id
-            self._main_image.clear()
-            self._main_image.buffer = []
-            self._main_image.max_len = 0
-        image_buffer = self.adjust_image_buffer(self._main_image, data)
+            self.main_image.clear()
+            self.main_image.buffer = []
+            self.main_image.max_len = 0
+        image_buffer = self.adjust_image_buffer(self.main_image, data)
         if self._color_bar is not None:
             self._color_bar.blockSignals(True)
-        self._main_image.set_data(image_buffer)
+        self.main_image.set_data(image_buffer)
         if self._color_bar is not None:
             self._color_bar.blockSignals(False)
         self.image_updated.emit()
@@ -1165,7 +457,7 @@ class Image(PlotBase):
         data = msg["data"]
         if self._color_bar is not None:
             self._color_bar.blockSignals(True)
-        self._main_image.set_data(data)
+        self.main_image.set_data(data)
         if self._color_bar is not None:
             self._color_bar.blockSignals(False)
         self.image_updated.emit()
@@ -1174,60 +466,18 @@ class Image(PlotBase):
     # Clean up
     ################################################################################
 
-    @staticmethod
-    def cleanup_histogram_lut_item(histogram_lut_item: pg.HistogramLUTItem):
-        """
-        Clean up HistogramLUTItem safely, including open ViewBox menus and child widgets.
-
-        Args:
-            histogram_lut_item(pg.HistogramLUTItem): The HistogramLUTItem to clean up.
-        """
-        histogram_lut_item.vb.menu.close()
-        histogram_lut_item.vb.menu.deleteLater()
-
-        histogram_lut_item.gradient.menu.close()
-        histogram_lut_item.gradient.menu.deleteLater()
-        histogram_lut_item.gradient.colorDialog.close()
-        histogram_lut_item.gradient.colorDialog.deleteLater()
-
     def cleanup(self):
         """
         Disconnect the image update signals and clean up the image.
         """
-        # Remove all ROIs
-        rois = self.rois
-        for roi in rois:
-            roi.remove()
-
         # Main Image cleanup
-        if self._main_image.config.monitor is not None:
-            self.disconnect_monitor(self._main_image.config.monitor)
-            self._main_image.config.monitor = None
-        self.plot_item.removeItem(self._main_image)
-        self._main_image = None
-
-        # Colorbar Cleanup
-        if self._color_bar:
-            if self.config.color_bar == "full":
-                self.cleanup_histogram_lut_item(self._color_bar)
-            if self.config.color_bar == "simple":
-                self.plot_widget.removeItem(self._color_bar)
-                self._color_bar.deleteLater()
-            self._color_bar = None
-
-        # Popup cleanup
-        if self.roi_manager_dialog is not None:
-            self.roi_manager_dialog.reject()
-            self.roi_manager_dialog = None
+        if self.main_image.config.monitor is not None:
+            self.disconnect_monitor(self.main_image.config.monitor)
+            self.main_image.config.monitor = None
 
         # Toolbar cleanup
         self.toolbar.widgets["monitor"].widget.close()
         self.toolbar.widgets["monitor"].widget.deleteLater()
-
-        # ROI plots cleanup
-        self.x_roi.cleanup_pyqtgraph()
-        self.y_roi.cleanup_pyqtgraph()
-
         super().cleanup()
 
 

--- a/bec_widgets/widgets/plots/image/image.py
+++ b/bec_widgets/widgets/plots/image/image.py
@@ -137,13 +137,7 @@ class Image(ImageBase):
             lambda: ImageLayerConfig(monitor=None, monitor_type="auto", source="auto")
         )
         super().__init__(
-            parent=parent,
-            main_image=ImageItem(parent_image=self),
-            config=config,
-            client=client,
-            gui_id=gui_id,
-            popups=popups,
-            **kwargs,
+            parent=parent, config=config, client=client, gui_id=gui_id, popups=popups, **kwargs
         )
         self.layer_removed.connect(self._on_layer_removed)
         self.scan_id = None
@@ -498,6 +492,7 @@ class Image(ImageBase):
         """
         Disconnect the image update signals and clean up the image.
         """
+        self.layer_removed.disconnect(self._on_layer_removed)
         for layer_name in list(self.subscriptions.keys()):
             config = self.subscriptions[layer_name]
             if config.monitor is not None:

--- a/bec_widgets/widgets/plots/image/image.py
+++ b/bec_widgets/widgets/plots/image/image.py
@@ -142,9 +142,6 @@ class Image(ImageBase):
         self.layer_removed.connect(self._on_layer_removed)
         self.scan_id = None
 
-        # Default Color map to plasma
-        self.color_map = "plasma"
-
     ################################################################################
     # Data Acquisition
 

--- a/bec_widgets/widgets/plots/image/image_base.py
+++ b/bec_widgets/widgets/plots/image/image_base.py
@@ -1,0 +1,1016 @@
+from __future__ import annotations
+
+from typing import Literal
+
+import numpy as np
+import pyqtgraph as pg
+from bec_lib import bec_logger
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+from qtpy.QtCore import QPointF, Signal, SignalInstance
+from qtpy.QtWidgets import QDialog, QVBoxLayout
+
+from bec_widgets.utils.error_popups import SafeProperty, SafeSlot
+from bec_widgets.utils.side_panel import SidePanel
+from bec_widgets.utils.toolbar import MaterialIconAction, SwitchableToolBarAction
+from bec_widgets.widgets.plots.image.image_item import ImageItem
+from bec_widgets.widgets.plots.image.image_roi_plot import ImageROIPlot
+from bec_widgets.widgets.plots.image.setting_widgets.image_roi_tree import ROIPropertyTree
+from bec_widgets.widgets.plots.image.toolbar_bundles.image_selection import (
+    MonitorSelectionToolbarBundle,
+)
+from bec_widgets.widgets.plots.image.toolbar_bundles.processing import ImageProcessingToolbarBundle
+from bec_widgets.widgets.plots.plot_base import PlotBase
+from bec_widgets.widgets.plots.roi.image_roi import (
+    BaseROI,
+    CircularROI,
+    RectangularROI,
+    ROIController,
+)
+
+logger = bec_logger.logger
+
+
+class ImageLayerSync(BaseModel):
+    """
+    Model for the image layer synchronization.
+    """
+
+    autorange: bool = Field(
+        True, description="Whether to synchronize the autorange of the image layer."
+    )
+    autorange_mode: bool = Field(
+        True, description="Whether to synchronize the autorange mode of the image layer."
+    )
+    color_map: bool = Field(
+        True, description="Whether to synchronize the color map of the image layer."
+    )
+    v_range: bool = Field(
+        True, description="Whether to synchronize the v_range of the image layer."
+    )
+    fft: bool = Field(True, description="Whether to synchronize the FFT of the image layer.")
+    log: bool = Field(True, description="Whether to synchronize the log of the image layer.")
+    rotation: bool = Field(
+        True, description="Whether to synchronize the rotation of the image layer."
+    )
+    transpose: bool = Field(
+        True, description="Whether to synchronize the transpose of the image layer."
+    )
+
+
+class ImageLayer(BaseModel):
+    """
+    Model for the image layer.
+    """
+
+    name: str = Field(description="The name of the image layer.")
+    image: ImageItem = Field(description="The image item to be displayed.")
+    sync: ImageLayerSync = Field(
+        default_factory=ImageLayerSync,
+        description="The synchronization settings for the image layer.",
+    )
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+
+class ImageLayerManager:
+    """
+    Manager for the image layers.
+    """
+
+    Z_RANGE_USER = (-100, 100)
+
+    def __init__(
+        self,
+        plot_item: pg.PlotItem,
+        on_add: SignalInstance | None = None,
+        on_remove: SignalInstance | None = None,
+    ):
+        self.plot_item = plot_item
+        self.on_add = on_add
+        self.on_remove = on_remove
+        self.layers: dict[str, ImageLayer] = {}
+
+    def add(
+        self,
+        name: str,
+        image: ImageItem,
+        z_position: int | Literal["top", "bottom"] | None = None,
+        sync: ImageLayerSync | None = None,
+        **kwargs,
+    ) -> ImageLayer:
+        """
+        Add an image layer to the widget.
+
+        Args:
+            name (str): The name of the image layer.
+            image (ImageItem): The image layer to add.
+            z_position (int | None): The z position of the image layer. If None, the layer is added to the top.
+            sync (ImageLayerSync | None): The synchronization settings for the image layer.
+            **kwargs: ImageLayerSync settings. Only used if sync is None.
+        """
+        if sync is None:
+            sync = ImageLayerSync(**kwargs)
+        if z_position is None or z_position == "top":
+            z_position = self._get_top_z_position()
+        elif z_position == "bottom":
+            z_position = self._get_bottom_z_position()
+        image.setZValue(z_position)
+        image.destroyed.connect(lambda: self._remove_destroyed_layer(name))
+        self.layers[name] = ImageLayer(name=name, image=image, sync=sync)
+        self.plot_item.addItem(image)
+
+        if self.on_add is not None:
+            self.on_add.emit(name)
+
+        return self.layers[name]
+
+    @SafeSlot(str)
+    def _remove_destroyed_layer(self, layer: str):
+        """
+        Remove a layer that has been destroyed.
+
+        Args:
+            layer (str): The name of the layer to remove.
+        """
+        self.remove(layer, pop=True)
+        if self.on_remove is not None:
+            self.on_remove.emit(layer)
+
+    def remove(self, layer: ImageLayer | str, pop=True):
+        """
+        Remove an image layer from the widget.
+
+        Args:
+            layer (ImageLayer | str): The image layer to remove. Can be the layer object or the name of the layer.
+            pop (bool): Whether to remove the layer from the manager's layers dictionary. If False, the layer is only removed from the plot item.
+        """
+        if isinstance(layer, str):
+            name = layer
+        else:
+            name = layer.name
+        if pop:
+            removed_layer = self.layers.pop(name, None)
+        else:
+            removed_layer = self.layers.get(name, None)
+        if not removed_layer:
+            return
+        self.plot_item.removeItem(removed_layer.image)
+        removed_layer.image.remove()
+        removed_layer.image.deleteLater()
+        removed_layer.image = None
+
+    def clear(self):
+        """
+        Clear all image layers from the manager.
+        """
+        for layer in self.layers.values():
+            # Remove each layer from the plot item and delete it
+            self.remove(layer, pop=False)
+        self.layers.clear()
+
+    def _get_top_z_position(self) -> int:
+        """
+        Get the top z position of the image layers, capping it to the maximum z value.
+
+        Returns:
+            int: The top z position of the image layers.
+        """
+        if not self.layers:
+            return 0
+        z = max(layer.image.zValue() for layer in self.layers.values()) + 1
+        return min(z, self.Z_RANGE_USER[1])
+
+    def _get_bottom_z_position(self) -> int:
+        """
+        Get the bottom z position of the image layers, capping it to the minimum z value.
+
+        Returns:
+            int: The bottom z position of the image layers.
+        """
+        if not self.layers:
+            return 0
+        z = min(layer.image.zValue() for layer in self.layers.values()) - 1
+        return max(z, self.Z_RANGE_USER[0])
+
+    def __iter__(self):
+        """
+        Iterate over the image layers.
+
+        Returns:
+            Iterator[ImageLayer]: An iterator over the image layers.
+        """
+        return iter(self.layers.values())
+
+    def __getitem__(self, name: str) -> ImageLayer:
+        """
+        Get an image layer by name.
+
+        Args:
+            name (str): The name of the image layer.
+
+        Returns:
+            ImageLayer: The image layer with the given name.
+        """
+        if not isinstance(name, str):
+            raise TypeError("name must be a string")
+        return self.layers[name]
+
+    def __len__(self) -> int:
+        """
+        Get the number of image layers.
+
+        Returns:
+            int: The number of image layers.
+        """
+        return len(self.layers)
+
+
+class ImageBase(PlotBase):
+    """
+    Base class for the Image widget.
+    """
+
+    sync_colorbar_with_autorange = Signal()
+    image_updated = Signal()
+    layer_added = Signal(str)
+    layer_removed = Signal(str)
+
+    def __init__(self, *args, main_image: ImageItem, **kwargs):
+        """
+        Initialize the ImageBase widget.
+        Args:
+            main_image (ImageItem): The main image item to be displayed. This is the main image layer, also used as reference for autoranging.
+        """
+        self.x_roi = None
+        self.y_roi = None
+        super().__init__(*args, **kwargs)
+        self.roi_controller = ROIController(colormap="viridis")
+
+        # Headless controller keeps the canonical list.
+        self.roi_manager_dialog = None
+        self.layers: ImageLayerManager = ImageLayerManager(
+            self.plot_item, on_add=self.layer_added, on_remove=self.layer_removed
+        )
+        self.layers.add("main", main_image)
+
+        self.autorange = True
+        self.autorange_mode = "mean"
+
+        # Initialize ROI plots and side panels
+        self._add_roi_plots()
+
+        # Refresh theme for ROI plots
+        self._update_theme()
+
+    ################################################################################
+    # Widget Specific GUI interactions
+    ################################################################################
+
+    def apply_theme(self, theme: str):
+        super().apply_theme(theme)
+        if self.x_roi is not None and self.y_roi is not None:
+            self.x_roi.apply_theme(theme)
+            self.y_roi.apply_theme(theme)
+
+    def _init_toolbar(self):
+
+        try:
+            # add to the first position
+            self.selection_bundle = MonitorSelectionToolbarBundle(
+                bundle_id="selection", target_widget=self
+            )
+            self.toolbar.add_bundle(self.selection_bundle, self)
+
+            super()._init_toolbar()
+
+            # Image specific changes to PlotBase toolbar
+            self.toolbar.widgets["reset_legend"].action.setVisible(False)
+
+            # ROI Bundle replacement with switchable crosshair
+            self.toolbar.remove_bundle("roi")
+            crosshair = MaterialIconAction(
+                icon_name="point_scan", tooltip="Show Crosshair", checkable=True, parent=self
+            )
+            crosshair_roi = MaterialIconAction(
+                icon_name="my_location",
+                tooltip="Show Crosshair with ROI plots",
+                checkable=True,
+                parent=self,
+            )
+            crosshair_roi.action.toggled.connect(self.toggle_roi_panels)
+            crosshair.action.toggled.connect(self.toggle_crosshair)
+            switch_crosshair = SwitchableToolBarAction(
+                actions={"crosshair_simple": crosshair, "crosshair_roi": crosshair_roi},
+                initial_action="crosshair_simple",
+                tooltip="Crosshair",
+                checkable=True,
+                parent=self,
+            )
+            self.toolbar.add_action(
+                action_id="switch_crosshair", action=switch_crosshair, target_widget=self
+            )
+
+            # Lock aspect ratio button
+            self.lock_aspect_ratio_action = MaterialIconAction(
+                icon_name="aspect_ratio", tooltip="Lock Aspect Ratio", checkable=True, parent=self
+            )
+            self.toolbar.add_action_to_bundle(
+                bundle_id="mouse_interaction",
+                action_id="lock_aspect_ratio",
+                action=self.lock_aspect_ratio_action,
+                target_widget=self,
+            )
+            self.lock_aspect_ratio_action.action.toggled.connect(
+                lambda checked: self.setProperty("lock_aspect_ratio", checked)
+            )
+            self.lock_aspect_ratio_action.action.setChecked(True)
+
+            self._init_autorange_action()
+            self._init_colorbar_action()
+
+            # Processing Bundle
+            self.processing_bundle = ImageProcessingToolbarBundle(
+                bundle_id="processing", target_widget=self
+            )
+            self.toolbar.add_bundle(self.processing_bundle, target_widget=self)
+        except Exception as e:
+            logger.error(f"Error initializing toolbar: {e}")
+
+    def _init_autorange_action(self):
+
+        self.autorange_mean_action = MaterialIconAction(
+            icon_name="hdr_auto", tooltip="Enable Auto Range (Mean)", checkable=True, parent=self
+        )
+        self.autorange_max_action = MaterialIconAction(
+            icon_name="hdr_auto",
+            tooltip="Enable Auto Range (Max)",
+            checkable=True,
+            filled=True,
+            parent=self,
+        )
+
+        self.autorange_switch = SwitchableToolBarAction(
+            actions={
+                "auto_range_mean": self.autorange_mean_action,
+                "auto_range_max": self.autorange_max_action,
+            },
+            initial_action="auto_range_mean",
+            tooltip="Enable Auto Range",
+            checkable=True,
+            parent=self,
+        )
+
+        self.toolbar.add_action(
+            action_id="autorange_image", action=self.autorange_switch, target_widget=self
+        )
+
+        self.autorange_mean_action.action.toggled.connect(
+            lambda checked: self.toggle_autorange(checked, mode="mean")
+        )
+        self.autorange_max_action.action.toggled.connect(
+            lambda checked: self.toggle_autorange(checked, mode="max")
+        )
+
+    def _init_colorbar_action(self):
+        self.full_colorbar_action = MaterialIconAction(
+            icon_name="edgesensor_low", tooltip="Enable Full Colorbar", checkable=True, parent=self
+        )
+        self.simple_colorbar_action = MaterialIconAction(
+            icon_name="smartphone", tooltip="Enable Simple Colorbar", checkable=True, parent=self
+        )
+
+        self.colorbar_switch = SwitchableToolBarAction(
+            actions={
+                "full_colorbar": self.full_colorbar_action,
+                "simple_colorbar": self.simple_colorbar_action,
+            },
+            initial_action="full_colorbar",
+            tooltip="Enable Full Colorbar",
+            checkable=True,
+            parent=self,
+        )
+
+        self.toolbar.add_action(
+            action_id="switch_colorbar", action=self.colorbar_switch, target_widget=self
+        )
+
+        self.simple_colorbar_action.action.toggled.connect(
+            lambda checked: self.enable_colorbar(checked, style="simple")
+        )
+        self.full_colorbar_action.action.toggled.connect(
+            lambda checked: self.enable_colorbar(checked, style="full")
+        )
+
+    ########################################
+    # ROI Gui Manager
+    def add_side_menus(self):
+        super().add_side_menus()
+
+        roi_mgr = ROIPropertyTree(parent=self, image_widget=self)
+        self.side_panel.add_menu(
+            action_id="roi_mgr",
+            icon_name="view_list",
+            tooltip="ROI Manager",
+            widget=roi_mgr,
+            title="ROI Manager",
+        )
+
+    def add_popups(self):
+        super().add_popups()  # keep Axis Settings
+
+        roi_action = MaterialIconAction(
+            icon_name="view_list", tooltip="ROI Manager", checkable=True, parent=self
+        )
+        # self.popup_bundle.add_action("roi_mgr", roi_action)
+        self.toolbar.add_action_to_bundle(
+            bundle_id="popup_bundle", action_id="roi_mgr", action=roi_action, target_widget=self
+        )
+        self.toolbar.widgets["roi_mgr"].action.triggered.connect(self.show_roi_manager_popup)
+
+    def show_roi_manager_popup(self):
+        roi_action = self.toolbar.widgets["roi_mgr"].action
+        if self.roi_manager_dialog is None or not self.roi_manager_dialog.isVisible():
+            self.roi_mgr = ROIPropertyTree(parent=self, image_widget=self)
+            self.roi_manager_dialog = QDialog(modal=False)
+            self.roi_manager_dialog.layout = QVBoxLayout(self.roi_manager_dialog)
+            self.roi_manager_dialog.layout.addWidget(self.roi_mgr)
+            self.roi_manager_dialog.finished.connect(self._roi_mgr_closed)
+            self.roi_manager_dialog.show()
+            roi_action.setChecked(True)
+        else:
+            self.roi_manager_dialog.raise_()
+            self.roi_manager_dialog.activateWindow()
+            roi_action.setChecked(True)
+
+    def _roi_mgr_closed(self):
+        self.roi_mgr.close()
+        self.roi_mgr.deleteLater()
+        self.roi_manager_dialog.close()
+        self.roi_manager_dialog.deleteLater()
+        self.roi_manager_dialog = None
+        self.toolbar.widgets["roi_mgr"].action.setChecked(False)
+
+    def enable_colorbar(
+        self,
+        enabled: bool,
+        style: Literal["full", "simple"] = "full",
+        vrange: tuple[int, int] | None = None,
+    ):
+        """
+        Enable the colorbar and switch types of colorbars.
+
+        Args:
+            enabled(bool): Whether to enable the colorbar.
+            style(Literal["full", "simple"]): The type of colorbar to enable.
+            vrange(tuple): The range of values to use for the colorbar.
+        """
+        autorange_state = self.layers["main"].image.autorange
+        if enabled:
+            if self._color_bar:
+                if self.config.color_bar == "full":
+                    self.cleanup_histogram_lut_item(self._color_bar)
+                self.plot_widget.removeItem(self._color_bar)
+                self._color_bar = None
+
+            if style == "simple":
+
+                def disable_autorange():
+                    print("Disabling autorange")
+                    self.setProperty("autorange", False)
+
+                self._color_bar = pg.ColorBarItem(colorMap=self.config.color_map)
+                self._color_bar.setImageItem(self.layers["main"].image)
+                self._color_bar.sigLevelsChangeFinished.connect(disable_autorange)
+
+            elif style == "full":
+                self._color_bar = pg.HistogramLUTItem()
+                self._color_bar.setImageItem(self.layers["main"].image)
+                self._color_bar.gradient.loadPreset(self.config.color_map)
+                self._color_bar.sigLevelsChanged.connect(
+                    lambda: self.setProperty("autorange", False)
+                )
+
+            self.plot_widget.addItem(self._color_bar, row=0, col=1)
+            self.config.color_bar = style
+        else:
+            if self._color_bar:
+                self.plot_widget.removeItem(self._color_bar)
+                self._color_bar = None
+            self.config.color_bar = None
+
+        self.autorange = autorange_state
+        self._sync_colorbar_actions()
+
+        if vrange:  # should be at the end to disable the autorange if defined
+            self.v_range = vrange
+
+    ################################################################################
+    # Static rois with roi manager
+
+    def add_roi(
+        self,
+        kind: Literal["rect", "circle"] = "rect",
+        name: str | None = None,
+        line_width: int | None = 5,
+        pos: tuple[float, float] | None = (10, 10),
+        size: tuple[float, float] | None = (50, 50),
+        **pg_kwargs,
+    ) -> RectangularROI | CircularROI:
+        """
+        Add a ROI to the image.
+
+        Args:
+            kind(str): The type of ROI to add. Options are "rect" or "circle".
+            name(str): The name of the ROI.
+            line_width(int): The line width of the ROI.
+            pos(tuple): The position of the ROI.
+            size(tuple): The size of the ROI.
+            **pg_kwargs: Additional arguments for the ROI.
+
+        Returns:
+            RectangularROI | CircularROI: The created ROI object.
+        """
+        if name is None:
+            name = f"ROI_{len(self.roi_controller.rois) + 1}"
+        if kind == "rect":
+            roi = RectangularROI(
+                pos=pos,
+                size=size,
+                parent_image=self,
+                line_width=line_width,
+                label=name,
+                **pg_kwargs,
+            )
+        elif kind == "circle":
+            roi = CircularROI(
+                pos=pos,
+                size=size,
+                parent_image=self,
+                line_width=line_width,
+                label=name,
+                **pg_kwargs,
+            )
+        else:
+            raise ValueError("kind must be 'rect' or 'circle'")
+
+        # Add to plot and controller (controller assigns color)
+        self.plot_item.addItem(roi)
+        self.roi_controller.add_roi(roi)
+        roi.add_scale_handle()
+        return roi
+
+    def remove_roi(self, roi: int | str):
+        """Remove an ROI by index or label via the ROIController."""
+        if isinstance(roi, int):
+            self.roi_controller.remove_roi_by_index(roi)
+        elif isinstance(roi, str):
+            self.roi_controller.remove_roi_by_name(roi)
+        else:
+            raise ValueError("roi must be an int index or str name")
+
+    def _add_roi_plots(self):
+        """
+        Initialize the ROI plots and side panels.
+        """
+        # Create ROI plot widgets
+        self.x_roi = ImageROIPlot(parent=self)
+        self.y_roi = ImageROIPlot(parent=self)
+        self.x_roi.apply_theme("dark")
+        self.y_roi.apply_theme("dark")
+
+        # Set titles for the plots
+        self.x_roi.plot_item.setTitle("X ROI")
+        self.y_roi.plot_item.setTitle("Y ROI")
+
+        # Create side panels
+        self.side_panel_x = SidePanel(
+            parent=self, orientation="bottom", panel_max_width=200, show_toolbar=False
+        )
+        self.side_panel_y = SidePanel(
+            parent=self, orientation="left", panel_max_width=200, show_toolbar=False
+        )
+
+        # Add ROI plots to side panels
+        self.x_panel_index = self.side_panel_x.add_menu(widget=self.x_roi)
+        self.y_panel_index = self.side_panel_y.add_menu(widget=self.y_roi)
+
+        # # Add side panels to the layout
+        self.layout_manager.add_widget_relative(
+            self.side_panel_x, self.round_plot_widget, position="bottom", shift_direction="down"
+        )
+        self.layout_manager.add_widget_relative(
+            self.side_panel_y, self.round_plot_widget, position="left", shift_direction="right"
+        )
+
+    def toggle_roi_panels(self, checked: bool):
+        """
+        Show or hide the ROI panels based on the test action toggle state.
+
+        Args:
+            checked (bool): Whether the test action is checked.
+        """
+        if checked:
+            # Show the ROI panels
+            self.hook_crosshair()
+            self.side_panel_x.show_panel(self.x_panel_index)
+            self.side_panel_y.show_panel(self.y_panel_index)
+            self.crosshair.coordinatesChanged2D.connect(self.update_image_slices)
+            self.image_updated.connect(self.update_image_slices)
+        else:
+            self.unhook_crosshair()
+            # Hide the ROI panels
+            self.side_panel_x.hide_panel()
+            self.side_panel_y.hide_panel()
+            self.image_updated.disconnect(self.update_image_slices)
+
+    @SafeSlot()
+    def update_image_slices(self, coordinates: tuple[int, int, int] = None):
+        """
+        Update the image slices based on the crosshair position.
+
+        Args:
+            coordinates(tuple): The coordinates of the crosshair.
+        """
+        if coordinates is None:
+            # Try to get coordinates from crosshair position (like in crosshair mouse_moved)
+            if (
+                hasattr(self, "crosshair")
+                and hasattr(self.crosshair, "v_line")
+                and hasattr(self.crosshair, "h_line")
+            ):
+                x = int(round(self.crosshair.v_line.value()))
+                y = int(round(self.crosshair.h_line.value()))
+            else:
+                return
+        else:
+            x = coordinates[1]
+            y = coordinates[2]
+        image = self.main_image.image
+        if image is None:
+            return
+        max_row, max_col = image.shape[0] - 1, image.shape[1] - 1
+        row, col = x, y
+        if not (0 <= row <= max_row and 0 <= col <= max_col):
+            return
+        # Horizontal slice
+        h_slice = image[:, col]
+        x_axis = np.arange(h_slice.shape[0])
+        self.x_roi.plot_item.clear()
+        self.x_roi.plot_item.plot(x_axis, h_slice, pen=pg.mkPen(self.x_roi.curve_color, width=3))
+        # Vertical slice
+        v_slice = image[row, :]
+        y_axis = np.arange(v_slice.shape[0])
+        self.y_roi.plot_item.clear()
+        self.y_roi.plot_item.plot(v_slice, y_axis, pen=pg.mkPen(self.y_roi.curve_color, width=3))
+
+    ################################################################################
+    # Widget Specific Properties
+    ################################################################################
+    ################################################################################
+    # Rois
+
+    @property
+    def rois(self) -> list[BaseROI]:
+        """
+        Get the list of ROIs.
+        """
+        return self.roi_controller.rois
+
+    ################################################################################
+    # Colorbar toggle
+
+    @SafeProperty(bool)
+    def enable_simple_colorbar(self) -> bool:
+        """
+        Enable the simple colorbar.
+        """
+        enabled = False
+        if self.config.color_bar == "simple":
+            enabled = True
+        return enabled
+
+    @enable_simple_colorbar.setter
+    def enable_simple_colorbar(self, value: bool):
+        """
+        Enable the simple colorbar.
+
+        Args:
+            value(bool): Whether to enable the simple colorbar.
+        """
+        self.enable_colorbar(enabled=value, style="simple")
+
+    @SafeProperty(bool)
+    def enable_full_colorbar(self) -> bool:
+        """
+        Enable the full colorbar.
+        """
+        enabled = False
+        if self.config.color_bar == "full":
+            enabled = True
+        return enabled
+
+    @enable_full_colorbar.setter
+    def enable_full_colorbar(self, value: bool):
+        """
+        Enable the full colorbar.
+
+        Args:
+            value(bool): Whether to enable the full colorbar.
+        """
+        self.enable_colorbar(enabled=value, style="full")
+
+    ################################################################################
+    # Appearance
+
+    @SafeProperty(str)
+    def color_map(self) -> str:
+        """
+        Set the color map of the image.
+        """
+        return self.config.color_map
+
+    @color_map.setter
+    def color_map(self, value: str):
+        """
+        Set the color map of the image.
+
+        Args:
+            value(str): The color map to set.
+        """
+        try:
+            self.config.color_map = value
+            for layer in self.layers:
+                if not layer.sync.color_map:
+                    continue
+                layer.image.color_map = value
+
+            if self._color_bar:
+                if self.config.color_bar == "simple":
+                    self._color_bar.setColorMap(value)
+                elif self.config.color_bar == "full":
+                    self._color_bar.gradient.loadPreset(value)
+        except ValidationError:
+            return
+
+    @SafeProperty("QPointF")
+    def v_range(self) -> QPointF:
+        """
+        Set the v_range of the main image.
+        """
+        vmin, vmax = self.layers["main"].image.v_range
+        return QPointF(vmin, vmax)
+
+    @v_range.setter
+    def v_range(self, value: tuple | list | QPointF):
+        """
+        Set the v_range of the main image.
+
+        Args:
+            value(tuple | list | QPointF): The range of values to set.
+        """
+        if isinstance(value, (tuple, list)):
+            value = self._tuple_to_qpointf(value)
+
+        vmin, vmax = value.x(), value.y()
+
+        for layer in self.layers:
+            if not layer.sync.v_range:
+                continue
+            layer.image.v_range = (vmin, vmax)
+
+        # propagate to colorbar if exists
+        if self._color_bar:
+            if self.config.color_bar == "simple":
+                self._color_bar.setLevels(low=vmin, high=vmax)
+            elif self.config.color_bar == "full":
+                self._color_bar.setLevels(min=vmin, max=vmax)
+                self._color_bar.setHistogramRange(vmin - 0.1 * vmin, vmax + 0.1 * vmax)
+
+        self.autorange_switch.set_state_all(False)
+
+    @property
+    def v_min(self) -> float:
+        """
+        Get the minimum value of the v_range.
+        """
+        return self.v_range.x()
+
+    @v_min.setter
+    def v_min(self, value: float):
+        """
+        Set the minimum value of the v_range.
+
+        Args:
+            value(float): The minimum value to set.
+        """
+        self.v_range = (value, self.v_range.y())
+
+    @property
+    def v_max(self) -> float:
+        """
+        Get the maximum value of the v_range.
+        """
+        return self.v_range.y()
+
+    @v_max.setter
+    def v_max(self, value: float):
+        """
+        Set the maximum value of the v_range.
+
+        Args:
+            value(float): The maximum value to set.
+        """
+        self.v_range = (self.v_range.x(), value)
+
+    @SafeProperty(bool)
+    def lock_aspect_ratio(self) -> bool:
+        """
+        Whether the aspect ratio is locked.
+        """
+        return self.config.lock_aspect_ratio
+
+    @lock_aspect_ratio.setter
+    def lock_aspect_ratio(self, value: bool):
+        """
+        Set the aspect ratio lock.
+
+        Args:
+            value(bool): Whether to lock the aspect ratio.
+        """
+        self.config.lock_aspect_ratio = bool(value)
+        self.plot_item.setAspectLocked(value)
+
+    ################################################################################
+    # Autorange + Colorbar sync
+
+    @SafeProperty(bool)
+    def autorange(self) -> bool:
+        """
+        Whether autorange is enabled.
+        """
+
+        # FIXME: this should be made more general
+        return self.layers["main"].image.autorange
+
+    @autorange.setter
+    def autorange(self, enabled: bool):
+        """
+        Set autorange.
+
+        Args:
+            enabled(bool): Whether to enable autorange.
+        """
+        for layer in self.layers:
+            if not layer.sync.autorange:
+                continue
+            layer.image.autorange = enabled
+            if enabled and layer.image.raw_data is not None:
+                layer.image.apply_autorange()
+                self._sync_colorbar_levels()
+        self._sync_autorange_switch()
+
+    @SafeProperty(str)
+    def autorange_mode(self) -> str:
+        """
+        Autorange mode.
+
+        Options:
+            - "max": Use the maximum value of the image for autoranging.
+            - "mean": Use the mean value of the image for autoranging.
+
+        """
+        return self.layers["main"].image.autorange_mode
+
+    @autorange_mode.setter
+    def autorange_mode(self, mode: str):
+        """
+        Set the autorange mode.
+
+        Args:
+            mode(str): The autorange mode. Options are "max" or "mean".
+        """
+        # for qt Designer
+        if mode not in ["max", "mean"]:
+            return
+        for layer in self.layers:
+            if not layer.sync.autorange_mode:
+                continue
+            layer.image.autorange_mode = mode
+
+        self._sync_autorange_switch()
+
+    @SafeSlot(bool, str, bool)
+    def toggle_autorange(self, enabled: bool, mode: str):
+        """
+        Toggle autorange.
+
+        Args:
+            enabled(bool): Whether to enable autorange.
+            mode(str): The autorange mode. Options are "max" or "mean".
+        """
+        if not self.layers:
+            return
+
+        for layer in self.layers:
+            if layer.sync.autorange:
+                layer.image.autorange = enabled
+            if layer.sync.autorange_mode:
+                layer.image.autorange_mode = mode
+
+            if not enabled:
+                continue
+            # We only need to apply autorange if we enabled it
+            layer.image.apply_autorange()
+
+        if enabled:
+            self._sync_colorbar_levels()
+
+    def _sync_autorange_switch(self):
+        """
+        Synchronize the autorange switch with the current autorange state and mode if changed from outside.
+        """
+        self.autorange_switch.block_all_signals(True)
+        self.autorange_switch.set_default_action(
+            f"auto_range_{self.layers['main'].image.autorange_mode}"
+        )
+        self.autorange_switch.set_state_all(self.layers["main"].image.autorange)
+        self.autorange_switch.block_all_signals(False)
+
+    def _sync_colorbar_levels(self):
+        """Immediately propagate current levels to the active colorbar."""
+
+        if not self._color_bar:
+            return
+
+        total_vrange = (0, 0)
+        for layer in self.layers:
+            if not layer.sync.v_range:
+                continue
+            img = layer.image
+            total_vrange = (min(total_vrange[0], img.v_min), max(total_vrange[1], img.v_max))
+
+        self._color_bar.blockSignals(True)
+        self.v_range = total_vrange  # type: ignore
+        self._color_bar.blockSignals(False)
+
+    def _sync_colorbar_actions(self):
+        """
+        Synchronize the colorbar actions with the current colorbar state.
+        """
+        self.colorbar_switch.block_all_signals(True)
+        if self._color_bar is not None:
+            self.colorbar_switch.set_default_action(f"{self.config.color_bar}_colorbar")
+            self.colorbar_switch.set_state_all(True)
+        else:
+            self.colorbar_switch.set_state_all(False)
+        self.colorbar_switch.block_all_signals(False)
+
+    @staticmethod
+    def cleanup_histogram_lut_item(histogram_lut_item: pg.HistogramLUTItem):
+        """
+        Clean up HistogramLUTItem safely, including open ViewBox menus and child widgets.
+
+        Args:
+            histogram_lut_item(pg.HistogramLUTItem): The HistogramLUTItem to clean up.
+        """
+        histogram_lut_item.vb.menu.close()
+        histogram_lut_item.vb.menu.deleteLater()
+
+        histogram_lut_item.gradient.menu.close()
+        histogram_lut_item.gradient.menu.deleteLater()
+        histogram_lut_item.gradient.colorDialog.close()
+        histogram_lut_item.gradient.colorDialog.deleteLater()
+
+    def cleanup(self):
+        """
+        Cleanup the widget.
+        """
+
+        # Remove all ROIs
+        rois = self.rois
+        for roi in rois:
+            roi.remove()
+
+        # Colorbar Cleanup
+        if self._color_bar:
+            if self.config.color_bar == "full":
+                self.cleanup_histogram_lut_item(self._color_bar)
+            if self.config.color_bar == "simple":
+                self.plot_widget.removeItem(self._color_bar)
+                self._color_bar.deleteLater()
+            self._color_bar = None
+
+        # Popup cleanup
+        if self.roi_manager_dialog is not None:
+            self.roi_manager_dialog.reject()
+            self.roi_manager_dialog = None
+
+        # ROI plots cleanup
+        if self.x_roi is not None:
+            self.x_roi.cleanup_pyqtgraph()
+        if self.y_roi is not None:
+            self.y_roi.cleanup_pyqtgraph()
+
+        self.layers.clear()
+        self.layers = None
+
+        super().cleanup()

--- a/bec_widgets/widgets/plots/image/image_base.py
+++ b/bec_widgets/widgets/plots/image/image_base.py
@@ -223,6 +223,9 @@ class ImageLayerManager:
         """
         if not isinstance(name, str):
             raise TypeError("name must be a string")
+        if name == "main" and name not in self.layers:
+            # If 'main' is requested, create a default layer if it doesn't exist
+            return self.add(name=name, z_position="top")
         return self.layers[name]
 
     def __len__(self) -> int:

--- a/bec_widgets/widgets/plots/image/image_base.py
+++ b/bec_widgets/widgets/plots/image/image_base.py
@@ -123,7 +123,7 @@ class ImageLayerManager:
             z_position = self._get_bottom_z_position()
         image = ImageItem(parent_image=self.parent, object_name=name)
         image.setZValue(z_position)
-        image.removed.connect(lambda: self._remove_destroyed_layer(name))
+        image.removed.connect(self._remove_destroyed_layer)
         self.layers[name] = ImageLayer(name=name, image=image, sync=sync)
         self.plot_item.addItem(image)
 

--- a/bec_widgets/widgets/plots/image/image_base.py
+++ b/bec_widgets/widgets/plots/image/image_base.py
@@ -124,6 +124,10 @@ class ImageLayerManager:
         image = ImageItem(parent_image=self.parent, object_name=name)
         image.setZValue(z_position)
         image.removed.connect(self._remove_destroyed_layer)
+
+        # FIXME: For now, we hard-code the default color map here. In the future, this should be configurable.
+        image.color_map = "plasma"
+
         self.layers[name] = ImageLayer(name=name, image=image, sync=sync)
         self.plot_item.addItem(image)
 

--- a/bec_widgets/widgets/plots/image/image_base.py
+++ b/bec_widgets/widgets/plots/image/image_base.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, ConfigDict, Field, ValidationError
 from qtpy.QtCore import QPointF, Signal, SignalInstance
 from qtpy.QtWidgets import QDialog, QVBoxLayout
 
+from bec_widgets.utils.container_utils import WidgetContainerUtils
 from bec_widgets.utils.error_popups import SafeProperty, SafeSlot
 from bec_widgets.utils.side_panel import SidePanel
 from bec_widgets.utils.toolbar import MaterialIconAction, SwitchableToolBarAction
@@ -93,7 +94,7 @@ class ImageLayerManager:
 
     def add(
         self,
-        name: str,
+        name: str | None = None,
         z_position: int | Literal["top", "bottom"] | None = None,
         sync: ImageLayerSync | None = None,
         **kwargs,
@@ -102,12 +103,16 @@ class ImageLayerManager:
         Add an image layer to the widget.
 
         Args:
-            name (str): The name of the image layer.
+            name (str | None): The name of the image layer. If None, a default name is generated.
             image (ImageItem): The image layer to add.
             z_position (int | None): The z position of the image layer. If None, the layer is added to the top.
             sync (ImageLayerSync | None): The synchronization settings for the image layer.
             **kwargs: ImageLayerSync settings. Only used if sync is None.
         """
+        if name is None:
+            name = WidgetContainerUtils.generate_unique_name(
+                "image_layer", list(self.layers.keys())
+            )
         if name in self.layers:
             raise ValueError(f"Layer with name '{name}' already exists.")
         if sync is None:

--- a/bec_widgets/widgets/plots/image/image_base.py
+++ b/bec_widgets/widgets/plots/image/image_base.py
@@ -80,10 +80,12 @@ class ImageLayerManager:
 
     def __init__(
         self,
+        parent: ImageBase,
         plot_item: pg.PlotItem,
         on_add: SignalInstance | None = None,
         on_remove: SignalInstance | None = None,
     ):
+        self.parent = parent
         self.plot_item = plot_item
         self.on_add = on_add
         self.on_remove = on_remove
@@ -92,7 +94,6 @@ class ImageLayerManager:
     def add(
         self,
         name: str,
-        image: ImageItem,
         z_position: int | Literal["top", "bottom"] | None = None,
         sync: ImageLayerSync | None = None,
         **kwargs,
@@ -107,14 +108,17 @@ class ImageLayerManager:
             sync (ImageLayerSync | None): The synchronization settings for the image layer.
             **kwargs: ImageLayerSync settings. Only used if sync is None.
         """
+        if name in self.layers:
+            raise ValueError(f"Layer with name '{name}' already exists.")
         if sync is None:
             sync = ImageLayerSync(**kwargs)
         if z_position is None or z_position == "top":
             z_position = self._get_top_z_position()
         elif z_position == "bottom":
             z_position = self._get_bottom_z_position()
+        image = ImageItem(parent_image=self.parent, object_name=name)
         image.setZValue(z_position)
-        image.destroyed.connect(lambda: self._remove_destroyed_layer(name))
+        image.removed.connect(lambda: self._remove_destroyed_layer(name))
         self.layers[name] = ImageLayer(name=name, image=image, sync=sync)
         self.plot_item.addItem(image)
 
@@ -131,30 +135,28 @@ class ImageLayerManager:
         Args:
             layer (str): The name of the layer to remove.
         """
-        self.remove(layer, pop=True)
+        self.remove(layer)
         if self.on_remove is not None:
             self.on_remove.emit(layer)
 
-    def remove(self, layer: ImageLayer | str, pop=True):
+    def remove(self, layer: ImageLayer | str):
         """
         Remove an image layer from the widget.
 
         Args:
             layer (ImageLayer | str): The image layer to remove. Can be the layer object or the name of the layer.
-            pop (bool): Whether to remove the layer from the manager's layers dictionary. If False, the layer is only removed from the plot item.
         """
         if isinstance(layer, str):
             name = layer
         else:
             name = layer.name
-        if pop:
-            removed_layer = self.layers.pop(name, None)
-        else:
-            removed_layer = self.layers.get(name, None)
+
+        removed_layer = self.layers.pop(name, None)
+
         if not removed_layer:
             return
         self.plot_item.removeItem(removed_layer.image)
-        removed_layer.image.remove()
+        removed_layer.image.remove(emit=False)
         removed_layer.image.deleteLater()
         removed_layer.image = None
 
@@ -162,9 +164,9 @@ class ImageLayerManager:
         """
         Clear all image layers from the manager.
         """
-        for layer in self.layers.values():
+        for layer in list(self.layers.keys()):
             # Remove each layer from the plot item and delete it
-            self.remove(layer, pop=False)
+            self.remove(layer)
         self.layers.clear()
 
     def _get_top_z_position(self) -> int:
@@ -234,11 +236,9 @@ class ImageBase(PlotBase):
     layer_added = Signal(str)
     layer_removed = Signal(str)
 
-    def __init__(self, *args, main_image: ImageItem, **kwargs):
+    def __init__(self, *args, **kwargs):
         """
         Initialize the ImageBase widget.
-        Args:
-            main_image (ImageItem): The main image item to be displayed. This is the main image layer, also used as reference for autoranging.
         """
         self.x_roi = None
         self.y_roi = None
@@ -248,9 +248,9 @@ class ImageBase(PlotBase):
         # Headless controller keeps the canonical list.
         self.roi_manager_dialog = None
         self.layers: ImageLayerManager = ImageLayerManager(
-            self.plot_item, on_add=self.layer_added, on_remove=self.layer_removed
+            self, plot_item=self.plot_item, on_add=self.layer_added, on_remove=self.layer_removed
         )
-        self.layers.add("main", main_image)
+        self.layers.add("main")
 
         self.autorange = True
         self.autorange_mode = "mean"
@@ -644,7 +644,7 @@ class ImageBase(PlotBase):
         else:
             x = coordinates[1]
             y = coordinates[2]
-        image = self.main_image.image
+        image = self.layers["main"].image.image
         if image is None:
             return
         max_row, max_col = image.shape[0] - 1, image.shape[1] - 1

--- a/bec_widgets/widgets/plots/image/image_base.py
+++ b/bec_widgets/widgets/plots/image/image_base.py
@@ -252,10 +252,10 @@ class ImageBase(PlotBase):
 
         # Headless controller keeps the canonical list.
         self.roi_manager_dialog = None
-        self.layers: ImageLayerManager = ImageLayerManager(
+        self.layer_manager: ImageLayerManager = ImageLayerManager(
             self, plot_item=self.plot_item, on_add=self.layer_added, on_remove=self.layer_removed
         )
-        self.layers.add("main")
+        self.layer_manager.add("main")
 
         self.autorange = True
         self.autorange_mode = "mean"
@@ -275,6 +275,40 @@ class ImageBase(PlotBase):
         if self.x_roi is not None and self.y_roi is not None:
             self.x_roi.apply_theme(theme)
             self.y_roi.apply_theme(theme)
+
+    def add_layer(self, name: str | None = None, **kwargs) -> ImageLayer:
+        """
+        Add a new image layer to the widget.
+
+        Args:
+            name (str | None): The name of the image layer. If None, a default name is generated.
+            **kwargs: Additional arguments for the image layer.
+
+        Returns:
+            ImageLayer: The added image layer.
+        """
+        layer = self.layer_manager.add(name=name, **kwargs)
+        self.image_updated.emit()
+        return layer
+
+    def remove_layer(self, layer: ImageLayer | str):
+        """
+        Remove an image layer from the widget.
+
+        Args:
+            layer (ImageLayer | str): The image layer to remove. Can be the layer object or the name of the layer.
+        """
+        self.layer_manager.remove(layer)
+        self.image_updated.emit()
+
+    def layers(self) -> list[ImageLayer]:
+        """
+        Get the list of image layers.
+
+        Returns:
+            list[ImageLayer]: The list of image layers.
+        """
+        return list(self.layer_manager.layers.values())
 
     def _init_toolbar(self):
 
@@ -468,7 +502,7 @@ class ImageBase(PlotBase):
             style(Literal["full", "simple"]): The type of colorbar to enable.
             vrange(tuple): The range of values to use for the colorbar.
         """
-        autorange_state = self.layers["main"].image.autorange
+        autorange_state = self.layer_manager["main"].image.autorange
         if enabled:
             if self._color_bar:
                 if self.config.color_bar == "full":
@@ -483,12 +517,12 @@ class ImageBase(PlotBase):
                     self.setProperty("autorange", False)
 
                 self._color_bar = pg.ColorBarItem(colorMap=self.config.color_map)
-                self._color_bar.setImageItem(self.layers["main"].image)
+                self._color_bar.setImageItem(self.layer_manager["main"].image)
                 self._color_bar.sigLevelsChangeFinished.connect(disable_autorange)
 
             elif style == "full":
                 self._color_bar = pg.HistogramLUTItem()
-                self._color_bar.setImageItem(self.layers["main"].image)
+                self._color_bar.setImageItem(self.layer_manager["main"].image)
                 self._color_bar.gradient.loadPreset(self.config.color_map)
                 self._color_bar.sigLevelsChanged.connect(
                     lambda: self.setProperty("autorange", False)
@@ -649,7 +683,7 @@ class ImageBase(PlotBase):
         else:
             x = coordinates[1]
             y = coordinates[2]
-        image = self.layers["main"].image.image
+        image = self.layer_manager["main"].image.image
         if image is None:
             return
         max_row, max_col = image.shape[0] - 1, image.shape[1] - 1
@@ -743,7 +777,7 @@ class ImageBase(PlotBase):
         """
         try:
             self.config.color_map = value
-            for layer in self.layers:
+            for layer in self.layer_manager:
                 if not layer.sync.color_map:
                     continue
                 layer.image.color_map = value
@@ -761,7 +795,7 @@ class ImageBase(PlotBase):
         """
         Set the v_range of the main image.
         """
-        vmin, vmax = self.layers["main"].image.v_range
+        vmin, vmax = self.layer_manager["main"].image.v_range
         return QPointF(vmin, vmax)
 
     @v_range.setter
@@ -777,7 +811,7 @@ class ImageBase(PlotBase):
 
         vmin, vmax = value.x(), value.y()
 
-        for layer in self.layers:
+        for layer in self.layer_manager:
             if not layer.sync.v_range:
                 continue
             layer.image.v_range = (vmin, vmax)
@@ -854,7 +888,7 @@ class ImageBase(PlotBase):
         """
 
         # FIXME: this should be made more general
-        return self.layers["main"].image.autorange
+        return self.layer_manager["main"].image.autorange
 
     @autorange.setter
     def autorange(self, enabled: bool):
@@ -864,7 +898,7 @@ class ImageBase(PlotBase):
         Args:
             enabled(bool): Whether to enable autorange.
         """
-        for layer in self.layers:
+        for layer in self.layer_manager:
             if not layer.sync.autorange:
                 continue
             layer.image.autorange = enabled
@@ -883,7 +917,7 @@ class ImageBase(PlotBase):
             - "mean": Use the mean value of the image for autoranging.
 
         """
-        return self.layers["main"].image.autorange_mode
+        return self.layer_manager["main"].image.autorange_mode
 
     @autorange_mode.setter
     def autorange_mode(self, mode: str):
@@ -896,7 +930,7 @@ class ImageBase(PlotBase):
         # for qt Designer
         if mode not in ["max", "mean"]:
             return
-        for layer in self.layers:
+        for layer in self.layer_manager:
             if not layer.sync.autorange_mode:
                 continue
             layer.image.autorange_mode = mode
@@ -912,10 +946,10 @@ class ImageBase(PlotBase):
             enabled(bool): Whether to enable autorange.
             mode(str): The autorange mode. Options are "max" or "mean".
         """
-        if not self.layers:
+        if not self.layer_manager:
             return
 
-        for layer in self.layers:
+        for layer in self.layer_manager:
             if layer.sync.autorange:
                 layer.image.autorange = enabled
             if layer.sync.autorange_mode:
@@ -935,9 +969,9 @@ class ImageBase(PlotBase):
         """
         self.autorange_switch.block_all_signals(True)
         self.autorange_switch.set_default_action(
-            f"auto_range_{self.layers['main'].image.autorange_mode}"
+            f"auto_range_{self.layer_manager['main'].image.autorange_mode}"
         )
-        self.autorange_switch.set_state_all(self.layers["main"].image.autorange)
+        self.autorange_switch.set_state_all(self.layer_manager["main"].image.autorange)
         self.autorange_switch.block_all_signals(False)
 
     def _sync_colorbar_levels(self):
@@ -947,7 +981,7 @@ class ImageBase(PlotBase):
             return
 
         total_vrange = (0, 0)
-        for layer in self.layers:
+        for layer in self.layer_manager:
             if not layer.sync.v_range:
                 continue
             img = layer.image
@@ -1015,7 +1049,7 @@ class ImageBase(PlotBase):
         if self.y_roi is not None:
             self.y_roi.cleanup_pyqtgraph()
 
-        self.layers.clear()
-        self.layers = None
+        self.layer_manager.clear()
+        self.layer_manager = None
 
         super().cleanup()

--- a/bec_widgets/widgets/plots/image/image_item.py
+++ b/bec_widgets/widgets/plots/image/image_item.py
@@ -43,6 +43,7 @@ class ImageItemConfig(ConnectionConfig):  # TODO review config
 
 
 class ImageItem(BECConnector, pg.ImageItem):
+
     RPC = True
     USER_ACCESS = [
         "color_map",
@@ -69,6 +70,7 @@ class ImageItem(BECConnector, pg.ImageItem):
     ]
 
     vRangeChangedManually = Signal(tuple)
+    removed = Signal()
 
     def __init__(
         self,
@@ -274,6 +276,8 @@ class ImageItem(BECConnector, pg.ImageItem):
         self.buffer = []
         self.max_len = 0
 
-    def remove(self):
+    def remove(self, emit: bool = True):
         self.clear()
         super().remove()
+        if emit:
+            self.removed.emit()

--- a/bec_widgets/widgets/plots/image/image_item.py
+++ b/bec_widgets/widgets/plots/image/image_item.py
@@ -74,7 +74,7 @@ class ImageItem(BECConnector, pg.ImageItem):
         self,
         config: Optional[ImageItemConfig] = None,
         gui_id: Optional[str] = None,
-        parent_image=None,
+        parent_image=None,  # FIXME: rename to parent
         **kwargs,
     ):
         if config is None:
@@ -269,6 +269,7 @@ class ImageItem(BECConnector, pg.ImageItem):
         return self.image
 
     def clear(self):
+        self.rpc_register.remove_rpc(self)
         super().clear()
         self.raw_data = None
         self.buffer = []

--- a/bec_widgets/widgets/plots/image/image_item.py
+++ b/bec_widgets/widgets/plots/image/image_item.py
@@ -67,7 +67,7 @@ class ImageItem(BECConnector, pg.ImageItem):
     ]
 
     vRangeChangedManually = Signal(tuple)
-    removed = Signal()
+    removed = Signal(str)
 
     def __init__(
         self,
@@ -277,4 +277,4 @@ class ImageItem(BECConnector, pg.ImageItem):
         self.clear()
         super().remove()
         if emit:
-            self.removed.emit()
+            self.removed.emit(self.objectName())

--- a/bec_widgets/widgets/plots/image/image_item.py
+++ b/bec_widgets/widgets/plots/image/image_item.py
@@ -269,7 +269,6 @@ class ImageItem(BECConnector, pg.ImageItem):
         return self.image
 
     def clear(self):
-        self.rpc_register.remove_rpc(self)
         super().clear()
         self.raw_data = None
         self.buffer = []
@@ -278,3 +277,4 @@ class ImageItem(BECConnector, pg.ImageItem):
     def remove(self):
         self.parent().disconnect_monitor(self.config.monitor)
         self.clear()
+        super().remove()

--- a/bec_widgets/widgets/plots/image/image_item.py
+++ b/bec_widgets/widgets/plots/image/image_item.py
@@ -21,9 +21,6 @@ logger = bec_logger.logger
 # noinspection PyDataclass
 class ImageItemConfig(ConnectionConfig):  # TODO review config
     parent_id: str | None = Field(None, description="The parent plot of the image.")
-    monitor: str | None = Field(None, description="The name of the monitor.")
-    monitor_type: Literal["1d", "2d", "auto"] = Field("auto", description="The type of monitor.")
-    source: str | None = Field(None, description="The source of the curve.")
     color_map: str | None = Field("plasma", description="The color map of the image.")
     downsample: bool | None = Field(True, description="Whether to downsample the image.")
     opacity: float | None = Field(1.0, description="The opacity of the image.")

--- a/bec_widgets/widgets/plots/image/image_item.py
+++ b/bec_widgets/widgets/plots/image/image_item.py
@@ -275,6 +275,5 @@ class ImageItem(BECConnector, pg.ImageItem):
         self.max_len = 0
 
     def remove(self):
-        self.parent().disconnect_monitor(self.config.monitor)
         self.clear()
         super().remove()

--- a/tests/end-2-end/test_rpc_widgets_e2e.py
+++ b/tests/end-2-end/test_rpc_widgets_e2e.py
@@ -145,7 +145,14 @@ def test_available_widgets(qtbot, connected_client_gui_obj):
 
         # Check that the number of top level widgets is still the same. As the cleanup is done by the
         # qt event loop, we need to wait for the qtbot to finish the cleanup
-        qtbot.waitUntil(lambda: len(gui._server_registry) == top_level_widgets_count)
+        try:
+            qtbot.waitUntil(lambda: len(gui._server_registry) == top_level_widgets_count)
+        except Exception as exc:
+            raise RuntimeError(
+                f"Widget {object_name} was not removed properly. The number of top level widgets "
+                f"is {len(gui._server_registry)} instead of {top_level_widgets_count}. The following "
+                f"widgets are still registered: {list(gui._server_registry.keys())}."
+            ) from exc
         # Number of widgets with parent_id == None, should be 2
         widgets = [
             widget

--- a/tests/unit_tests/test_image_layer.py
+++ b/tests/unit_tests/test_image_layer.py
@@ -1,0 +1,84 @@
+from unittest import mock
+
+import pyqtgraph as pg
+import pytest
+
+from bec_widgets.widgets.plots.image.image_base import ImageLayerManager
+from bec_widgets.widgets.plots.image.image_item import ImageItem
+
+
+@pytest.fixture()
+def image_layer_manager():
+    """Fixture to create an instance of ImageLayer."""
+    layer = ImageLayerManager(plot_item=mock.MagicMock(spec=pg.PlotItem))
+    yield layer
+    layer.clear()
+
+
+def test_image_layer_manager_initialization(image_layer_manager):
+    """Test the initialization of the ImageLayer."""
+    assert isinstance(image_layer_manager, ImageLayerManager)
+    assert image_layer_manager.plot_item is not None
+
+
+def test_add_image_layer(image_layer_manager):
+    """Test adding an image layer to the ImageLayerManager."""
+    image = ImageItem()
+    layer = image_layer_manager.add(name="Test Layer", image=image)
+    assert layer.image.zValue() == 0
+
+    image2 = ImageItem()
+    layer2 = image_layer_manager.add(name="Test Layer 2", image=image2)
+    assert layer2.image.zValue() == 1
+
+    image3 = ImageItem()
+    layer3 = image_layer_manager.add(name="Test Layer 3", image=image3, z_position="top")
+    assert layer3.image.zValue() == 2
+
+    image4 = ImageItem()
+    layer4 = image_layer_manager.add(name="Test Layer 4", image=image4, z_position="bottom")
+    assert layer4.image.zValue() == -1
+
+
+def test_remove_image_layer(image_layer_manager):
+    """Test removing an image layer from the ImageLayerManager."""
+    image = ImageItem()
+    layer = image_layer_manager.add(name="Test Layer", image=image)
+    assert len(image_layer_manager) == 1
+
+    image_layer_manager.remove(layer)
+    assert len(image_layer_manager) == 0
+
+
+def test_clear_image_layers(image_layer_manager):
+    """Test clearing all image layers from the ImageLayerManager."""
+    image = ImageItem()
+    layer = image_layer_manager.add(name="Test Layer", image=image)
+    assert len(image_layer_manager) == 1
+
+    image_layer_manager.clear()
+    assert len(image_layer_manager) == 0
+
+
+def test_image_layer_manager_getitem(image_layer_manager):
+    """Test getting an image layer by index."""
+    image = ImageItem()
+    layer = image_layer_manager.add(name="Test Layer", image=image)
+    assert image_layer_manager["Test Layer"] == layer
+
+    with pytest.raises(TypeError):
+        _ = image_layer_manager[1]
+
+    image_layer_manager.remove("Test Layer")
+    assert len(image_layer_manager) == 0
+
+
+def test_image_layer_iteration(image_layer_manager):
+    """Test iterating over image layers."""
+    image = ImageItem()
+    layer = image_layer_manager.add(name="Test Layer", image=image)
+    assert list(image_layer_manager) == [layer]
+
+    image2 = ImageItem()
+    layer2 = image_layer_manager.add(name="Test Layer 2", image=image2)
+    assert list(image_layer_manager) == [layer, layer2]

--- a/tests/unit_tests/test_image_layer.py
+++ b/tests/unit_tests/test_image_layer.py
@@ -10,7 +10,7 @@ from bec_widgets.widgets.plots.image.image_item import ImageItem
 @pytest.fixture()
 def image_layer_manager():
     """Fixture to create an instance of ImageLayer."""
-    layer = ImageLayerManager(plot_item=mock.MagicMock(spec=pg.PlotItem))
+    layer = ImageLayerManager(parent=None, plot_item=mock.MagicMock(spec=pg.PlotItem))
     yield layer
     layer.clear()
 
@@ -23,27 +23,22 @@ def test_image_layer_manager_initialization(image_layer_manager):
 
 def test_add_image_layer(image_layer_manager):
     """Test adding an image layer to the ImageLayerManager."""
-    image = ImageItem()
-    layer = image_layer_manager.add(name="Test Layer", image=image)
+    layer = image_layer_manager.add(name="Test Layer")
     assert layer.image.zValue() == 0
 
-    image2 = ImageItem()
-    layer2 = image_layer_manager.add(name="Test Layer 2", image=image2)
+    layer2 = image_layer_manager.add(name="Test Layer 2")
     assert layer2.image.zValue() == 1
 
-    image3 = ImageItem()
-    layer3 = image_layer_manager.add(name="Test Layer 3", image=image3, z_position="top")
+    layer3 = image_layer_manager.add(name="Test Layer 3", z_position="top")
     assert layer3.image.zValue() == 2
 
-    image4 = ImageItem()
-    layer4 = image_layer_manager.add(name="Test Layer 4", image=image4, z_position="bottom")
+    layer4 = image_layer_manager.add(name="Test Layer 4", z_position="bottom")
     assert layer4.image.zValue() == -1
 
 
 def test_remove_image_layer(image_layer_manager):
     """Test removing an image layer from the ImageLayerManager."""
-    image = ImageItem()
-    layer = image_layer_manager.add(name="Test Layer", image=image)
+    layer = image_layer_manager.add(name="Test Layer")
     assert len(image_layer_manager) == 1
 
     image_layer_manager.remove(layer)
@@ -52,8 +47,7 @@ def test_remove_image_layer(image_layer_manager):
 
 def test_clear_image_layers(image_layer_manager):
     """Test clearing all image layers from the ImageLayerManager."""
-    image = ImageItem()
-    layer = image_layer_manager.add(name="Test Layer", image=image)
+    layer = image_layer_manager.add(name="Test Layer")
     assert len(image_layer_manager) == 1
 
     image_layer_manager.clear()
@@ -62,8 +56,7 @@ def test_clear_image_layers(image_layer_manager):
 
 def test_image_layer_manager_getitem(image_layer_manager):
     """Test getting an image layer by index."""
-    image = ImageItem()
-    layer = image_layer_manager.add(name="Test Layer", image=image)
+    layer = image_layer_manager.add(name="Test Layer")
     assert image_layer_manager["Test Layer"] == layer
 
     with pytest.raises(TypeError):
@@ -75,10 +68,8 @@ def test_image_layer_manager_getitem(image_layer_manager):
 
 def test_image_layer_iteration(image_layer_manager):
     """Test iterating over image layers."""
-    image = ImageItem()
-    layer = image_layer_manager.add(name="Test Layer", image=image)
+    layer = image_layer_manager.add(name="Test Layer")
     assert list(image_layer_manager) == [layer]
 
-    image2 = ImageItem()
-    layer2 = image_layer_manager.add(name="Test Layer 2", image=image2)
+    layer2 = image_layer_manager.add(name="Test Layer 2")
     assert list(image_layer_manager) == [layer, layer2]

--- a/tests/unit_tests/test_image_layer.py
+++ b/tests/unit_tests/test_image_layer.py
@@ -73,3 +73,8 @@ def test_image_layer_iteration(image_layer_manager):
 
     layer2 = image_layer_manager.add(name="Test Layer 2")
     assert list(image_layer_manager) == [layer, layer2]
+
+    layer3 = image_layer_manager.add()
+    assert list(image_layer_manager) == [layer, layer2, layer3]
+    names = list(image_layer_manager.layers.keys())
+    assert names == ["Test Layer", "Test Layer 2", "image_layer_0"]

--- a/tests/unit_tests/test_image_view_next_gen.py
+++ b/tests/unit_tests/test_image_view_next_gen.py
@@ -117,8 +117,8 @@ def test_image_setup_image_2d(qtbot, mocked_client):
     bec_image_view = create_widget(qtbot, Image, client=mocked_client)
     bec_image_view.image(monitor="eiger", monitor_type="2d")
     assert bec_image_view.monitor == "eiger"
-    assert bec_image_view.main_image.config.source == "device_monitor_2d"
-    assert bec_image_view.main_image.config.monitor_type == "2d"
+    assert bec_image_view.subscriptions["main"].source == "device_monitor_2d"
+    assert bec_image_view.subscriptions["main"].monitor_type == "2d"
     assert bec_image_view.main_image.raw_data is None
     assert bec_image_view.main_image.image is None
 
@@ -127,8 +127,8 @@ def test_image_setup_image_1d(qtbot, mocked_client):
     bec_image_view = create_widget(qtbot, Image, client=mocked_client)
     bec_image_view.image(monitor="eiger", monitor_type="1d")
     assert bec_image_view.monitor == "eiger"
-    assert bec_image_view.main_image.config.source == "device_monitor_1d"
-    assert bec_image_view.main_image.config.monitor_type == "1d"
+    assert bec_image_view.subscriptions["main"].source == "device_monitor_1d"
+    assert bec_image_view.subscriptions["main"].monitor_type == "1d"
     assert bec_image_view.main_image.raw_data is None
     assert bec_image_view.main_image.image is None
 
@@ -137,8 +137,8 @@ def test_image_setup_image_auto(qtbot, mocked_client):
     bec_image_view = create_widget(qtbot, Image, client=mocked_client)
     bec_image_view.image(monitor="eiger", monitor_type="auto")
     assert bec_image_view.monitor == "eiger"
-    assert bec_image_view.main_image.config.source == "auto"
-    assert bec_image_view.main_image.config.monitor_type == "auto"
+    assert bec_image_view.subscriptions["main"].source == "auto"
+    assert bec_image_view.subscriptions["main"].monitor_type == "auto"
     assert bec_image_view.main_image.raw_data is None
     assert bec_image_view.main_image.image is None
 
@@ -235,8 +235,8 @@ def test_setup_image_from_toolbar(qtbot, mocked_client):
     bec_image_view.selection_bundle.dim_combo_box.setCurrentText("2d")
 
     assert bec_image_view.monitor == "eiger"
-    assert bec_image_view.main_image.config.source == "device_monitor_2d"
-    assert bec_image_view.main_image.config.monitor_type == "2d"
+    assert bec_image_view.subscriptions["main"].source == "device_monitor_2d"
+    assert bec_image_view.subscriptions["main"].monitor_type == "2d"
     assert bec_image_view.main_image.raw_data is None
     assert bec_image_view.main_image.image is None
 

--- a/tests/unit_tests/test_image_view_next_gen.py
+++ b/tests/unit_tests/test_image_view_next_gen.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pyqtgraph as pg
 import pytest
+from qtpy.QtCore import QPointF
 
 from bec_widgets.widgets.plots.image.image import Image
 from tests.unit_tests.client_mocks import mocked_client
@@ -61,8 +62,8 @@ def test_lock_aspect_ratio(qtbot, mocked_client):
 
 def test_set_vrange(qtbot, mocked_client):
     bec_image_view = create_widget(qtbot, Image, client=mocked_client)
-    bec_image_view.vrange = (10, 100)
-    assert bec_image_view.vrange == (10, 100)
+    bec_image_view.v_range = (10, 100)
+    assert bec_image_view.v_range == QPointF(10, 100)
     assert bec_image_view.main_image.levels == (10, 100)
     assert bec_image_view.main_image.config.v_range == (10, 100)
 
@@ -107,7 +108,7 @@ def test_enable_colorbar_with_vrange(qtbot, mocked_client, colorbar_type):
         assert isinstance(bec_image_view._color_bar, pg.HistogramLUTItem)
         assert bec_image_view.enable_full_colorbar is True
     assert bec_image_view.config.color_bar == colorbar_type
-    assert bec_image_view.vrange == (0, 100)
+    assert bec_image_view.v_range == QPointF(0, 100)
     assert bec_image_view.main_image.levels == (0, 100)
     assert bec_image_view._color_bar is not None
 
@@ -150,7 +151,7 @@ def test_image_data_update_2d(qtbot, mocked_client):
 
     bec_image_view.on_image_update_2d(message, metadata)
 
-    np.testing.assert_array_equal(bec_image_view._main_image.image, test_data)
+    np.testing.assert_array_equal(bec_image_view.main_image.image, test_data)
 
 
 def test_image_data_update_1d(qtbot, mocked_client):
@@ -160,10 +161,10 @@ def test_image_data_update_1d(qtbot, mocked_client):
     metadata = {"scan_id": "scan_test"}
 
     bec_image_view.on_image_update_1d({"data": waveform1}, metadata)
-    assert bec_image_view._main_image.raw_data.shape == (1, 50)
+    assert bec_image_view.main_image.raw_data.shape == (1, 50)
 
     bec_image_view.on_image_update_1d({"data": waveform2}, metadata)
-    assert bec_image_view._main_image.raw_data.shape == (2, 60)
+    assert bec_image_view.main_image.raw_data.shape == (2, 60)
 
 
 def test_toolbar_actions_presence(qtbot, mocked_client):
@@ -207,8 +208,8 @@ def test_setting_vrange_with_colorbar(qtbot, mocked_client, colorbar_type):
     elif colorbar_type == "full":
         bec_image_view.enable_full_colorbar = True
 
-    bec_image_view.vrange = (0, 100)
-    assert bec_image_view.vrange == (0, 100)
+    bec_image_view.v_range = (0, 100)
+    assert bec_image_view.v_range == QPointF(0, 100)
     assert bec_image_view.main_image.levels == (0, 100)
     assert bec_image_view.main_image.config.v_range == (0, 100)
     assert bec_image_view.v_min == 0


### PR DESCRIPTION
This pull request introduces several changes to improve code clarity, functionality, and testing in the `bec_widgets` package. The most notable updates include the introduction of a new ImageBase class and the renaming the `vrange` property to `v_range` for consistency.

### Code Refactoring and Naming Updates:
* Moved (likely) shared components into ImageBase class to simplify the development of new image-based widgets, such as the heatmap widget. 
* Renamed the `vrange` property to `v_range` in `bec_widgets/cli/client.py` to improve naming consistency and clarity. Updated both getter and setter methods accordingly. `([bec_widgets/cli/client.pyL1182-R1191](diffhunk://#diff-761d0ac7b2d27daa2c0b873e961ec530e220c7e558c44b9a4c891890d6abcae7L1182-R1191))`
* Added a `FIXME` comment to consider renaming the `parent_image` parameter to `parent` in the `ImageItem` class for better readability. (`[bec_widgets/widgets/plots/image/image_item.pyL77-R77](diffhunk://#diff-34b5442fe1bb7b5a9059130516c03b6b458d1743ea0b896ec2b7577359ff2657L77-R77)`)

### Functional Enhancements:
* Modified the `clear` method in `ImageItem` to unregister the object from `rpc_register`, ensuring proper cleanup. (`[bec_widgets/widgets/plots/image/image_item.pyR272](diffhunk://#diff-34b5442fe1bb7b5a9059130516c03b6b458d1743ea0b896ec2b7577359ff2657R272)`)

### Testing Improvements:
* Added comprehensive unit tests for the `ImageLayerManager` class in `tests/unit_tests/test_image_layer.py`, covering initialization, adding/removing layers, clearing layers, and iteration. (`[tests/unit_tests/test_image_layer.pyR1-R84](diffhunk://#diff-c8c6c8c9fe6671be6c79dcec8d6b67af8392d6a188fdac0a931ac66b0e9b5629R1-R84)`)
* Updated existing test cases in `tests/unit_tests/test_image_view_next_gen.py` to use the renamed `v_range` property and ensure compatibility with the new naming convention. (`[[1]](diffhunk://#diff-5f14329b717a2bd5fc997758f90e602888b4714298382cf8ce2c2b1e45ae7500L64-R66)`, `[[2]](diffhunk://#diff-5f14329b717a2bd5fc997758f90e602888b4714298382cf8ce2c2b1e45ae7500L110-R111)`, `[[3]](diffhunk://#diff-5f14329b717a2bd5fc997758f90e602888b4714298382cf8ce2c2b1e45ae7500L210-R212)`)
* Replaced references to `_main_image` with `main_image` in test cases to align with updated attribute usage. (`[[1]](diffhunk://#diff-5f14329b717a2bd5fc997758f90e602888b4714298382cf8ce2c2b1e45ae7500L153-R154)`, `[[2]](diffhunk://#diff-5f14329b717a2bd5fc997758f90e602888b4714298382cf8ce2c2b1e45ae7500L163-R167)`)





closes #618 
