### PR TITLE
fix(crosshair): emitted name from crosshair 2D is objectName of image or its id

### DIFF
--- a/bec_widgets/utils/crosshair.py
+++ b/bec_widgets/utils/crosshair.py
@@ -312,7 +312,7 @@ class Crosshair(QObject):
                     y_values[name] = closest_y
                     x_values[name] = closest_x
             elif isinstance(item, pg.ImageItem):  # 2D plot
-                name = item.config.monitor or str(id(item))
+                name = item.objectName() or str(id(item))
                 image_2d = item.image
                 if image_2d is None:
                     continue
@@ -400,7 +400,7 @@ class Crosshair(QObject):
                     )
                     self.coordinatesChanged1D.emit(coordinate_to_emit)
                 elif isinstance(item, pg.ImageItem):
-                    name = item.config.monitor or str(id(item))
+                    name = item.objectName() or str(id(item))
                     x, y = x_snap_values[name], y_snap_values[name]
                     if x is None or y is None:
                         continue

--- a/tests/unit_tests/test_crosshair.py
+++ b/tests/unit_tests/test_crosshair.py
@@ -29,7 +29,6 @@ def image_widget_with_crosshair(qtbot):
 
     image_item = pg.ImageItem()
     image_item.setImage(np.random.rand(100, 100))
-    image_item.config = type("obj", (object,), {"monitor": "test"})
 
     widget.addItem(image_item)
     plot_item = widget.getPlotItem()
@@ -99,6 +98,7 @@ def test_mouse_moved_signals_outside(plot_widget_with_crosshair):
 
 def test_mouse_moved_signals_2D(image_widget_with_crosshair):
     crosshair, plot_item = image_widget_with_crosshair
+    image_item = plot_item.items[0]
 
     emitted_values_2D = []
 
@@ -113,7 +113,7 @@ def test_mouse_moved_signals_2D(image_widget_with_crosshair):
 
     crosshair.mouse_moved(event_mock)
 
-    assert emitted_values_2D == [("test", 21, 55)]
+    assert emitted_values_2D == [(str(id(image_item)), 21, 55)]
 
 
 def test_mouse_moved_signals_2D_outside(image_widget_with_crosshair):


### PR DESCRIPTION
## Description

Fixes bug introduced with new Image base. Currently image items are not holding the monitor info in config, which was fetched for crosshair as identifier. Now it is fetching object name or id. 

## Related Issues

- closes #688 