### PR TITLE
ci: composite actions for installing BEC Widgets

### DIFF
--- a/.github/actions/bw_install/action.yml
+++ b/.github/actions/bw_install/action.yml
@@ -1,0 +1,64 @@
+name: "BEC Widgets Install"
+description: "Install BEC Widgets and related os dependencies"
+inputs:
+  BEC_WIDGETS_BRANCH: # id of input
+    required: false
+    default: "main"
+    description: "Branch of BEC Widgets to install"
+  BEC_CORE_BRANCH: # id of input
+    required: false
+    default: "main"
+    description: "Branch of BEC Core to install"
+  OPHYD_DEVICES_BRANCH: # id of input
+    required: false
+    default: "main"
+    description: "Branch of Ophyd Devices to install"
+  PYTHON_VERSION: # id of input
+    required: false
+    default: "3.11"
+    description: "Python version to use"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Setup Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ inputs.PYTHON_VERSION }}
+
+    - name: Checkout BEC Core
+      uses: actions/checkout@v4
+      with:
+        repository: bec-project/bec
+        ref: ${{ inputs.BEC_CORE_BRANCH }}
+        path: ./bec
+
+    - name: Checkout Ophyd Devices
+      uses: actions/checkout@v4
+      with:
+        repository: bec-project/ophyd_devices
+        ref: ${{ inputs.OPHYD_DEVICES_BRANCH }}
+        path: ./ophyd_devices
+
+    - name: Checkout BEC Widgets
+      uses: actions/checkout@v4
+      with:
+        repository: bec-project/bec_widgets
+        ref: ${{ inputs.BEC_WIDGETS_BRANCH }}
+        path: ./bec_widgets
+
+    - name: Install dependencies
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libgl1 libegl1 x11-utils libxkbcommon-x11-0 libdbus-1-3 xvfb
+        sudo apt-get -y install libnss3 libxdamage1 libasound2t64 libatomic1 libxcursor1
+
+    - name: Install Python dependencies
+      shell: bash
+      run: |
+        pip install uv
+        uv pip install --system -e ./ophyd_devices
+        uv pip install --system -e ./bec/bec_lib[dev]
+        uv pip install --system -e ./bec/bec_ipython_client
+        uv pip install --system -e ./bec_widgets[dev,pyside6]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,21 @@
 name: Full CI
-on: [push, pull_request]
+on: 
+  push:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      BEC_WIDGETS_BRANCH:
+        description: 'Branch of BEC Widgets to install'
+        required: false
+        type: string
+      BEC_CORE_BRANCH:
+        description: 'Branch of BEC Core to install'
+        required: false
+        type: string
+      OPHYD_DEVICES_BRANCH:
+        description: 'Branch of Ophyd Devices to install'
+        required: false
+        type: string
 
 permissions:
   pull-requests: write
@@ -17,6 +33,10 @@ jobs:
     needs: [check_pr_status, formatter]
     if: needs.check_pr_status.outputs.branch-pr == ''
     uses: ./.github/workflows/pytest.yml
+    with:
+      BEC_WIDGETS_BRANCH: ${{ inputs.BEC_WIDGETS_BRANCH || github.head_ref }}
+      BEC_CORE_BRANCH: ${{ inputs.BEC_CORE_BRANCH || 'main' }}
+      OPHYD_DEVICES_BRANCH: ${{ inputs.OPHYD_DEVICES_BRANCH || 'main' }}
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
@@ -24,6 +44,10 @@ jobs:
     needs: [check_pr_status, formatter]
     if: needs.check_pr_status.outputs.branch-pr == ''
     uses: ./.github/workflows/pytest-matrix.yml
+    with:
+      BEC_WIDGETS_BRANCH: ${{ inputs.BEC_WIDGETS_BRANCH || github.head_ref || github.sha}}
+      BEC_CORE_BRANCH: ${{ inputs.BEC_CORE_BRANCH || 'main' }}
+      OPHYD_DEVICES_BRANCH: ${{ inputs.OPHYD_DEVICES_BRANCH || 'main' }}
 
   generate-cli-test:
     needs: [check_pr_status, formatter]

--- a/.github/workflows/pytest-matrix.yml
+++ b/.github/workflows/pytest-matrix.yml
@@ -1,5 +1,26 @@
 name: Run Pytest with different Python versions
-on: [workflow_call]
+on: 
+  workflow_call:
+    inputs:
+      pr_number:
+        description: 'Pull request number'
+        required: false
+        type: number
+      BEC_CORE_BRANCH:
+        description: 'Branch of BEC Core to install'
+        required: false
+        default: 'main'
+        type: string
+      OPHYD_DEVICES_BRANCH:
+        description: 'Branch of Ophyd Devices to install'
+        required: false
+        default: 'main'
+        type: string
+      BEC_WIDGETS_BRANCH:
+        description: 'Branch of BEC Widgets to install'
+        required: false
+        default: 'main'
+        type: string
 
 jobs:
   pytest-matrix:
@@ -9,7 +30,7 @@ jobs:
         python-version: ["3.10", "3.11", "3.12"]
 
     env:
-      CHILD_PIPELINE_BRANCH: main  # Set the branch you want for ophyd_devices
+      BEC_WIDGETS_BRANCH: main  # Set the branch you want for bec_widgets
       BEC_CORE_BRANCH: main        # Set the branch you want for bec
       OPHYD_DEVICES_BRANCH: main   # Set the branch you want for ophyd_devices
       PROJECT_PATH: ${{ github.repository }}
@@ -17,31 +38,20 @@ jobs:
       QT_QPA_PLATFORM: "offscreen"
 
     steps:
-      - uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Checkout BEC Widgets
+        uses: actions/checkout@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          repository: bec-project/bec_widgets
+          ref: ${{ inputs.BEC_WIDGETS_BRANCH }}
 
-      - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libgl1 libegl1 x11-utils libxkbcommon-x11-0 libdbus-1-3 xvfb
-          sudo apt-get -y install libnss3 libxdamage1 libasound2t64 libatomic1 libxcursor1
-
-      - name: Clone and install dependencies
-        run: |
-          echo -e "\033[35;1m Using branch $BEC_CORE_BRANCH of BEC CORE \033[0;m";
-          git clone --branch $BEC_CORE_BRANCH https://github.com/bec-project/bec.git
-          echo -e "\033[35;1m Using branch $OPHYD_DEVICES_BRANCH of OPHYD_DEVICES \033[0;m";
-          git clone --branch $OPHYD_DEVICES_BRANCH https://github.com/bec-project/ophyd_devices.git
-          export OHPYD_DEVICES_PATH=$PWD/ophyd_devices
-          pip install uv
-          uv pip install --system -e ./ophyd_devices
-          uv pip install --system -e ./bec/bec_lib[dev]
-          uv pip install --system -e ./bec/bec_ipython_client
-          uv pip install --system -e .[dev,pyside6]
+      - name: Install BEC Widgets and dependencies
+        uses: ./.github/actions/bw_install
+        with:
+          BEC_WIDGETS_BRANCH: ${{ inputs.BEC_WIDGETS_BRANCH }}
+          BEC_CORE_BRANCH: ${{ inputs.BEC_CORE_BRANCH }}
+          OPHYD_DEVICES_BRANCH: ${{ inputs.OPHYD_DEVICES_BRANCH }}
+          PYTHON_VERSION: ${{ matrix.python-version }}
 
       - name: Run Pytest
         run: |

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -6,6 +6,21 @@ on:
         description: 'Pull request number'
         required: false
         type: number
+      BEC_CORE_BRANCH:
+        description: 'Branch of BEC Core to install'
+        required: false
+        default: 'main'
+        type: string
+      OPHYD_DEVICES_BRANCH:
+        description: 'Branch of Ophyd Devices to install'
+        required: false
+        default: 'main'
+        type: string
+      BEC_WIDGETS_BRANCH:
+        description: 'Branch of BEC Widgets to install'
+        required: false
+        default: 'main'
+        type: string
     secrets:
       CODECOV_TOKEN:
         required: true
@@ -20,39 +35,23 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      CHILD_PIPELINE_BRANCH: main  # Set the branch you want for ophyd_devices
-      BEC_CORE_BRANCH: main        # Set the branch you want for bec
-      OPHYD_DEVICES_BRANCH: main   # Set the branch you want for ophyd_devices
-      PROJECT_PATH: ${{ github.repository }}
       QTWEBENGINE_DISABLE_SANDBOX: 1
       QT_QPA_PLATFORM: "offscreen"
 
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Checkout BEC Widgets
+        uses: actions/checkout@v4
         with:
-          python-version: '3.11'
+          repository: bec-project/bec_widgets
+          ref: ${{ inputs.BEC_WIDGETS_BRANCH }}
 
-      - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libgl1 libegl1 x11-utils libxkbcommon-x11-0 libdbus-1-3 xvfb
-          sudo apt-get -y install libnss3 libxdamage1 libasound2t64 libatomic1 libxcursor1
-
-      - name: Clone and install dependencies
-        run: |
-          echo -e "\033[35;1m Using branch $BEC_CORE_BRANCH of BEC CORE \033[0;m";
-          git clone --branch $BEC_CORE_BRANCH https://github.com/bec-project/bec.git
-          echo -e "\033[35;1m Using branch $OPHYD_DEVICES_BRANCH of OPHYD_DEVICES \033[0;m";
-          git clone --branch $OPHYD_DEVICES_BRANCH https://github.com/bec-project/ophyd_devices.git
-          export OHPYD_DEVICES_PATH=$PWD/ophyd_devices
-          pip install uv
-          uv pip install --system -e ./ophyd_devices
-          uv pip install --system -e ./bec/bec_lib[dev]
-          uv pip install --system -e ./bec/bec_ipython_client
-          uv pip install --system -e .[dev,pyside6]
+      - name: Install BEC Widgets and dependencies
+        uses: ./.github/actions/bw_install
+        with:
+          BEC_WIDGETS_BRANCH: ${{ inputs.BEC_WIDGETS_BRANCH }}
+          BEC_CORE_BRANCH: ${{ inputs.BEC_CORE_BRANCH }}
+          OPHYD_DEVICES_BRANCH: ${{ inputs.OPHYD_DEVICES_BRANCH }}
+          PYTHON_VERSION: 3.11
 
       - name: Run Pytest with Coverage
         id: coverage


### PR DESCRIPTION
This pull request introduces a reusable GitHub Action for installing BEC Widgets and related dependencies, and updates multiple workflows (`ci.yml`, `pytest.yml`, and `pytest-matrix.yml`) to use this action. It also enhances the workflows with support for custom branch inputs, improving flexibility and maintainability.

### New GitHub Action:
* Created a composite action in `.github/actions/bw_install/action.yml` to handle the installation of BEC Widgets, BEC Core, Ophyd Devices, and their dependencies. This includes setting up Python, checking out repositories, and installing system and Python dependencies.

### Workflow Enhancements:
* Updated `.github/workflows/ci.yml` to:
  - Add `workflow_dispatch` support with inputs for specifying branches of BEC Widgets, BEC Core, and Ophyd Devices.
  - Pass branch inputs to the `pytest.yml` and `pytest-matrix.yml` workflows.

* Updated `.github/workflows/pytest-matrix.yml` to:
  - Accept branch inputs for BEC Widgets, BEC Core, and Ophyd Devices.
  - Replace inline dependency installation with the new `bw_install` action.

* Updated `.github/workflows/pytest.yml` to:
  - Accept branch inputs for BEC Widgets, BEC Core, and Ophyd Devices.
  - Replace inline dependency installation with the new `bw_install` action.