### PR TITLE
ci: check for disallowed imports from PySide

### DIFF
--- a/.github/workflows/formatter.yml
+++ b/.github/workflows/formatter.yml
@@ -14,10 +14,15 @@ jobs:
 
       - name: Run black and isort
         run: |
-          pip install black isort
-          pip install -e .[dev]
+          pip install uv
+          uv pip install --system black isort
+          uv pip install --system -e .[dev]
           black --check --diff --color .
           isort --check --diff ./
+      
+      - name: Check for disallowed imports from PySide
+        run: '! grep -re "from PySide6\." bec_widgets/ | grep  -v -e "PySide6.QtDesigner" -e "PySide6.scripts"'
+
   Pylint:
     runs-on: ubuntu-latest
 

--- a/bec_widgets/utils/settings_dialog.py
+++ b/bec_widgets/utils/settings_dialog.py
@@ -1,5 +1,5 @@
 from bec_lib.logger import bec_logger
-from PySide6.QtGui import QCloseEvent
+from qtpy.QtGui import QCloseEvent
 from qtpy.QtWidgets import QDialog, QDialogButtonBox, QHBoxLayout, QPushButton, QVBoxLayout, QWidget
 
 from bec_widgets.utils.error_popups import SafeSlot

--- a/bec_widgets/utils/ui_loader.py
+++ b/bec_widgets/utils/ui_loader.py
@@ -9,7 +9,7 @@ from bec_widgets.utils.plugin_utils import get_custom_classes
 logger = bec_logger.logger
 
 if PYSIDE6:
-    from PySide6.QtUiTools import QUiLoader
+    from qtpy.QtUiTools import QUiLoader
 
     class CustomUiLoader(QUiLoader):
         def __init__(self, baseinstance, custom_widgets: dict | None = None):


### PR DESCRIPTION
Add a CI formatter step which errors if we import from `PySide6`, except for designer plugins

See before removing such imports: https://github.com/bec-project/bec_widgets/actions/runs/15416417469/job/43380153263
After: https://github.com/bec-project/bec_widgets/actions/runs/15416471105/job/43380326928