### PR TITLE
View device config in device browser

### DIFF
--- a/bec_widgets/cli/client.py
+++ b/bec_widgets/cli/client.py
@@ -50,7 +50,6 @@ _Widgets = {
     "ResumeButton": "ResumeButton",
     "RingProgressBar": "RingProgressBar",
     "ScanControl": "ScanControl",
-    "ScanMetadata": "ScanMetadata",
     "ScatterWaveform": "ScatterWaveform",
     "SignalComboBox": "SignalComboBox",
     "SignalLabel": "SignalLabel",
@@ -3059,22 +3058,6 @@ class ScanControl(RPCBase):
     def remove(self):
         """
         Cleanup the BECConnector
-        """
-
-
-class ScanMetadata(RPCBase):
-    @property
-    @rpc_call
-    def enabled(self):
-        """
-        None
-        """
-
-    @enabled.setter
-    @rpc_call
-    def enabled(self):
-        """
-        None
         """
 
 

--- a/bec_widgets/cli/client.py
+++ b/bec_widgets/cli/client.py
@@ -50,6 +50,7 @@ _Widgets = {
     "ResumeButton": "ResumeButton",
     "RingProgressBar": "RingProgressBar",
     "ScanControl": "ScanControl",
+    "ScanMetadata": "ScanMetadata",
     "ScatterWaveform": "ScatterWaveform",
     "SignalComboBox": "SignalComboBox",
     "SignalLabel": "SignalLabel",
@@ -3058,6 +3059,22 @@ class ScanControl(RPCBase):
     def remove(self):
         """
         Cleanup the BECConnector
+        """
+
+
+class ScanMetadata(RPCBase):
+    @property
+    @rpc_call
+    def enabled(self):
+        """
+        None
+        """
+
+    @enabled.setter
+    @rpc_call
+    def enabled(self):
+        """
+        None
         """
 
 

--- a/bec_widgets/tests/utils.py
+++ b/bec_widgets/tests/utils.py
@@ -184,8 +184,8 @@ class FakePositioner(BECPositioner):
 class Positioner(FakePositioner):
     """just placeholder for testing embedded isinstance check in DeviceCombobox"""
 
-    def __init__(self, name="test", limits=None, read_value=1.0):
-        super().__init__(name, limits, read_value)
+    def __init__(self, name="test", limits=None, read_value=1.0, enabled=True):
+        super().__init__(name, limits=limits, read_value=read_value, enabled=enabled)
 
 
 class Device(FakeDevice):

--- a/bec_widgets/utils/clickable_label.py
+++ b/bec_widgets/utils/clickable_label.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from PySide6.QtGui import QMouseEvent
+from qtpy.QtCore import Signal
+from qtpy.QtWidgets import QLabel
+
+
+class ClickableLabel(QLabel):
+    clicked = Signal()
+
+    def mouseReleaseEvent(self, ev: QMouseEvent) -> None:
+        self.clicked.emit()
+        return super().mouseReleaseEvent(ev)

--- a/bec_widgets/utils/clickable_label.py
+++ b/bec_widgets/utils/clickable_label.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from PySide6.QtGui import QMouseEvent
 from qtpy.QtCore import Signal
+from qtpy.QtGui import QMouseEvent
 from qtpy.QtWidgets import QLabel
 
 

--- a/bec_widgets/utils/colors.py
+++ b/bec_widgets/utils/colors.py
@@ -15,12 +15,15 @@ if TYPE_CHECKING:  # pragma: no cover
     from bec_qthemes._main import AccentColors
 
 
-def get_theme_palette():
+def get_theme_name():
     if QApplication.instance() is None or not hasattr(QApplication.instance(), "theme"):
-        theme = "dark"
+        return "dark"
     else:
-        theme = QApplication.instance().theme.theme
-    return bec_qthemes.load_palette(theme)
+        return QApplication.instance().theme.theme
+
+
+def get_theme_palette():
+    return bec_qthemes.load_palette(get_theme_name())
 
 
 def get_accent_colors() -> AccentColors | None:

--- a/bec_widgets/utils/expandable_frame.py
+++ b/bec_widgets/utils/expandable_frame.py
@@ -14,6 +14,7 @@ from qtpy.QtWidgets import (
     QWidget,
 )
 
+from bec_widgets.utils.clickable_label import ClickableLabel
 from bec_widgets.utils.error_popups import SafeProperty, SafeSlot
 
 
@@ -39,8 +40,8 @@ class ExpandableGroupFrame(QFrame):
         self._title_layout = QHBoxLayout()
         self._layout.addLayout(self._title_layout)
 
-        self._title = QLabel(f"<b>{title}</b>")
-        self._title_icon = QLabel()
+        self._title = ClickableLabel(f"<b>{title}</b>")
+        self._title_icon = ClickableLabel()
         self._title_layout.addWidget(self._title_icon)
         self._title_layout.addWidget(self._title)
         self.icon_name = icon

--- a/bec_widgets/utils/expandable_frame.py
+++ b/bec_widgets/utils/expandable_frame.py
@@ -20,7 +20,9 @@ class ExpandableGroupFrame(QFrame):
     EXPANDED_ICON_NAME: str = "collapse_all"
     COLLAPSED_ICON_NAME: str = "expand_all"
 
-    def __init__(self, title: str, parent: QWidget | None = None, expanded: bool = True) -> None:
+    def __init__(
+        self, title: str, parent: QWidget | None = None, expanded: bool = True, icon: str = ""
+    ) -> None:
         super().__init__(parent=parent)
         self._expanded = expanded
 
@@ -29,13 +31,21 @@ class ExpandableGroupFrame(QFrame):
         self._layout = QVBoxLayout()
         self._layout.setContentsMargins(0, 0, 0, 0)
         self.setLayout(self._layout)
+
         self._title_layout = QHBoxLayout()
         self._layout.addLayout(self._title_layout)
-        self._expansion_button = QToolButton()
-        self._update_icon()
+
         self._title = QLabel(f"<b>{title}</b>")
-        self._title_layout.addWidget(self._expansion_button)
+        self._title_icon = QLabel()
+        self._title_layout.addWidget(self._title_icon)
         self._title_layout.addWidget(self._title)
+        self.icon_name = icon
+
+        self._title_layout.addStretch(1)
+
+        self._expansion_button = QToolButton()
+        self._update_expansion_icon()
+        self._title_layout.addWidget(self._expansion_button, stretch=1)
 
         self._contents = QWidget(self)
         self._layout.addWidget(self._contents)
@@ -50,7 +60,7 @@ class ExpandableGroupFrame(QFrame):
     @SafeSlot()
     def switch_expanded_state(self):
         self.expanded = not self.expanded  # type: ignore
-        self._update_icon()
+        self._update_expansion_icon()
 
     @SafeProperty(bool)
     def expanded(self):  # type: ignore
@@ -62,7 +72,7 @@ class ExpandableGroupFrame(QFrame):
         self._contents.setVisible(expanded)
         self.updateGeometry()
 
-    def _update_icon(self):
+    def _update_expansion_icon(self):
         self._expansion_button.setIcon(
             material_icon(icon_name=self.EXPANDED_ICON_NAME, size=(10, 10), convert_to_pixmap=False)
             if self.expanded
@@ -70,3 +80,21 @@ class ExpandableGroupFrame(QFrame):
                 icon_name=self.COLLAPSED_ICON_NAME, size=(10, 10), convert_to_pixmap=False
             )
         )
+
+    @SafeProperty(str)
+    def icon_name(self):  # type: ignore
+        return self._title_icon_name
+
+    @icon_name.setter
+    def icon_name(self, icon_name: str):
+        self._title_icon_name = icon_name
+        self._set_title_icon(self._title_icon_name)
+
+    def _set_title_icon(self, icon_name: str):
+        if icon_name:
+            self._title_icon.setVisible(True)
+            self._title_icon.setPixmap(
+                material_icon(icon_name=icon_name, size=(20, 20), convert_to_pixmap=True)
+            )
+        else:
+            self._title_icon.setVisible(False)

--- a/bec_widgets/utils/expandable_frame.py
+++ b/bec_widgets/utils/expandable_frame.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 from bec_qthemes import material_icon
+from qtpy.QtCore import Signal
 from qtpy.QtWidgets import (
+    QApplication,
     QFrame,
     QHBoxLayout,
     QLabel,
@@ -17,11 +19,13 @@ from bec_widgets.utils.error_popups import SafeProperty, SafeSlot
 
 class ExpandableGroupFrame(QFrame):
 
+    expansion_state_changed = Signal()
+
     EXPANDED_ICON_NAME: str = "collapse_all"
     COLLAPSED_ICON_NAME: str = "expand_all"
 
     def __init__(
-        self, title: str, parent: QWidget | None = None, expanded: bool = True, icon: str = ""
+        self, parent: QWidget | None = None, title: str = "", expanded: bool = True, icon: str = ""
     ) -> None:
         super().__init__(parent=parent)
         self._expanded = expanded
@@ -52,6 +56,7 @@ class ExpandableGroupFrame(QFrame):
 
         self._expansion_button.clicked.connect(self.switch_expanded_state)
         self.expanded = self._expanded  # type: ignore
+        self.expansion_state_changed.emit()
 
     def set_layout(self, layout: QLayout) -> None:
         self._contents.setLayout(layout)
@@ -61,6 +66,7 @@ class ExpandableGroupFrame(QFrame):
     def switch_expanded_state(self):
         self.expanded = not self.expanded  # type: ignore
         self._update_expansion_icon()
+        self.expansion_state_changed.emit()
 
     @SafeProperty(bool)
     def expanded(self):  # type: ignore
@@ -71,6 +77,7 @@ class ExpandableGroupFrame(QFrame):
         self._expanded = expanded
         self._contents.setVisible(expanded)
         self.updateGeometry()
+        self.adjustSize()
 
     def _update_expansion_icon(self):
         self._expansion_button.setIcon(
@@ -98,3 +105,18 @@ class ExpandableGroupFrame(QFrame):
             )
         else:
             self._title_icon.setVisible(False)
+
+
+# Application example
+if __name__ == "__main__":  # pragma: no cover
+
+    app = QApplication([])
+    frame = ExpandableGroupFrame()
+    layout = QVBoxLayout()
+    frame.set_layout(layout)
+    layout.addWidget(QLabel("test1"))
+    layout.addWidget(QLabel("test2"))
+    layout.addWidget(QLabel("test3"))
+
+    frame.show()
+    app.exec()

--- a/bec_widgets/utils/forms_from_types/forms.py
+++ b/bec_widgets/utils/forms_from_types/forms.py
@@ -8,7 +8,7 @@ from bec_lib.logger import bec_logger
 from bec_qthemes import material_icon
 from pydantic import BaseModel, ValidationError
 from qtpy.QtCore import Signal  # type: ignore
-from qtpy.QtWidgets import QGridLayout, QLabel, QLayout, QVBoxLayout, QWidget
+from qtpy.QtWidgets import QGridLayout, QLabel, QLayout, QSizePolicy, QVBoxLayout, QWidget
 
 from bec_widgets.utils.bec_widget import BECWidget
 from bec_widgets.utils.compact_popup import CompactPopupWidget
@@ -59,10 +59,14 @@ class TypedForm(BECWidget, QWidget):
             enabled (bool, optional):               whether fields are enabled for editing.
             pretty_display (bool, optional): Whether to use a pretty display for the widget. Defaults to False. If True, disables the widget, doesn't add a clear button, and adapts the stylesheet for non-editable display.
         """
-        if (items is not None and form_item_specs is not None) or (
-            items is None and form_item_specs is None
-        ):
-            raise ValueError("Must specify one and only one of items and form_item_specs")
+        if items is not None and form_item_specs is not None:
+            logger.error(
+                "Must specify one and only one of items and form_item_specs! Ignoring `items`."
+            )
+            items = None
+        if items is None and form_item_specs is None:
+            logger.error("Must specify one and only one of items and form_item_specs!")
+            items = []
         super().__init__(parent=parent, client=client, **kwargs)
         self._items = (
             form_item_specs
@@ -72,6 +76,7 @@ class TypedForm(BECWidget, QWidget):
                 for name, item_type in items  # type: ignore
             ]
         )
+        self.setSizePolicy(QSizePolicy.MinimumExpanding, QSizePolicy.MinimumExpanding)
         self._layout = QVBoxLayout()
         self._layout.setContentsMargins(0, 0, 0, 0)
         self.setLayout(self._layout)
@@ -79,7 +84,11 @@ class TypedForm(BECWidget, QWidget):
         self._enabled: bool = enabled
 
         self._form_grid_container = QWidget(parent=self)
+        self._form_grid_container.setSizePolicy(
+            QSizePolicy.MinimumExpanding, QSizePolicy.MinimumExpanding
+        )
         self._form_grid = QWidget(parent=self._form_grid_container)
+        self._form_grid.setSizePolicy(QSizePolicy.MinimumExpanding, QSizePolicy.MinimumExpanding)
         self._layout.addWidget(self._form_grid_container)
         self._form_grid_container.setLayout(QVBoxLayout())
         self._form_grid.setLayout(self._new_grid_layout())
@@ -100,6 +109,7 @@ class TypedForm(BECWidget, QWidget):
         grid.addWidget(label, row, 0)
         widget = widget_from_type(item.item_type)(parent=self, spec=item)
         widget.valueChanged.connect(self.value_changed)
+        widget.setSizePolicy(QSizePolicy.MinimumExpanding, QSizePolicy.MinimumExpanding)
         grid.addWidget(widget, row, 1)
 
     def enumerate_form_widgets(self):
@@ -125,7 +135,7 @@ class TypedForm(BECWidget, QWidget):
             old_layout.deleteLater()
             self._form_grid.deleteLater()
         self._form_grid = QWidget()
-
+        self._form_grid.setSizePolicy(QSizePolicy.MinimumExpanding, QSizePolicy.MinimumExpanding)
         self._form_grid.setLayout(self._new_grid_layout())
         self._form_grid_container.layout().addWidget(self._form_grid)
 
@@ -139,7 +149,6 @@ class TypedForm(BECWidget, QWidget):
     def _new_grid_layout(self):
         new_grid = QGridLayout()
         new_grid.setContentsMargins(0, 0, 0, 0)
-        new_grid.setSizeConstraint(QLayout.SizeConstraint.SetFixedSize)
         return new_grid
 
     @property

--- a/bec_widgets/utils/forms_from_types/forms.py
+++ b/bec_widgets/utils/forms_from_types/forms.py
@@ -44,6 +44,7 @@ class TypedForm(BECWidget, QWidget):
         items: list[tuple[str, type]] | None = None,
         form_item_specs: list[FormItemSpec] | None = None,
         enabled: bool = True,
+        pretty_display: bool = False,
         client=None,
         **kwargs,
     ):
@@ -55,7 +56,8 @@ class TypedForm(BECWidget, QWidget):
             form_item_specs (list[FormItemSpec]):   list of form item specs, equivalent to items.
                                                     only one of items or form_item_specs should be
                                                     supplied.
-            enabled (bool):                         whether fields are enabled for editing.
+            enabled (bool, optional):               whether fields are enabled for editing.
+            pretty_display (bool, optional): Whether to use a pretty display for the widget. Defaults to False. If True, disables the widget, doesn't add a clear button, and adapts the stylesheet for non-editable display.
         """
         if (items is not None and form_item_specs is not None) or (
             items is None and form_item_specs is None
@@ -66,7 +68,7 @@ class TypedForm(BECWidget, QWidget):
             form_item_specs
             if form_item_specs is not None
             else [
-                FormItemSpec(name=name, item_type=item_type)
+                FormItemSpec(name=name, item_type=item_type, pretty_display=pretty_display)
                 for name, item_type in items  # type: ignore
             ]
         )
@@ -83,6 +85,7 @@ class TypedForm(BECWidget, QWidget):
         self._form_grid.setLayout(self._new_grid_layout())
 
         self.populate()
+        self.enabled = self._enabled  # type: ignore # QProperty
 
     def populate(self):
         self._clear_grid()
@@ -139,10 +142,6 @@ class TypedForm(BECWidget, QWidget):
         new_grid.setSizeConstraint(QLayout.SizeConstraint.SetFixedSize)
         return new_grid
 
-    def _set_widgets_enabled(self, enabled: bool):
-        for row in self.enumerate_form_widgets():
-            row.widget.setEnabled(enabled)
-
     @property
     def widget_dict(self):
         return {
@@ -157,7 +156,7 @@ class TypedForm(BECWidget, QWidget):
     @enabled.setter
     def enabled(self, value: bool):
         self._enabled = value
-        self._set_widgets_enabled(value)
+        self.setEnabled(value)
 
 
 class PydanticModelForm(TypedForm):
@@ -169,6 +168,7 @@ class PydanticModelForm(TypedForm):
         parent=None,
         data_model: type[BaseModel] | None = None,
         enabled: bool = True,
+        pretty_display: bool = False,
         client=None,
         **kwargs,
     ):
@@ -178,7 +178,10 @@ class PydanticModelForm(TypedForm):
         Args:
             data_model (type[BaseModel]): the model class for which to generate a form.
             enabled (bool): whether fields are enabled for editing.
+            pretty_display (bool, optional): Whether to use a pretty display for the widget. Defaults to False. If True, disables the widget, doesn't add a clear button, and adapts the stylesheet for non-editable display.
+
         """
+        self._pretty_display = pretty_display
         self._md_schema = data_model
         super().__init__(
             parent=parent, form_item_specs=self._form_item_specs(), enabled=enabled, client=client
@@ -214,7 +217,9 @@ class PydanticModelForm(TypedForm):
 
     def _form_item_specs(self):
         return [
-            FormItemSpec(name=name, info=info, item_type=info.annotation)
+            FormItemSpec(
+                name=name, info=info, item_type=info.annotation, pretty_display=self._pretty_display
+            )
             for name, info in self._md_schema.model_fields.items()
         ]
 

--- a/bec_widgets/utils/forms_from_types/forms.py
+++ b/bec_widgets/utils/forms_from_types/forms.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from decimal import Decimal
 from types import NoneType
+from typing import NamedTuple
 
 from bec_lib.logger import bec_logger
 from bec_qthemes import material_icon
@@ -11,9 +12,21 @@ from qtpy.QtWidgets import QGridLayout, QLabel, QLayout, QVBoxLayout, QWidget
 
 from bec_widgets.utils.bec_widget import BECWidget
 from bec_widgets.utils.compact_popup import CompactPopupWidget
-from bec_widgets.utils.forms_from_types.items import FormItemSpec, widget_from_type
+from bec_widgets.utils.error_popups import SafeProperty
+from bec_widgets.utils.forms_from_types.items import (
+    DynamicFormItem,
+    DynamicFormItemType,
+    FormItemSpec,
+    widget_from_type,
+)
 
 logger = bec_logger.logger
+
+
+class GridRow(NamedTuple):
+    i: int
+    label: QLabel
+    widget: DynamicFormItem
 
 
 class TypedForm(BECWidget, QWidget):
@@ -22,25 +35,27 @@ class TypedForm(BECWidget, QWidget):
 
     value_changed = Signal()
 
-    RPC = False
+    RPC = True
+    USER_ACCESS = ["enabled", "enabled.setter"]
 
     def __init__(
         self,
         parent=None,
         items: list[tuple[str, type]] | None = None,
         form_item_specs: list[FormItemSpec] | None = None,
+        enabled: bool = True,
         client=None,
         **kwargs,
     ):
         """Widget with a list of form items based on a list of types.
 
         Args:
-            items (list[tuple[str, type]]): list of tuples of a name for the field and its type.
-                                            Should be a type supported by the logic in items.py
-            form_item_specs (list[FormItemSpec]): list of form item specs, equivalent to items.
-                                                  only one of items or form_item_specs should be
-                                                  supplied.
-
+            items (list[tuple[str, type]]):         list of tuples of a name for the field and its type.
+                                                    Should be a type supported by the logic in items.py
+            form_item_specs (list[FormItemSpec]):   list of form item specs, equivalent to items.
+                                                    only one of items or form_item_specs should be
+                                                    supplied.
+            enabled (bool):                         whether fields are enabled for editing.
         """
         if (items is not None and form_item_specs is not None) or (
             items is None and form_item_specs is None
@@ -58,6 +73,8 @@ class TypedForm(BECWidget, QWidget):
         self._layout = QVBoxLayout()
         self._layout.setContentsMargins(0, 0, 0, 0)
         self.setLayout(self._layout)
+
+        self._enabled: bool = enabled
 
         self._form_grid_container = QWidget(parent=self)
         self._form_grid = QWidget(parent=self._form_grid_container)
@@ -82,15 +99,17 @@ class TypedForm(BECWidget, QWidget):
         widget.valueChanged.connect(self.value_changed)
         grid.addWidget(widget, row, 1)
 
-    def _dict_from_grid(self) -> dict[str, str | int | float | Decimal | bool]:
+    def enumerate_form_widgets(self):
+        """Return a generator over the rows of the form, with the row number, the label widget (to
+        which the field name is attached as a property), and the entry widget"""
         grid: QGridLayout = self._form_grid.layout()  # type: ignore
+        for i in range(grid.rowCount()):
+            yield GridRow(i, grid.itemAtPosition(i, 0).widget(), grid.itemAtPosition(i, 1).widget())
+
+    def _dict_from_grid(self) -> dict[str, DynamicFormItemType]:
         return {
-            grid.itemAtPosition(i, 0)
-            .widget()
-            .property("_model_field_name"): grid.itemAtPosition(i, 1)
-            .widget()
-            .getValue()  # type: ignore # we only add 'DynamicFormItem's here
-            for i in range(grid.rowCount())
+            row.label.property("_model_field_name"): row.widget.getValue()
+            for row in self.enumerate_form_widgets()
         }
 
     def _clear_grid(self):
@@ -107,6 +126,9 @@ class TypedForm(BECWidget, QWidget):
         self._form_grid.setLayout(self._new_grid_layout())
         self._form_grid_container.layout().addWidget(self._form_grid)
 
+        self.update_size()
+
+    def update_size(self):
         self._form_grid.adjustSize()
         self._form_grid_container.adjustSize()
         self.adjustSize()
@@ -117,20 +139,50 @@ class TypedForm(BECWidget, QWidget):
         new_grid.setSizeConstraint(QLayout.SizeConstraint.SetFixedSize)
         return new_grid
 
+    def _set_widgets_enabled(self, enabled: bool):
+        for row in self.enumerate_form_widgets():
+            row.widget.setEnabled(enabled)
+
+    @property
+    def widget_dict(self):
+        return {
+            row.label.property("_model_field_name"): row.widget
+            for row in self.enumerate_form_widgets()
+        }
+
+    @SafeProperty(bool)
+    def enabled(self):
+        return self._enabled
+
+    @enabled.setter
+    def enabled(self, value: bool):
+        self._enabled = value
+        self._set_widgets_enabled(value)
+
 
 class PydanticModelForm(TypedForm):
     metadata_updated = Signal(dict)
     metadata_cleared = Signal(NoneType)
 
-    def __init__(self, parent=None, metadata_model: type[BaseModel] = None, client=None, **kwargs):
+    def __init__(
+        self,
+        parent=None,
+        data_model: type[BaseModel] | None = None,
+        enabled: bool = True,
+        client=None,
+        **kwargs,
+    ):
         """
         A form generated from a pydantic model.
 
         Args:
-            metadata_model (type[BaseModel]): the model class for which to generate a form.
+            data_model (type[BaseModel]): the model class for which to generate a form.
+            enabled (bool): whether fields are enabled for editing.
         """
-        self._md_schema = metadata_model
-        super().__init__(parent=parent, form_item_specs=self._form_item_specs(), client=client)
+        self._md_schema = data_model
+        super().__init__(
+            parent=parent, form_item_specs=self._form_item_specs(), enabled=enabled, client=client
+        )
 
         self._validity = CompactPopupWidget()
         self._validity.compact_view = True  # type: ignore
@@ -146,6 +198,19 @@ class PydanticModelForm(TypedForm):
     def set_schema(self, schema: type[BaseModel]):
         self._md_schema = schema
         self.populate()
+
+    def set_data(self, data: BaseModel):
+        """Fill the data for the form.
+
+        Args:
+            data (BaseModel):   the data to enter into the form. Must be the same type as the
+                                currently set schema, raises TypeError otherwise."""
+        if not self._md_schema:
+            raise ValueError("Schema not set - can't set data")
+        if not isinstance(data, self._md_schema):
+            raise TypeError(f"Supplied data {data} not of type {self._md_schema}")
+        for form_item in self.enumerate_form_widgets():
+            form_item.widget.setValue(getattr(data, form_item.label.property("_model_field_name")))
 
     def _form_item_specs(self):
         return [

--- a/bec_widgets/utils/forms_from_types/items.py
+++ b/bec_widgets/utils/forms_from_types/items.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 from abc import abstractmethod
 from decimal import Decimal
-from types import UnionType
-from typing import Callable, Protocol
+from types import GenericAlias, UnionType
+from typing import Literal
 
 from bec_lib.logger import bec_logger
 from bec_qthemes import material_icon
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 from pydantic.fields import FieldInfo
 from qtpy.QtCore import Signal  # type: ignore
 from qtpy.QtWidgets import (
@@ -47,9 +47,36 @@ class FormItemSpec(BaseModel):
     """
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
-    item_type: type | UnionType
+
+    item_type: type | UnionType | GenericAlias
     name: str
     info: FieldInfo = FieldInfo()
+    pretty_display: bool = Field(
+        default=False,
+        description="Whether to use a pretty display for the widget. Defaults to False. If True, disables the widget, doesn't add a clear button, and adapts the stylesheet for non-editable display.",
+    )
+
+    @field_validator("item_type", mode="before")
+    @classmethod
+    def _validate_type(cls, v):
+        allowed_primitives = [str, int, float, bool]
+        if isinstance(v, (type, UnionType)):
+            return v
+        if isinstance(v, GenericAlias):
+            if v.__origin__ in [list, dict] and all(
+                arg in allowed_primitives for arg in v.__args__
+            ):
+                return v
+            raise ValueError(
+                f"Generics of type {v} are not supported - only lists and dicts of primitive types {allowed_primitives}"
+            )
+        if type(v) is type(Literal[""]):  # _LiteralGenericAlias is not exported from typing
+            arg_types = set(type(arg) for arg in v.__args__)
+            if len(arg_types) != 1:
+                raise ValueError("Mixtures of literal types are not supported!")
+            if (t := arg_types.pop()) in allowed_primitives:
+                return t
+            raise ValueError(f"Literals of type {t} are not supported")
 
 
 class ClearableBoolEntry(QWidget):
@@ -102,6 +129,13 @@ class DynamicFormItem(QWidget):
     valueChanged = Signal()
 
     def __init__(self, parent: QWidget | None = None, *, spec: FormItemSpec) -> None:
+        """
+        Initializes the form item widget.
+
+        Args:
+            parent (QWidget | None, optional): The parent widget. Defaults to None.
+            spec (FormItemSpec): The specification for the form item.
+        """
         super().__init__(parent)
         self._spec = spec
         self._layout = QHBoxLayout()
@@ -111,8 +145,11 @@ class DynamicFormItem(QWidget):
         self._desc = self._spec.info.description
         self.setLayout(self._layout)
         self._add_main_widget()
-        if clearable_required(spec.info):
-            self._add_clear_button()
+        if not spec.pretty_display:
+            if clearable_required(spec.info):
+                self._add_clear_button()
+        else:
+            self._set_pretty_display()
 
     @abstractmethod
     def getValue(self) -> DynamicFormItemType: ...
@@ -124,6 +161,9 @@ class DynamicFormItem(QWidget):
     def _add_main_widget(self) -> None:
         """Add the main data entry widget to self._main_widget and appply any
         constraints from the field info"""
+
+    def _set_pretty_display(self):
+        self.setEnabled(False)
 
     def _describe(self, pad=" "):
         return pad + (self._desc if self._desc else "")
@@ -168,7 +208,7 @@ class StrMetadataField(DynamicFormItem):
     def setValue(self, value: str):
         if value is None:
             self._main_widget.setText("")
-        self._main_widget.setText(value)
+        self._main_widget.setText(str(value))
 
 
 class IntMetadataField(DynamicFormItem):
@@ -260,8 +300,12 @@ class DictMetadataField(DynamicFormItem):
         super().__init__(parent=parent, spec=spec)
         self._main_widget.data_changed.connect(self._value_changed)
 
+    def _set_pretty_display(self):
+        self._main_widget.set_button_visibility(False)
+        super()._set_pretty_display()
+
     def _add_main_widget(self) -> None:
-        self._main_widget = DictBackedTable([])
+        self._main_widget = DictBackedTable(self, [])
         self._layout.addWidget(self._main_widget)
         self._main_widget.setToolTip(self._describe(""))
 

--- a/bec_widgets/utils/forms_from_types/items.py
+++ b/bec_widgets/utils/forms_from_types/items.py
@@ -94,6 +94,9 @@ class ClearableBoolEntry(QWidget):
         self._false.setToolTip(tooltip)
 
 
+DynamicFormItemType = str | int | float | Decimal | bool
+
+
 class DynamicFormItem(QWidget):
     valueChanged = Signal()
 
@@ -111,7 +114,7 @@ class DynamicFormItem(QWidget):
             self._add_clear_button()
 
     @abstractmethod
-    def getValue(self): ...
+    def getValue(self) -> DynamicFormItemType: ...
 
     @abstractmethod
     def setValue(self, value): ...
@@ -204,7 +207,7 @@ class FloatDecimalMetadataField(DynamicFormItem):
     def _add_main_widget(self) -> None:
         self._main_widget = QDoubleSpinBox()
         self._layout.addWidget(self._main_widget)
-        min_, max_ = field_limits(self._spec.info, int)
+        min_, max_ = field_limits(self._spec.info, float)
         self._main_widget.setMinimum(min_)
         self._main_widget.setMaximum(max_)
         precision = field_precision(self._spec.info)
@@ -224,10 +227,10 @@ class FloatDecimalMetadataField(DynamicFormItem):
             return self._default
         return self._main_widget.value()
 
-    def setValue(self, value: float):
+    def setValue(self, value: float | Decimal):
         if value is None:
             self._main_widget.clear()
-        self._main_widget.setValue(value)
+        self._main_widget.setValue(float(value))
 
 
 class BoolMetadataField(DynamicFormItem):

--- a/bec_widgets/utils/forms_from_types/items.py
+++ b/bec_widgets/utils/forms_from_types/items.py
@@ -21,6 +21,7 @@ from qtpy.QtWidgets import (
     QLayout,
     QLineEdit,
     QRadioButton,
+    QSizePolicy,
     QSpinBox,
     QToolButton,
     QWidget,
@@ -145,6 +146,8 @@ class DynamicFormItem(QWidget):
         self._desc = self._spec.info.description
         self.setLayout(self._layout)
         self._add_main_widget()
+        self._main_widget: QWidget
+        self._main_widget.setSizePolicy(QSizePolicy.MinimumExpanding, QSizePolicy.MinimumExpanding)
         if not spec.pretty_display:
             if clearable_required(spec.info):
                 self._add_clear_button()

--- a/bec_widgets/utils/forms_from_types/items.py
+++ b/bec_widgets/utils/forms_from_types/items.py
@@ -26,6 +26,7 @@ from qtpy.QtWidgets import (
     QWidget,
 )
 
+from bec_widgets.widgets.editors.dict_backed_table import DictBackedTable
 from bec_widgets.widgets.editors.scan_metadata._util import (
     clearable_required,
     field_default,
@@ -94,7 +95,7 @@ class ClearableBoolEntry(QWidget):
         self._false.setToolTip(tooltip)
 
 
-DynamicFormItemType = str | int | float | Decimal | bool
+DynamicFormItemType = str | int | float | Decimal | bool | dict
 
 
 class DynamicFormItem(QWidget):
@@ -205,12 +206,12 @@ class FloatDecimalMetadataField(DynamicFormItem):
         self._main_widget.textChanged.connect(self._value_changed)
 
     def _add_main_widget(self) -> None:
+        precision = field_precision(self._spec.info)
         self._main_widget = QDoubleSpinBox()
         self._layout.addWidget(self._main_widget)
-        min_, max_ = field_limits(self._spec.info, float)
+        min_, max_ = field_limits(self._spec.info, float, precision)
         self._main_widget.setMinimum(min_)
         self._main_widget.setMaximum(max_)
-        precision = field_precision(self._spec.info)
         if precision:
             self._main_widget.setDecimals(precision)
         minstr = f"{float(min_):.3f}" if abs(min_) <= 1000 else f"{float(min_):.3e}"
@@ -254,6 +255,23 @@ class BoolMetadataField(DynamicFormItem):
         self._main_widget.setChecked(value)
 
 
+class DictMetadataField(DynamicFormItem):
+    def __init__(self, *, parent: QWidget | None = None, spec: FormItemSpec) -> None:
+        super().__init__(parent=parent, spec=spec)
+        self._main_widget.data_changed.connect(self._value_changed)
+
+    def _add_main_widget(self) -> None:
+        self._main_widget = DictBackedTable([])
+        self._layout.addWidget(self._main_widget)
+        self._main_widget.setToolTip(self._describe(""))
+
+    def getValue(self):
+        return self._main_widget.dump_dict()
+
+    def setValue(self, value):
+        self._main_widget.replace_data(value)
+
+
 def widget_from_type(annotation: type | UnionType | None) -> type[DynamicFormItem]:
     if annotation in [str, str | None]:
         return StrMetadataField
@@ -263,6 +281,14 @@ def widget_from_type(annotation: type | UnionType | None) -> type[DynamicFormIte
         return FloatDecimalMetadataField
     if annotation in [bool, bool | None]:
         return BoolMetadataField
+    if annotation in [dict, dict | None] or (
+        isinstance(annotation, GenericAlias) and annotation.__origin__ is dict
+    ):
+        return DictMetadataField
+    if annotation in [list, list | None] or (
+        isinstance(annotation, GenericAlias) and annotation.__origin__ is list
+    ):
+        return StrMetadataField
     else:
         logger.warning(f"Type {annotation} is not (yet) supported in metadata form creation.")
         return StrMetadataField

--- a/bec_widgets/utils/forms_from_types/styles.py
+++ b/bec_widgets/utils/forms_from_types/styles.py
@@ -1,0 +1,22 @@
+import bec_qthemes
+
+
+def pretty_display_theme(theme: str = "dark"):
+    print(f"loading theme {theme}")
+    palette = bec_qthemes.load_palette(theme)
+    foreground = palette.text().color().name()
+    background = palette.base().color().name()
+    border = palette.shadow().color().name()
+    accent = palette.accent().color().name()
+    return f"""
+QWidget {{color: {foreground}; background-color: {background}}}
+QLabel {{ font-weight: bold; }}
+QLineEdit,QLabel,QTreeView {{ border-style: solid; border-width: 2px; border-color: {border} }}
+QRadioButton {{ color: {foreground}; }}
+QRadioButton::indicator::checked {{ color: {accent}; }}
+QCheckBox {{ color: {accent}; }}
+"""
+
+
+if __name__ == "__main__":
+    print(pretty_display_theme())

--- a/bec_widgets/utils/forms_from_types/styles.py
+++ b/bec_widgets/utils/forms_from_types/styles.py
@@ -2,7 +2,6 @@ import bec_qthemes
 
 
 def pretty_display_theme(theme: str = "dark"):
-    print(f"loading theme {theme}")
     palette = bec_qthemes.load_palette(theme)
     foreground = palette.text().color().name()
     background = palette.base().color().name()

--- a/bec_widgets/utils/generate_designer_plugin.py
+++ b/bec_widgets/utils/generate_designer_plugin.py
@@ -8,6 +8,9 @@ from qtpy.QtCore import QObject
 from bec_widgets.utils.name_utils import pascal_to_snake
 
 EXCLUDED_PLUGINS = ["BECConnector", "BECDockArea", "BECDock", "BECFigure"]
+_PARENT_ARG_REGEX = r".__init__\(\s*(?:parent\)|parent=parent,?|parent,?)"
+_SELF_PARENT_ARG_REGEX = r".__init__\(\s*self,\s*(?:parent\)|parent=parent,?|parent,?)"
+SUPER_INIT_REGEX = re.compile(r"super\(\)" + _PARENT_ARG_REGEX, re.MULTILINE)
 
 
 class PluginFilenames(NamedTuple):
@@ -90,34 +93,20 @@ class DesignerPluginGenerator:
 
         # Check if the widget class calls the super constructor with parent argument
         init_source = inspect.getsource(self.widget.__init__)
-        cls_init_found = (
-            bool(init_source.find(f"{base_cls[0].__name__}.__init__(self, parent=parent") > 0)
-            or bool(init_source.find(f"{base_cls[0].__name__}.__init__(self, parent)") > 0)
-            or bool(init_source.find(f"{base_cls[0].__name__}.__init__(self, parent,") > 0)
+        class_re = re.compile(base_cls[0].__name__ + _SELF_PARENT_ARG_REGEX, re.MULTILINE)
+        cls_init_found = class_re.search(init_source) is not None
+        super_self_re = re.compile(
+            rf"super\({base_cls[0].__name__}, self\)" + _PARENT_ARG_REGEX, re.MULTILINE
         )
-        super_init_found = (
-            bool(
-                init_source.find(f"super({base_cls[0].__name__}, self).__init__(parent=parent") > 0
-            )
-            or bool(init_source.find(f"super({base_cls[0].__name__}, self).__init__(parent,") > 0)
-            or bool(init_source.find(f"super({base_cls[0].__name__}, self).__init__(parent)") > 0)
-        )
+        super_init_found = super_self_re.search(init_source) is not None
         if issubclass(self.widget.__bases__[0], QObject) and not super_init_found:
-            super_init_found = (
-                bool(init_source.find("super().__init__(parent=parent") > 0)
-                or bool(init_source.find("super().__init__(parent,") > 0)
-                or bool(init_source.find("super().__init__(parent)") > 0)
-            )
+            super_init_found = SUPER_INIT_REGEX.search(init_source) is not None
 
         # for the new style classes, we only have one super call. We can therefore check if the
         # number of __init__ calls is 2 (the class itself and the super class)
         num_inits = re.findall(r"__init__", init_source)
         if len(num_inits) == 2 and not super_init_found:
-            super_init_found = bool(
-                init_source.find("super().__init__(parent=parent") > 0
-                or init_source.find("super().__init__(parent,") > 0
-                or init_source.find("super().__init__(parent)") > 0
-            )
+            super_init_found = SUPER_INIT_REGEX.search(init_source) is not None
 
         if not cls_init_found and not super_init_found:
             raise ValueError(

--- a/bec_widgets/widgets/control/scan_control/scan_control.py
+++ b/bec_widgets/widgets/control/scan_control/scan_control.py
@@ -89,7 +89,7 @@ class ScanControl(BECWidget, QWidget):
         self.config.allowed_scans = allowed_scans
 
         self._scan_metadata: dict | None = None
-        self._metadata_form = ScanMetadata(parent=parent)
+        self._metadata_form = ScanMetadata(parent=self)
 
         # Create and set main layout
         self._init_UI()

--- a/bec_widgets/widgets/control/scan_control/scan_control.py
+++ b/bec_widgets/widgets/control/scan_control/scan_control.py
@@ -89,6 +89,7 @@ class ScanControl(BECWidget, QWidget):
         self.config.allowed_scans = allowed_scans
 
         self._scan_metadata: dict | None = None
+        self._metadata_form = ScanMetadata(parent=parent)
 
         # Create and set main layout
         self._init_UI()
@@ -165,7 +166,6 @@ class ScanControl(BECWidget, QWidget):
         self.layout.addStretch()
 
     def _add_metadata_form(self):
-        self._metadata_form = ScanMetadata(parent=self)
         self.layout.addWidget(self._metadata_form)
         self._metadata_form.update_with_new_scan(self.comboBox_scan_selection.currentText())
         self.scan_selected.connect(self._metadata_form.update_with_new_scan)

--- a/bec_widgets/widgets/editors/dict_backed_table.py
+++ b/bec_widgets/widgets/editors/dict_backed_table.py
@@ -57,6 +57,11 @@ class DictBackedTableModel(QAbstractTableModel):
             return True
         return False
 
+    def replaceData(self, data: dict):
+        self.resetInternalData()
+        self._data = [[k, v] for k, v in data.items()]
+        self.dataChanged.emit(self.index(0, 0), self.index(len(self._data), 0))
+
     def update_disallowed_keys(self, keys: list[str]):
         """Set the list of keys which may not be used.
 
@@ -110,7 +115,7 @@ class DictBackedTableModel(QAbstractTableModel):
 
 class DictBackedTable(QWidget):
     delete_rows = Signal(list)
-    data_updated = Signal()
+    data_changed = Signal(dict)
 
     def __init__(self, initial_data: list[list[str]]):
         """Widget which uses a DictBackedTableModel to display an editable table
@@ -143,11 +148,14 @@ class DictBackedTable(QWidget):
         self._add_button.clicked.connect(self._table_model.add_row)
         self._remove_button.clicked.connect(self.delete_selected_rows)
         self.delete_rows.connect(self._table_model.delete_rows)
-        self._table_model.dataChanged.connect(self._emit_data_updated)
+        self._table_model.dataChanged.connect(lambda *_: self.data_changed.emit(self.dump_dict()))
 
-    def _emit_data_updated(self, *args, **kwargs):
-        """Just to swallow the args"""
-        self.data_updated.emit()
+    @SafeSlot()
+    def clear(self):
+        self._table_model.replaceData({})
+
+    def replace_data(self, data: dict):
+        self._table_model.replaceData(data)
 
     def delete_selected_rows(self):
         """Delete rows which are part of the selection model"""

--- a/bec_widgets/widgets/editors/dict_backed_table.py
+++ b/bec_widgets/widgets/editors/dict_backed_table.py
@@ -45,7 +45,11 @@ class DictBackedTableModel(QAbstractTableModel):
 
     def data(self, index, role=Qt.ItemDataRole):
         if index.isValid():
-            if role == Qt.ItemDataRole.DisplayRole or role == Qt.ItemDataRole.EditRole:
+            if role in [
+                Qt.ItemDataRole.DisplayRole,
+                Qt.ItemDataRole.EditRole,
+                Qt.ItemDataRole.ToolTipRole,
+            ]:
                 return str(self._data[index.row()][index.column()])
 
     def setData(self, index, value, role):
@@ -132,7 +136,7 @@ class DictBackedTable(QWidget):
         self._table_view = QTreeView()
         self._table_view.setModel(self._table_model)
         self._table_view.setSizePolicy(
-            QSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Minimum)
+            QSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
         )
         self._table_view.setAlternatingRowColors(True)
         self._layout.addWidget(self._table_view)

--- a/bec_widgets/widgets/editors/dict_backed_table.py
+++ b/bec_widgets/widgets/editors/dict_backed_table.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from qtpy import QtWidgets
 from qtpy.QtCore import QAbstractTableModel, QModelIndex, Qt, Signal  # type: ignore
 from qtpy.QtWidgets import (
     QApplication,
@@ -139,6 +140,8 @@ class DictBackedTable(QWidget):
             QSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
         )
         self._table_view.setAlternatingRowColors(True)
+        self._table_view.header().setSectionResizeMode(QtWidgets.QHeaderView.ResizeToContents)
+        self._table_view.header().setSectionResizeMode(5, QtWidgets.QHeaderView.Stretch)
         self._layout.addWidget(self._table_view)
 
         self._button_holder = QWidget()

--- a/bec_widgets/widgets/editors/dict_backed_table.py
+++ b/bec_widgets/widgets/editors/dict_backed_table.py
@@ -121,14 +121,14 @@ class DictBackedTable(QWidget):
     delete_rows = Signal(list)
     data_changed = Signal(dict)
 
-    def __init__(self, initial_data: list[list[str]]):
+    def __init__(self, parent: QWidget | None = None, initial_data: list[list[str]] = []):
         """Widget which uses a DictBackedTableModel to display an editable table
         which can be extracted as a dict.
 
         Args:
             initial_data (list[list[str]]): list of key-value pairs to initialise with
         """
-        super().__init__()
+        super().__init__(parent)
 
         self._layout = QHBoxLayout()
         self.setLayout(self._layout)
@@ -141,8 +141,10 @@ class DictBackedTable(QWidget):
         self._table_view.setAlternatingRowColors(True)
         self._layout.addWidget(self._table_view)
 
+        self._button_holder = QWidget()
         self._buttons = QVBoxLayout()
-        self._layout.addLayout(self._buttons)
+        self._button_holder.setLayout(self._buttons)
+        self._layout.addWidget(self._button_holder)
         self._add_button = QPushButton("+")
         self._add_button.setToolTip("add a new row")
         self._remove_button = QPushButton("-")
@@ -153,6 +155,9 @@ class DictBackedTable(QWidget):
         self._remove_button.clicked.connect(self.delete_selected_rows)
         self.delete_rows.connect(self._table_model.delete_rows)
         self._table_model.dataChanged.connect(lambda *_: self.data_changed.emit(self.dump_dict()))
+
+    def set_button_visibility(self, value: bool):
+        self._button_holder.setVisible(value)
 
     @SafeSlot()
     def clear(self):
@@ -186,6 +191,6 @@ if __name__ == "__main__":  # pragma: no cover
     app = QApplication([])
     set_theme("dark")
 
-    window = DictBackedTable([["key1", "value1"], ["key2", "value2"], ["key3", "value3"]])
+    window = DictBackedTable(None, [["key1", "value1"], ["key2", "value2"], ["key3", "value3"]])
     window.show()
     app.exec()

--- a/bec_widgets/widgets/editors/scan_metadata/_util.py
+++ b/bec_widgets/widgets/editors/scan_metadata/_util.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import sys
 from decimal import Decimal
-from math import inf, nextafter
+from math import copysign, inf, nextafter
 from typing import TYPE_CHECKING, TypeVar, get_args
 
 from annotated_types import Ge, Gt, Le, Lt
@@ -23,16 +23,19 @@ _MAXFLOAT = sys.float_info.max
 T = TypeVar("T", int, float, Decimal)
 
 
-def field_limits(info: FieldInfo, type_: type[T]) -> tuple[T, T]:
+def field_limits(info: FieldInfo, type_: type[T], prec: int | None = None) -> tuple[T, T]:
+    def _nextafter(x, y):
+        return nextafter(x, y) if prec is None else x + (10 ** (-prec)) * (copysign(1, y))
+
     _min = _MININT if type_ is int else _MINFLOAT
     _max = _MAXINT if type_ is int else _MAXFLOAT
     for md in info.metadata:
         if isinstance(md, Ge):
             _min = type_(md.ge)  # type: ignore
         if isinstance(md, Gt):
-            _min = type_(md.gt) + 1 if type_ is int else nextafter(type_(md.gt), inf)  # type: ignore
+            _min = type_(md.gt) + 1 if type_ is int else _nextafter(type_(md.gt), inf)  # type: ignore
         if isinstance(md, Lt):
-            _max = type_(md.lt) - 1 if type_ is int else nextafter(type_(md.lt), -inf)  # type: ignore
+            _max = type_(md.lt) - 1 if type_ is int else _nextafter(type_(md.lt), -inf)  # type: ignore
         if isinstance(md, Le):
             _max = type_(md.le)  # type: ignore
     return _min, _max  # type: ignore

--- a/bec_widgets/widgets/editors/scan_metadata/scan_metadata.py
+++ b/bec_widgets/widgets/editors/scan_metadata/scan_metadata.py
@@ -45,7 +45,7 @@ class ScanMetadata(PydanticModelForm):
         self._md_schema = get_metadata_schema_for_scan(self._scan_name)
         self._additional_metadata.data_updated.connect(self.validate_form)
 
-        super().__init__(parent=parent, metadata_model=self._md_schema, client=client, **kwargs)
+        super().__init__(parent=parent, data_model=self._md_schema, client=client, **kwargs)
 
         self._layout.addWidget(self._additional_md_box)
         self._additional_md_box_layout.addWidget(self._additional_metadata)

--- a/bec_widgets/widgets/editors/scan_metadata/scan_metadata.py
+++ b/bec_widgets/widgets/editors/scan_metadata/scan_metadata.py
@@ -43,7 +43,7 @@ class ScanMetadata(PydanticModelForm):
         self._additional_metadata = DictBackedTable(initial_extras or [])
         self._scan_name = scan_name or ""
         self._md_schema = get_metadata_schema_for_scan(self._scan_name)
-        self._additional_metadata.data_updated.connect(self.validate_form)
+        self._additional_metadata.data_changed.connect(self.validate_form)
 
         super().__init__(parent=parent, data_model=self._md_schema, client=client, **kwargs)
 

--- a/bec_widgets/widgets/editors/scan_metadata/scan_metadata.py
+++ b/bec_widgets/widgets/editors/scan_metadata/scan_metadata.py
@@ -16,6 +16,9 @@ logger = bec_logger.logger
 
 
 class ScanMetadata(PydanticModelForm):
+
+    RPC = False
+
     def __init__(
         self,
         parent=None,

--- a/bec_widgets/widgets/editors/scan_metadata/scan_metadata.py
+++ b/bec_widgets/widgets/editors/scan_metadata/scan_metadata.py
@@ -36,11 +36,13 @@ class ScanMetadata(PydanticModelForm):
 
         # self.populate() gets called in super().__init__
         # so make sure self._additional_metadata exists
-        self._additional_md_box = ExpandableGroupFrame("Additional metadata", expanded=False)
+        self._additional_md_box = ExpandableGroupFrame(
+            parent, "Additional metadata", expanded=False
+        )
         self._additional_md_box_layout = QHBoxLayout()
         self._additional_md_box.set_layout(self._additional_md_box_layout)
 
-        self._additional_metadata = DictBackedTable(initial_extras or [])
+        self._additional_metadata = DictBackedTable(parent, initial_extras or [])
         self._scan_name = scan_name or ""
         self._md_schema = get_metadata_schema_for_scan(self._scan_name)
         self._additional_metadata.data_changed.connect(self.validate_form)
@@ -127,6 +129,7 @@ if __name__ == "__main__":  # pragma: no cover
         w.setLayout(layout)
 
         scan_metadata = ScanMetadata(
+            parent=w,
             scan_name="grid_scan",
             initial_extras=[["key1", "value1"], ["key2", "value2"], ["key3", "value3"]],
         )

--- a/bec_widgets/widgets/services/device_browser/device_browser.py
+++ b/bec_widgets/widgets/services/device_browser/device_browser.py
@@ -6,8 +6,7 @@ from bec_lib.callback_handler import EventType
 from bec_lib.logger import bec_logger
 from bec_lib.messages import ConfigAction
 from pyqtgraph import SignalProxy
-from PySide6.QtCore import QSize
-from qtpy.QtCore import Signal
+from qtpy.QtCore import QSize, Signal
 from qtpy.QtWidgets import QListWidget, QListWidgetItem, QVBoxLayout, QWidget
 
 from bec_widgets.cli.rpc.rpc_register import RPCRegister

--- a/bec_widgets/widgets/services/device_browser/device_browser.py
+++ b/bec_widgets/widgets/services/device_browser/device_browser.py
@@ -1,15 +1,23 @@
 import os
 import re
-from typing import Optional
+from functools import partial
 
 from bec_lib.callback_handler import EventType
+from bec_lib.logger import bec_logger
+from bec_lib.messages import ConfigAction
 from pyqtgraph import SignalProxy
-from qtpy.QtCore import Signal, Slot
-from qtpy.QtWidgets import QListWidgetItem, QVBoxLayout, QWidget
+from PySide6.QtCore import QSize
+from qtpy.QtCore import Signal
+from qtpy.QtWidgets import QListWidget, QListWidgetItem, QVBoxLayout, QWidget
 
+from bec_widgets.cli.rpc.rpc_register import RPCRegister
 from bec_widgets.utils.bec_widget import BECWidget
+from bec_widgets.utils.error_popups import SafeSlot
 from bec_widgets.utils.ui_loader import UILoader
 from bec_widgets.widgets.services.device_browser.device_item import DeviceItem
+from bec_widgets.widgets.services.device_browser.util import map_device_type_to_icon
+
+logger = bec_logger.logger
 
 
 class DeviceBrowser(BECWidget, QWidget):
@@ -23,18 +31,18 @@ class DeviceBrowser(BECWidget, QWidget):
 
     def __init__(
         self,
-        parent: Optional[QWidget] = None,
+        parent: QWidget | None = None,
         config=None,
         client=None,
-        gui_id: Optional[str] = None,
+        gui_id: str | None = None,
         **kwargs,
     ) -> None:
         super().__init__(parent=parent, client=client, gui_id=gui_id, config=config, **kwargs)
-
         self.get_bec_shortcuts()
         self.ui = None
         self.ini_ui()
-
+        self.dev_list: QListWidget = self.ui.device_list
+        self.dev_list.setVerticalScrollMode(QListWidget.ScrollMode.ScrollPerPixel)
         self.proxy_device_update = SignalProxy(
             self.ui.filter_input.textChanged, rateLimit=500, slot=self.update_device_list
         )
@@ -43,6 +51,7 @@ class DeviceBrowser(BECWidget, QWidget):
         )
         self.device_update.connect(self.update_device_list)
 
+        self.init_device_list()
         self.update_device_list()
 
     def ini_ui(self) -> None:
@@ -50,14 +59,12 @@ class DeviceBrowser(BECWidget, QWidget):
         Initialize the UI by loading the UI file and setting the layout.
         """
         layout = QVBoxLayout()
-        layout.setContentsMargins(0, 0, 0, 0)
-
         ui_file_path = os.path.join(os.path.dirname(__file__), "device_browser.ui")
         self.ui = UILoader(self).loader(ui_file_path)
         layout.addWidget(self.ui)
         self.setLayout(layout)
 
-    def on_device_update(self, action: str, content: dict) -> None:
+    def on_device_update(self, action: ConfigAction, content: dict) -> None:
         """
         Callback for device update events. Triggers the device_update signal.
 
@@ -68,8 +75,43 @@ class DeviceBrowser(BECWidget, QWidget):
         if action in ["add", "remove", "reload"]:
             self.device_update.emit()
 
-    @Slot()
-    def update_device_list(self) -> None:
+    def init_device_list(self):
+        self.dev_list.clear()
+        self._device_items: dict[str, QListWidgetItem] = {}
+
+        def _updatesize(item: QListWidgetItem, device_item: DeviceItem):
+            device_item.adjustSize()
+            item.setSizeHint(QSize(device_item.width(), device_item.height()))
+            logger.debug(f"Adjusting {item} size to {device_item.width(), device_item.height()}")
+
+        with RPCRegister.delayed_broadcast():
+            for device, device_obj in self.dev.items():
+                item = QListWidgetItem(self.dev_list)
+                device_item = DeviceItem(
+                    parent=self, device=device, icon=map_device_type_to_icon(device_obj)
+                )
+
+                device_item.expansion_state_changed.connect(partial(_updatesize, item, device_item))
+
+                device_config = self.dev[device]._config  # pylint: disable=protected-access
+                device_item.set_display_config(device_config)
+                tooltip = device_config.get("description", "")
+                device_item.setToolTip(tooltip)
+                device_item.broadcast_size_hint.connect(item.setSizeHint)
+                item.setSizeHint(device_item.sizeHint())
+
+                self.dev_list.setItemWidget(item, device_item)
+                self.dev_list.addItem(item)
+                self._device_items[device] = item
+
+    @SafeSlot()
+    def reset_device_list(self) -> None:
+        self.init_device_list()
+        self.update_device_list()
+
+    @SafeSlot()
+    @SafeSlot(str)
+    def update_device_list(self, *_) -> None:
         """
         Update the device list based on the filter input.
         There are two ways to trigger this function:
@@ -80,23 +122,14 @@ class DeviceBrowser(BECWidget, QWidget):
         """
         filter_text = self.ui.filter_input.text()
         try:
-            regex = re.compile(filter_text, re.IGNORECASE)
+            self.regex = re.compile(filter_text, re.IGNORECASE)
         except re.error:
-            regex = None  # Invalid regex, disable filtering
-
-        dev_list = self.ui.device_list
-        dev_list.clear()
+            self.regex = None  # Invalid regex, disable filtering
+            for device in self.dev:
+                self._device_items[device].setHidden(False)
+            return
         for device in self.dev:
-            if regex is None or regex.search(device):
-                item = QListWidgetItem(dev_list)
-                device_item = DeviceItem(device)
-
-                # pylint: disable=protected-access
-                tooltip = self.dev[device]._config.get("description", "")
-                device_item.setToolTip(tooltip)
-                item.setSizeHint(device_item.sizeHint())
-                dev_list.setItemWidget(item, device_item)
-                dev_list.addItem(item)
+            self._device_items[device].setHidden(not self.regex.search(device))
 
 
 if __name__ == "__main__":  # pragma: no cover
@@ -104,10 +137,10 @@ if __name__ == "__main__":  # pragma: no cover
 
     from qtpy.QtWidgets import QApplication
 
-    from bec_widgets.utils.colors import apply_theme
+    from bec_widgets.utils.colors import set_theme
 
     app = QApplication(sys.argv)
-    apply_theme("light")
+    set_theme("light")
     widget = DeviceBrowser()
     widget.show()
     sys.exit(app.exec_())

--- a/bec_widgets/widgets/services/device_browser/device_item/device_item.py
+++ b/bec_widgets/widgets/services/device_browser/device_item/device_item.py
@@ -65,6 +65,8 @@ class DeviceItem(ExpandableGroupFrame):
         self.set_layout(layout)
 
         self.adjustSize()
+        self._title.clicked.connect(self.switch_expanded_state)
+        self._title_icon.clicked.connect(self.switch_expanded_state)
 
     @SafeSlot()
     def switch_expanded_state(self):

--- a/bec_widgets/widgets/services/device_browser/device_item/device_item.py
+++ b/bec_widgets/widgets/services/device_browser/device_item/device_item.py
@@ -2,10 +2,18 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from bec_lib.atlas_models import Device as DeviceConfigModel
 from bec_lib.logger import bec_logger
-from qtpy.QtCore import QMimeData, Qt
+from qtpy.QtCore import QMimeData, QSize, Qt, Signal
 from qtpy.QtGui import QDrag
-from qtpy.QtWidgets import QApplication, QHBoxLayout, QLabel, QWidget
+from qtpy.QtWidgets import QApplication, QHBoxLayout, QWidget
+
+from bec_widgets.utils.colors import get_theme_name
+from bec_widgets.utils.error_popups import SafeSlot
+from bec_widgets.utils.expandable_frame import ExpandableGroupFrame
+from bec_widgets.utils.forms_from_types import styles
+from bec_widgets.utils.forms_from_types.forms import PydanticModelForm
+from bec_widgets.widgets.utility.visual.dark_mode_button.dark_mode_button import DarkModeButton
 
 if TYPE_CHECKING:  # pragma: no cover
     from qtpy.QtGui import QMouseEvent
@@ -13,26 +21,75 @@ if TYPE_CHECKING:  # pragma: no cover
 logger = bec_logger.logger
 
 
-class DeviceItem(QWidget):
-    def __init__(self, device: str) -> None:
-        super().__init__()
+class DeviceItemForm(PydanticModelForm):
+    RPC = False
+    PLUGIN = False
+
+    def __init__(self, parent=None, client=None, pretty_display=False, **kwargs):
+        super().__init__(
+            parent=parent,
+            data_model=DeviceConfigModel,
+            pretty_display=pretty_display,
+            client=client,
+            **kwargs,
+        )
+        self._validity.setVisible(False)
+        self._connect_to_theme_change()
+
+    def set_pretty_display_theme(self, theme: str | None = None):
+        if theme is None:
+            theme = get_theme_name()
+        self.setStyleSheet(styles.pretty_display_theme(theme))
+
+    def _connect_to_theme_change(self):
+        """Connect to the theme change signal."""
+        qapp = QApplication.instance()
+        if hasattr(qapp, "theme_signal"):
+            qapp.theme_signal.theme_updated.connect(self.set_pretty_display_theme)  # type: ignore
+
+
+class DeviceItem(ExpandableGroupFrame):
+    broadcast_size_hint = Signal(QSize)
+
+    RPC = False
+
+    def __init__(self, parent, device: str, icon: str = "") -> None:
+        super().__init__(parent, title=device, expanded=False, icon=icon)
 
         self._drag_pos = None
-
+        self._expanded_first_time = False
+        self._data = None
         self.device = device
         layout = QHBoxLayout()
-        layout.setContentsMargins(10, 2, 10, 2)
-        self.label = QLabel(device)
-        layout.addWidget(self.label)
-        self.setLayout(layout)
+        layout.setContentsMargins(0, 0, 0, 0)
+        self.set_layout(layout)
 
-        self.setStyleSheet(
-            """
-            border: 1px solid #ddd;
-            border-radius: 5px;
-            padding: 10px;
-        """
-        )
+        self.adjustSize()
+
+    @SafeSlot()
+    def switch_expanded_state(self):
+        if not self.expanded and not self._expanded_first_time:
+            self._expanded_first_time = True
+            self.form = DeviceItemForm(parent=self, pretty_display=True)
+            self._contents.layout().addWidget(self.form)
+            if self._data:
+                self.form.set_data(self._data)
+            self.broadcast_size_hint.emit(self.sizeHint())
+        super().switch_expanded_state()
+        if self._expanded_first_time:
+            self.form.adjustSize()
+            self.updateGeometry()
+            if self._expanded:
+                self.form.set_pretty_display_theme()
+        self.adjustSize()
+        self.broadcast_size_hint.emit(self.sizeHint())
+
+    def set_display_config(self, config_dict: dict):
+        """Set the displayed information from a device config dict, which must conform to the
+        bec_lib.atlas_models.Device config model."""
+        self._data = DeviceConfigModel.model_validate(config_dict)
+        if self._expanded_first_time:
+            self.form.set_data(self._data)
 
     def mousePressEvent(self, event: QMouseEvent) -> None:
         super().mousePressEvent(event)
@@ -63,6 +120,25 @@ if __name__ == "__main__":  # pragma: no cover
     from qtpy.QtWidgets import QApplication
 
     app = QApplication(sys.argv)
-    widget = DeviceItem("Device")
+    widget = QWidget()
+    layout = QHBoxLayout()
+    widget.setLayout(layout)
+    item = DeviceItem("Device")
+    layout.addWidget(DarkModeButton())
+    layout.addWidget(item)
+    item.set_display_config(
+        {
+            "name": "Test Device",
+            "enabled": True,
+            "deviceClass": "FakeDeviceClass",
+            "deviceConfig": {"kwarg1": "value1"},
+            "readoutPriority": "baseline",
+            "description": "A device for testing out a widget",
+            "readOnly": True,
+            "softwareTrigger": False,
+            "deviceTags": ["tag1", "tag2", "tag3"],
+            "userParameter": {"some_setting": "some_ value"},
+        }
+    )
     widget.show()
     sys.exit(app.exec_())

--- a/bec_widgets/widgets/services/device_browser/util.py
+++ b/bec_widgets/widgets/services/device_browser/util.py
@@ -1,0 +1,11 @@
+from bec_lib.device import Device
+
+
+def map_device_type_to_icon(device_obj: Device) -> str:
+    """Associate device types with material icon names"""
+    match device_obj._info.get("device_base_class", "").lower():
+        case "positioner":
+            return "precision_manufacturing"
+        case "signal":
+            return "vital_signs"
+    return "deployed_code"

--- a/tests/unit_tests/test_device_browser.py
+++ b/tests/unit_tests/test_device_browser.py
@@ -77,7 +77,8 @@ def test_update_event_captured(device_browser, qtbot):
 
 def test_device_item_expansion(device_browser, qtbot):
     """
-    Test that the form is displayed when the item is expanded
+    Test that the form is displayed when the item is expanded, and that the expansion is triggered
+    by clicking on the expansion button, the title, or the device icon
     """
     device_item: QListWidgetItem = device_browser.ui.device_list.itemAt(0, 0)
     widget: DeviceItem = device_browser.ui.device_list.itemWidget(device_item)
@@ -89,6 +90,12 @@ def test_device_item_expansion(device_browser, qtbot):
     assert name_field.getValue() == "samx"
     qtbot.mouseClick(widget._expansion_button, Qt.MouseButton.LeftButton)
     assert not widget.expanded
+
+    qtbot.mouseClick(widget._title, Qt.MouseButton.LeftButton)
+    qtbot.waitUntil(lambda: widget.expanded, timeout=500)
+
+    qtbot.mouseClick(widget._title_icon, Qt.MouseButton.LeftButton)
+    qtbot.waitUntil(lambda: not widget.expanded, timeout=500)
 
 
 def test_device_item_mouse_press_and_move_events_creates_drag(device_browser, qtbot):

--- a/tests/unit_tests/test_device_browser.py
+++ b/tests/unit_tests/test_device_browser.py
@@ -11,7 +11,13 @@ from .client_mocks import mocked_client
 if TYPE_CHECKING:  # pragma: no cover
     from qtpy.QtWidgets import QListWidgetItem
 
-    from bec_widgets.widgets.services.device_browser import DeviceItem
+    from bec_widgets.widgets.services.device_browser.device_item import DeviceItem
+
+
+# pylint: disable=no-member
+# pylint: disable=missing-function-docstring
+# pylint: disable=redefined-outer-name
+# pylint: disable=protected-access
 
 
 @pytest.fixture
@@ -34,18 +40,21 @@ def test_device_browser_filtering(qtbot, device_browser):
     """
     Test that the device browser is able to filter the device list.
     """
-    device_list = device_browser.ui.device_list
+
+    def num_visible(item_dict):
+        return len(list(filter(lambda i: not i.isHidden(), item_dict.values())))
+
     device_browser.ui.filter_input.setText("sam")
     qtbot.wait(1000)
-    assert device_list.count() == 3
+    assert num_visible(device_browser._device_items) == 3
 
     device_browser.ui.filter_input.setText("nonexistent")
     qtbot.wait(1000)
-    assert device_list.count() == 0
+    assert num_visible(device_browser._device_items) == 0
 
     device_browser.ui.filter_input.setText("")
     qtbot.wait(1000)
-    assert device_list.count() == len(device_browser.dev)
+    assert num_visible(device_browser._device_items) == len(device_browser.dev)
 
 
 def test_device_item_mouse_press_event(device_browser, qtbot):
@@ -55,7 +64,7 @@ def test_device_item_mouse_press_event(device_browser, qtbot):
     # Simulate a left mouse press event on the device item
     device_item: QListWidgetItem = device_browser.ui.device_list.itemAt(0, 0)
     widget: DeviceItem = device_browser.ui.device_list.itemWidget(device_item)
-    qtbot.mouseClick(widget.label, Qt.MouseButton.LeftButton)
+    qtbot.mouseClick(widget._title, Qt.MouseButton.LeftButton)
 
 
 def test_device_item_mouse_press_and_move_events_creates_drag(device_browser, qtbot):
@@ -67,7 +76,7 @@ def test_device_item_mouse_press_and_move_events_creates_drag(device_browser, qt
     device_name = widget.device
     with mock.patch("qtpy.QtGui.QDrag.exec_") as mock_exec:
         with mock.patch("qtpy.QtGui.QDrag.setMimeData") as mock_set_mimedata:
-            qtbot.mousePress(widget.label, Qt.MouseButton.LeftButton, pos=QPoint(0, 0))
+            qtbot.mousePress(widget._title, Qt.MouseButton.LeftButton, pos=QPoint(0, 0))
             qtbot.mouseMove(widget, pos=QPoint(10, 10))
             qtbot.mouseRelease(widget, Qt.MouseButton.LeftButton)
             mock_set_mimedata.assert_called_once()

--- a/tests/unit_tests/test_device_browser.py
+++ b/tests/unit_tests/test_device_browser.py
@@ -5,6 +5,7 @@ import pytest
 from qtpy.QtCore import QPoint, Qt
 
 from bec_widgets.widgets.services.device_browser.device_browser import DeviceBrowser
+from bec_widgets.widgets.services.device_browser.device_item.device_item import DeviceItemForm
 
 from .client_mocks import mocked_client
 
@@ -36,25 +37,24 @@ def test_device_browser_init_with_devices(device_browser):
     assert device_list.count() == len(device_browser.dev)
 
 
-def test_device_browser_filtering(qtbot, device_browser):
+@pytest.mark.parametrize(
+    ["search_term", "expected_num_visible"],
+    [("sam", 3), ("nonexistent", 0), ("", -1), (r"(\)", -1)],
+)
+def test_device_browser_filtering(
+    qtbot, device_browser, search_term: str, expected_num_visible: int
+):
     """
     Test that the device browser is able to filter the device list.
     """
+    expected = expected_num_visible if expected_num_visible >= 0 else len(device_browser.dev)
 
     def num_visible(item_dict):
         return len(list(filter(lambda i: not i.isHidden(), item_dict.values())))
 
-    device_browser.ui.filter_input.setText("sam")
-    qtbot.wait(1000)
-    assert num_visible(device_browser._device_items) == 3
-
-    device_browser.ui.filter_input.setText("nonexistent")
-    qtbot.wait(1000)
-    assert num_visible(device_browser._device_items) == 0
-
-    device_browser.ui.filter_input.setText("")
-    qtbot.wait(1000)
-    assert num_visible(device_browser._device_items) == len(device_browser.dev)
+    device_browser.ui.filter_input.setText(search_term)
+    qtbot.wait(100)
+    assert num_visible(device_browser._device_items) == expected
 
 
 def test_device_item_mouse_press_event(device_browser, qtbot):
@@ -65,6 +65,30 @@ def test_device_item_mouse_press_event(device_browser, qtbot):
     device_item: QListWidgetItem = device_browser.ui.device_list.itemAt(0, 0)
     widget: DeviceItem = device_browser.ui.device_list.itemWidget(device_item)
     qtbot.mouseClick(widget._title, Qt.MouseButton.LeftButton)
+
+
+def test_update_event_captured(device_browser, qtbot):
+    device_browser.update_device_list = mock.MagicMock()
+    device_browser.update_device_list.assert_not_called()
+    device_browser.on_device_update("remove", {})
+    device_browser.update_device_list.assert_called_once()
+    device_browser.on_device_update("", {})
+
+
+def test_device_item_expansion(device_browser, qtbot):
+    """
+    Test that the form is displayed when the item is expanded
+    """
+    device_item: QListWidgetItem = device_browser.ui.device_list.itemAt(0, 0)
+    widget: DeviceItem = device_browser.ui.device_list.itemWidget(device_item)
+    qtbot.mouseClick(widget._expansion_button, Qt.MouseButton.LeftButton)
+    form = widget._contents.layout().itemAt(0).widget()
+    qtbot.waitUntil(lambda: isinstance(form, DeviceItemForm), timeout=500)
+    assert widget.expanded
+    assert (name_field := form.widget_dict.get("name")) is not None
+    assert name_field.getValue() == "samx"
+    qtbot.mouseClick(widget._expansion_button, Qt.MouseButton.LeftButton)
+    assert not widget.expanded
 
 
 def test_device_item_mouse_press_and_move_events_creates_drag(device_browser, qtbot):

--- a/tests/unit_tests/test_generate_plugin.py
+++ b/tests/unit_tests/test_generate_plugin.py
@@ -48,12 +48,22 @@ class MyWidget(QWidget):
 from qtpy.QtWidgets import QWidget
 class MyWidget(QWidget):
     def __init__(self, parent=None):
-        super(QWidget, self).__init__(parent)"""
+        super(QWidget, self).__init__(parent)
+""",
         """
 from qtpy.QtWidgets import QWidget
 class MyWidget(QWidget):
     def __init__(self, parent=None):
         super(QWidget, self).__init__(parent=parent)
+""",
+        """
+from qtpy.QtWidgets import QWidget
+class MyWidget(QWidget):
+    def __init__(self, parent=None):
+        super(QWidget, self).__init__(
+            parent=parent,
+            other=arguments,
+        )
 """,
     ]
 )

--- a/tests/unit_tests/test_generated_form_items.py
+++ b/tests/unit_tests/test_generated_form_items.py
@@ -1,0 +1,60 @@
+import sys
+from typing import Literal
+
+import pytest
+from pydantic import ValidationError
+from pydantic.fields import FieldInfo
+
+from bec_widgets.utils.forms_from_types.items import FormItemSpec
+
+
+@pytest.mark.skipif(sys.version_info < (3, 11), reason="Generic types don't support this in 3.10")
+@pytest.mark.parametrize(
+    ["input", "validity"],
+    [
+        ({}, False),
+        ({"item_type": int, "name": "test", "info": FieldInfo(), "pretty_display": True}, True),
+        (
+            {
+                "item_type": dict[dict, dict],
+                "name": "test",
+                "info": FieldInfo(),
+                "pretty_display": True,
+            },
+            False,
+        ),
+        (
+            {
+                "item_type": dict[str, str],
+                "name": "test",
+                "info": FieldInfo(),
+                "pretty_display": True,
+            },
+            True,
+        ),
+        (
+            {
+                "item_type": Literal["a", "b"],
+                "name": "test",
+                "info": FieldInfo(),
+                "pretty_display": True,
+            },
+            True,
+        ),
+        (
+            {
+                "item_type": Literal["a", 2],
+                "name": "test",
+                "info": FieldInfo(),
+                "pretty_display": True,
+            },
+            False,
+        ),
+    ],
+)
+def test_form_item_spec(input, validity):
+    if validity:
+        assert FormItemSpec.model_validate(input)
+    else:
+        with pytest.raises(ValidationError):
+            FormItemSpec.model_validate(input)

--- a/tests/unit_tests/test_pydantic_model_form.py
+++ b/tests/unit_tests/test_pydantic_model_form.py
@@ -50,12 +50,11 @@ def example_md():
 
 
 @pytest.fixture
-def model_widget():
+def model_widget(qtbot):
     widget = PydanticModelForm(data_model=ExampleSchema)
     widget.populate()
+    qtbot.addWidget(widget)
     yield widget
-    widget._clear_grid()
-    widget.deleteLater()
 
 
 def test_widget_dict(model_widget: PydanticModelForm):

--- a/tests/unit_tests/test_pydantic_model_form.py
+++ b/tests/unit_tests/test_pydantic_model_form.py
@@ -5,8 +5,6 @@ from pydantic import BaseModel, Field
 
 from bec_widgets.utils.forms_from_types.forms import PydanticModelForm
 from bec_widgets.utils.forms_from_types.items import (
-    BoolMetadataField,
-    DynamicFormItem,
     FloatDecimalMetadataField,
     IntMetadataField,
     StrMetadataField,
@@ -34,7 +32,7 @@ class ExampleSchema(BaseModel):
 
 TEST_DICT = {
     "sample_name": "test name",
-    "str_optional": None,
+    "str_optional": "None",
     "str_required": "something",
     "bool_optional": None,
     "bool_required_default": True,

--- a/tests/unit_tests/test_pydantic_model_form.py
+++ b/tests/unit_tests/test_pydantic_model_form.py
@@ -1,0 +1,83 @@
+from decimal import Decimal
+
+import pytest
+from pydantic import BaseModel, Field
+
+from bec_widgets.utils.forms_from_types.forms import PydanticModelForm
+from bec_widgets.utils.forms_from_types.items import (
+    BoolMetadataField,
+    DynamicFormItem,
+    FloatDecimalMetadataField,
+    IntMetadataField,
+    StrMetadataField,
+)
+
+# pylint: disable=no-member
+# pylint: disable=missing-function-docstring
+# pylint: disable=redefined-outer-name
+# pylint: disable=protected-access
+
+
+class ExampleSchema(BaseModel):
+    str_optional: str | None = Field(
+        None, title="Optional string", description="an optional string", max_length=23
+    )
+    str_required: str
+    bool_optional: bool | None = Field(None)
+    bool_required_default: bool = Field(True)
+    bool_required_nodefault: bool = Field()
+    int_default: int = Field(123)
+    int_nodefault_optional: int | None = Field(lt=-1, ge=-44)
+    float_nodefault: float
+    decimal_dp_limits_nodefault: Decimal = Field(decimal_places=2, gt=1, le=34.5)
+
+
+TEST_DICT = {
+    "sample_name": "test name",
+    "str_optional": None,
+    "str_required": "something",
+    "bool_optional": None,
+    "bool_required_default": True,
+    "bool_required_nodefault": False,
+    "int_default": 21,
+    "int_nodefault_optional": -10,
+    "float_nodefault": 123.456,
+    "decimal_dp_limits_nodefault": 34.5,
+}
+
+
+@pytest.fixture
+def example_md():
+    return ExampleSchema.model_validate(TEST_DICT)
+
+
+@pytest.fixture
+def model_widget():
+    widget = PydanticModelForm(data_model=ExampleSchema)
+    widget.populate()
+    yield widget
+    widget._clear_grid()
+    widget.deleteLater()
+
+
+def test_widget_dict(model_widget: PydanticModelForm):
+    assert isinstance(model_widget.widget_dict["str_optional"], StrMetadataField)
+    assert isinstance(model_widget.widget_dict["float_nodefault"], FloatDecimalMetadataField)
+    assert isinstance(model_widget.widget_dict["int_default"], IntMetadataField)
+
+
+def test_widget_set_data(model_widget: PydanticModelForm):
+    data = ExampleSchema.model_validate(TEST_DICT)
+    model_widget.set_data(data)
+    for key in [
+        "str_optional",
+        "str_required",
+        "bool_optional",
+        "bool_required_default",
+        "bool_required_nodefault",
+        "int_default",
+        "int_nodefault_optional",
+        "float_nodefault",
+        "decimal_dp_limits_nodefault",
+    ]:
+        assert model_widget.widget_dict[key].getValue() == TEST_DICT[key]

--- a/tests/unit_tests/test_scan_metadata.py
+++ b/tests/unit_tests/test_scan_metadata.py
@@ -1,4 +1,5 @@
 from decimal import Decimal
+from typing import Set
 
 import pytest
 from bec_lib.metadata_schema import BasicScanMetadata
@@ -8,6 +9,7 @@ from qtpy.QtCore import QItemSelectionModel, QPoint, Qt
 
 from bec_widgets.utils.forms_from_types.items import (
     BoolMetadataField,
+    DictMetadataField,
     DynamicFormItem,
     FloatDecimalMetadataField,
     IntMetadataField,
@@ -34,12 +36,13 @@ class ExampleSchema(BasicScanMetadata):
     int_nodefault_optional: int | None = Field(lt=-1, ge=-44)
     float_nodefault: float
     decimal_dp_limits_nodefault: Decimal = Field(Decimal(1.23), decimal_places=2, gt=1, le=34.5)
-    unsupported_class: Json = Field(default_factory=dict)
+    dict_default: dict = Field(default_factory=dict)
+    unsupported_class: Json = Field(default=set())
 
 
 TEST_DICT = {
     "sample_name": "test name",
-    "str_optional": None,
+    "str_optional": "None",
     "str_required": "something",
     "bool_optional": None,
     "bool_required_default": True,
@@ -47,8 +50,9 @@ TEST_DICT = {
     "int_default": 21,
     "int_nodefault_optional": -10,
     "float_nodefault": pytest.approx(0.1),
-    "decimal_dp_limits_nodefault": pytest.approx(34),
-    "unsupported_class": '{"key": "value"}',
+    "decimal_dp_limits_nodefault": pytest.approx(34.5),
+    "dict_default": {"test_dict": "values"},
+    "unsupported_class": '["set", "item"]',
 }
 
 
@@ -82,7 +86,8 @@ def metadata_widget(empty_metadata_widget: ScanMetadata):
     int_nodefault_optional = widget._form_grid.layout().itemAtPosition(7, 1).widget()
     float_nodefault = widget._form_grid.layout().itemAtPosition(8, 1).widget()
     decimal_dp_limits_nodefault = widget._form_grid.layout().itemAtPosition(9, 1).widget()
-    unsupported_class = widget._form_grid.layout().itemAtPosition(10, 1).widget()
+    dict_default = widget._form_grid.layout().itemAtPosition(10, 1).widget()
+    unsupported_class = widget._form_grid.layout().itemAtPosition(11, 1).widget()
 
     yield (
         widget,
@@ -97,6 +102,7 @@ def metadata_widget(empty_metadata_widget: ScanMetadata):
             "int_nodefault_optional": int_nodefault_optional,
             "float_nodefault": float_nodefault,
             "decimal_dp_limits_nodefault": decimal_dp_limits_nodefault,
+            "dict_default": dict_default,
             "unsupported_class": unsupported_class,
         },
     )
@@ -112,7 +118,8 @@ def fill_commponents(components: dict[str, DynamicFormItem]):
     components["int_nodefault_optional"].setValue(-10)
     components["float_nodefault"].setValue(0.1)
     components["decimal_dp_limits_nodefault"].setValue(456.789)
-    components["unsupported_class"].setValue(r'{"key": "value"}')
+    components["dict_default"].setValue({"test_dict": "values"})
+    components["unsupported_class"].setValue(r'["set", "item"]')
 
 
 def test_griditems_are_correct_class(
@@ -129,6 +136,7 @@ def test_griditems_are_correct_class(
     assert isinstance(components["int_nodefault_optional"], IntMetadataField)
     assert isinstance(components["float_nodefault"], FloatDecimalMetadataField)
     assert isinstance(components["decimal_dp_limits_nodefault"], FloatDecimalMetadataField)
+    assert isinstance(components["dict_default"], DictMetadataField)
     assert isinstance(components["unsupported_class"], StrMetadataField)
 
 
@@ -168,8 +176,8 @@ def test_numbers_clipped_to_limits(
     fill_commponents(components)
 
     components["decimal_dp_limits_nodefault"].setValue(-56)
+    assert components["decimal_dp_limits_nodefault"].getValue() == pytest.approx(1.01)
     widget.validate_form()
-    assert components["decimal_dp_limits_nodefault"].getValue() == pytest.approx(2)
     assert widget._validity_message.text() == "No errors!"
 
 

--- a/tests/unit_tests/test_scan_metadata.py
+++ b/tests/unit_tests/test_scan_metadata.py
@@ -183,7 +183,9 @@ def test_numbers_clipped_to_limits(
 
 @pytest.fixture
 def table():
-    table = DictBackedTable([["key1", "value1"], ["key2", "value2"], ["key3", "value3"]])
+    table = DictBackedTable(
+        initial_data=[["key1", "value1"], ["key2", "value2"], ["key3", "value3"]]
+    )
     yield table
     table._table_model.deleteLater()
     table._table_view.deleteLater()

--- a/tests/unit_tests/test_scan_metadata.py
+++ b/tests/unit_tests/test_scan_metadata.py
@@ -62,12 +62,11 @@ def example_md():
 
 
 @pytest.fixture
-def empty_metadata_widget():
+def empty_metadata_widget(qtbot):
     widget = ScanMetadata()
     widget._additional_metadata._table_model._data = [["extra_field", "extra_data"]]
+    qtbot.addWidget(widget)
     yield widget
-    widget._clear_grid()
-    widget.deleteLater()
 
 
 @pytest.fixture


### PR DESCRIPTION
Closes #493 

- Adds a dictionary widget type to the generated form
- Adds "pretty display" stylesheet option for disabled generated forms to display config values
- Adds a display for the config to the device browser

For some of the originally proposed features I created #650 instead, which will help towards #495 