### PR TITLE
fix: make registry update log message debug level

### DIFF
--- a/bec_widgets/utils/rpc_server.py
+++ b/bec_widgets/utils/rpc_server.py
@@ -195,7 +195,7 @@ class RPCServer:
             return
         self._broadcasted_data = data
 
-        logger.info(f"Broadcasting registry update: {data} for {self.gui_id}")
+        logger.debug(f"Broadcasting registry update: {data} for {self.gui_id}")
         self.client.connector.xadd(
             MessageEndpoints.gui_registry_state(self.gui_id),
             msg_dict={"data": messages.GUIRegistryStateMessage(state=data)},


### PR DESCRIPTION
## Description
changes the logging level of the registry update message from `info` to `debug`