### PR TITLE
fix: guard plugin repo import in e2e test

### DIFF
--- a/tests/end-2-end/test_with_plugins_e2e.py
+++ b/tests/end-2-end/test_with_plugins_e2e.py
@@ -1,7 +1,12 @@
 import time
 
 import pytest
-from bec_testing_plugin.scans.metadata_schema.custom_test_scan_schema import CustomScanSchema
+
+try:
+    from bec_testing_plugin.scans.metadata_schema.custom_test_scan_schema import CustomScanSchema
+except ImportError:
+    pytest.skip(reason="Requires plugin repo!", allow_module_level=True)
+
 from qtpy.QtWidgets import QGridLayout
 
 from bec_widgets.utils.widget_io import WidgetIO


### PR DESCRIPTION
To avoid errors in test collection when the plugin repo is not installed