### PR TITLE
test(e2e): add tests involving plugin repo

### DIFF
--- a/.github/workflows/end2end-conda.yml
+++ b/.github/workflows/end2end-conda.yml
@@ -12,6 +12,7 @@ jobs:
       CHILD_PIPELINE_BRANCH: main  # Set the branch you want for ophyd_devices
       BEC_CORE_BRANCH: main        # Set the branch you want for bec
       OPHYD_DEVICES_BRANCH: main   # Set the branch you want for ophyd_devices
+      PLUGIN_REPO_BRANCH: main     # Set the branch you want for the plugin repo
       PROJECT_PATH: ${{ github.repository }}
       QTWEBENGINE_DISABLE_SANDBOX: 1
       QT_QPA_PLATFORM: "offscreen"
@@ -39,10 +40,11 @@ jobs:
           echo -e "\033[35;1m Using branch $OPHYD_DEVICES_BRANCH of OPHYD_DEVICES \033[0;m";
           git clone --branch $OPHYD_DEVICES_BRANCH https://github.com/bec-project/ophyd_devices.git
           export OHPYD_DEVICES_PATH=$PWD/ophyd_devices
+          echo -e "\033[35;1m Using branch $PLUGIN_REPO_BRANCH of bec_testing_plugin \033[0;m";
+          git clone --branch $PLUGIN_REPO_BRANCH https://github.com/bec-project/bec_testing_plugin.git
           cd ./bec
           conda create -q -n test-environment python=3.11
           source ./bin/install_bec_dev.sh -t
           cd ../
-          pip install -e ./ophyd_devices
-          pip install -e .[dev,pyside6]
+          pip install -e ./ophyd_devices -e .[dev,pyside6] -e ./bec_testing_plugin
           pytest -v --files-path ./ --start-servers --random-order  ./tests/end-2-end

--- a/tests/end-2-end/conftest.py
+++ b/tests/end-2-end/conftest.py
@@ -5,9 +5,18 @@ import random
 import pytest
 
 from bec_widgets.cli.client_utils import BECGuiClient
+from bec_widgets.widgets.control.scan_control import ScanControl
 
 # pylint: disable=unused-argument
 # pylint: disable=redefined-outer-name
+
+
+@pytest.fixture(scope="function")
+def scan_control(qtbot, bec_client_lib):  # , mock_dev):
+    widget = ScanControl(client=bec_client_lib)
+    qtbot.addWidget(widget)
+    qtbot.waitExposed(widget)
+    yield widget
 
 
 @pytest.fixture(autouse=True)

--- a/tests/end-2-end/test_scan_control_e2e.py
+++ b/tests/end-2-end/test_scan_control_e2e.py
@@ -3,15 +3,6 @@ import time
 import pytest
 
 from bec_widgets.utils.widget_io import WidgetIO
-from bec_widgets.widgets.control.scan_control import ScanControl
-
-
-@pytest.fixture(scope="function")
-def scan_control(qtbot, bec_client_lib):  # , mock_dev):
-    widget = ScanControl(client=bec_client_lib)
-    qtbot.addWidget(widget)
-    qtbot.waitExposed(widget)
-    yield widget
 
 
 def test_scan_control_populate_scans_e2e(scan_control):
@@ -27,6 +18,7 @@ def test_scan_control_populate_scans_e2e(scan_control):
         "monitor_scan",
         "acquire",
         "line_scan",
+        "custom_testing_scan",
     ]
     items = [
         scan_control.comboBox_scan_selection.itemText(i)

--- a/tests/end-2-end/test_with_plugins_e2e.py
+++ b/tests/end-2-end/test_with_plugins_e2e.py
@@ -1,0 +1,89 @@
+import time
+
+import pytest
+from bec_testing_plugin.scans.metadata_schema.custom_test_scan_schema import CustomScanSchema
+from qtpy.QtWidgets import QGridLayout
+
+from bec_widgets.utils.widget_io import WidgetIO
+from bec_widgets.widgets.control.scan_control import ScanControl
+
+
+@pytest.fixture(scope="function")
+def scan_control(qtbot, bec_client_lib):  # , mock_dev):
+    widget = ScanControl(client=bec_client_lib)
+    qtbot.addWidget(widget)
+    qtbot.waitExposed(widget)
+    yield widget
+
+
+@pytest.mark.parametrize(
+    ["md", "valid"],
+    [
+        ({"treatment_description": "soaking", "treatment_temperature_k": 123}, True),
+        ({"treatment_description": "soaking", "treatment_temperature_k": "wrong type"}, False),
+        ({"treatment_description": "soaking", "wrong key": 123}, False),
+        (
+            {
+                "sample_name": "test sample",
+                "treatment_description": "soaking",
+                "treatment_temperature_k": 123,
+            },
+            True,
+        ),
+    ],
+)
+def test_scan_metadata_for_custom_scan(
+    scan_control: ScanControl, bec_client_lib, qtbot, md: dict, valid: bool
+):
+    client = bec_client_lib
+    queue = client.queue
+
+    scan_name = "custom_testing_scan"
+    kwargs = {"exp_time": 0.01, "steps": 10, "relative": True, "burst_at_each_point": 1}
+    args = {"device": "samx", "start": -5, "stop": 5}
+
+    scan_control.comboBox_scan_selection.setCurrentText(scan_name)
+
+    # Set kwargs in the UI
+    for kwarg_box in scan_control.kwarg_boxes:
+        for widget in kwarg_box.widgets:
+            for key, value in kwargs.items():
+                if widget.arg_name == key:
+                    WidgetIO.set_value(widget, value)
+                    break
+    # Set args in the UI
+    for widget in scan_control.arg_box.widgets:
+        for key, value in args.items():
+            if widget.arg_name == key:
+                WidgetIO.set_value(widget, value)
+                break
+
+    assert scan_control._metadata_form._md_schema == CustomScanSchema
+    assert not scan_control.button_run_scan.isEnabled()
+
+    def do_test():
+        # Set the metadata
+        grid: QGridLayout = scan_control._metadata_form._form_grid.layout()
+        for i in range(grid.rowCount()):  # type: ignore
+            field_name = grid.itemAtPosition(i, 0).widget().property("_model_field_name")
+            if (value_to_set := md.pop(field_name, None)) is not None:
+                grid.itemAtPosition(i, 1).widget().setValue(value_to_set)
+        # all values should be used
+        assert md == {}
+        assert scan_control.button_run_scan.isEnabled()
+
+        # Run the scan
+        scan_control.button_run_scan.click()
+        time.sleep(2)
+
+        last_scan = queue.scan_storage.storage[-1]
+        assert last_scan.status_message.info["scan_name"] == scan_name
+        assert last_scan.status_message.info["exp_time"] == kwargs["exp_time"]
+        assert last_scan.status_message.info["scan_motors"] == [args["device"]]
+        assert last_scan.status_message.info["num_points"] == kwargs["steps"]
+
+    if valid:
+        do_test()
+    else:
+        with pytest.raises(Exception):
+            do_test()


### PR DESCRIPTION
## Description

Add e2e tests using the new testing plugin repository https://github.com/bec-project/bec_testing_plugin

In particular, an e2e test using the ScanControl widget for a custom scan with a metadata schema, both loaded for the plugin repository, which completes successfully when the right values are filled in and raises errors when they are not.

This is intended just to be a starting point for further integration with the plugin repos and to help us test template changes and plugin tools in the future
