### PR TITLE
docs: fix build process for sphinx

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,13 +7,13 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-20.04
+  os: ubuntu-22.04
   tools:
-    python: "3.10"
+    python: "3.11"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
-   configuration: docs/conf.py
+  configuration: docs/conf.py
 
 # If using Sphinx, optionally build your docs in additional formats such as PDF
 # formats:
@@ -21,5 +21,7 @@ sphinx:
 
 # Optionally declare the Python requirements required to build your docs
 python:
-   install:
-   - requirements: docs/requirements.txt
+  install:
+    - requirements: docs/requirements.txt
+    - method: pip
+      path: .[dev]

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -7,6 +7,4 @@ sphinx-copybutton
 sphinx-inline-tabs
 myst-parser
 sphinx-design
-PySide6~=6.8.2
-bec-widgets
 tomli


### PR DESCRIPTION
Install directly from pulled GH repo instead of pypi