### PR TITLE
ROI mouse lock/unlock

### DIFF
--- a/bec_widgets/cli/client.py
+++ b/bec_widgets/cli/client.py
@@ -532,6 +532,26 @@ class BaseROI(RPCBase):
 
     @property
     @rpc_call
+    def movable(self) -> "bool":
+        """
+        Gets whether this ROI is movable.
+
+        Returns:
+            bool: True if the ROI can be moved, False otherwise.
+        """
+
+    @movable.setter
+    @rpc_call
+    def movable(self) -> "bool":
+        """
+        Gets whether this ROI is movable.
+
+        Returns:
+            bool: True if the ROI can be moved, False otherwise.
+        """
+
+    @property
+    @rpc_call
     def line_color(self) -> "str":
         """
         Gets the current line color of the ROI.
@@ -637,6 +657,26 @@ class CircularROI(RPCBase):
 
         Returns:
             str: The current name of the ROI.
+        """
+
+    @property
+    @rpc_call
+    def movable(self) -> "bool":
+        """
+        Gets whether this ROI is movable.
+
+        Returns:
+            bool: True if the ROI can be moved, False otherwise.
+        """
+
+    @movable.setter
+    @rpc_call
+    def movable(self) -> "bool":
+        """
+        Gets whether this ROI is movable.
+
+        Returns:
+            bool: True if the ROI can be moved, False otherwise.
         """
 
     @property
@@ -1494,6 +1534,7 @@ class Image(RPCBase):
         line_width: "int | None" = 5,
         pos: "tuple[float, float] | None" = (10, 10),
         size: "tuple[float, float] | None" = (50, 50),
+        movable: "bool" = True,
         **pg_kwargs,
     ) -> "RectangularROI | CircularROI":
         """
@@ -1505,6 +1546,7 @@ class Image(RPCBase):
             line_width(int): The line width of the ROI.
             pos(tuple): The position of the ROI.
             size(tuple): The size of the ROI.
+            movable(bool): Whether the ROI is movable.
             **pg_kwargs: Additional arguments for the ROI.
 
         Returns:
@@ -2662,6 +2704,26 @@ class RectangularROI(RPCBase):
 
         Returns:
             str: The current name of the ROI.
+        """
+
+    @property
+    @rpc_call
+    def movable(self) -> "bool":
+        """
+        Gets whether this ROI is movable.
+
+        Returns:
+            bool: True if the ROI can be moved, False otherwise.
+        """
+
+    @movable.setter
+    @rpc_call
+    def movable(self) -> "bool":
+        """
+        Gets whether this ROI is movable.
+
+        Returns:
+            bool: True if the ROI can be moved, False otherwise.
         """
 
     @property

--- a/bec_widgets/widgets/plots/image/image_base.py
+++ b/bec_widgets/widgets/plots/image/image_base.py
@@ -559,6 +559,7 @@ class ImageBase(PlotBase):
         line_width: int | None = 5,
         pos: tuple[float, float] | None = (10, 10),
         size: tuple[float, float] | None = (50, 50),
+        movable: bool = True,
         **pg_kwargs,
     ) -> RectangularROI | CircularROI:
         """
@@ -570,6 +571,7 @@ class ImageBase(PlotBase):
             line_width(int): The line width of the ROI.
             pos(tuple): The position of the ROI.
             size(tuple): The size of the ROI.
+            movable(bool): Whether the ROI is movable.
             **pg_kwargs: Additional arguments for the ROI.
 
         Returns:
@@ -584,6 +586,7 @@ class ImageBase(PlotBase):
                 parent_image=self,
                 line_width=line_width,
                 label=name,
+                movable=movable,
                 **pg_kwargs,
             )
         elif kind == "circle":
@@ -593,6 +596,7 @@ class ImageBase(PlotBase):
                 parent_image=self,
                 line_width=line_width,
                 label=name,
+                movable=movable,
                 **pg_kwargs,
             )
         else:

--- a/bec_widgets/widgets/plots/image/image_base.py
+++ b/bec_widgets/widgets/plots/image/image_base.py
@@ -601,7 +601,6 @@ class ImageBase(PlotBase):
         # Add to plot and controller (controller assigns color)
         self.plot_item.addItem(roi)
         self.roi_controller.add_roi(roi)
-        roi.add_scale_handle()
         return roi
 
     def remove_roi(self, roi: int | str):

--- a/bec_widgets/widgets/plots/image/setting_widgets/image_roi_tree.py
+++ b/bec_widgets/widgets/plots/image/setting_widgets/image_roi_tree.py
@@ -8,6 +8,7 @@ from qtpy.QtCore import QEvent, Qt
 from qtpy.QtGui import QColor
 from qtpy.QtWidgets import (
     QColorDialog,
+    QHBoxLayout,
     QHeaderView,
     QSpinBox,
     QToolButton,
@@ -33,6 +34,28 @@ from bec_widgets.widgets.utility.visual.colormap_widget.colormap_widget import B
 
 if TYPE_CHECKING:
     from bec_widgets.widgets.plots.image.image import Image
+
+
+class ROILockButton(QToolButton):
+    """Keeps its icon and checked state in sync with a single ROI."""
+
+    def __init__(self, roi: BaseROI, parent=None):
+        super().__init__(parent)
+        self.setCheckable(True)
+        self._roi = roi
+        self.clicked.connect(self._toggle)
+        roi.movableChanged.connect(lambda _: self._sync())
+        self._sync()
+
+    def _toggle(self):
+        # checked -> locked -> movable = False
+        self._roi.movable = not self.isChecked()
+
+    def _sync(self):
+        movable = self._roi.movable
+        self.setChecked(not movable)
+        icon = "lock_open_right" if movable else "lock"
+        self.setIcon(material_icon(icon, size=(20, 20), convert_to_pixmap=False))
 
 
 class ROIPropertyTree(BECWidget, QWidget):
@@ -124,6 +147,24 @@ class ROIPropertyTree(BECWidget, QWidget):
         self.expand_toggle.action.toggled.connect(_exp_toggled)
 
         self.expand_toggle.action.setChecked(False)
+
+        # Lock/Unlock all ROIs
+        self.lock_all_action = MaterialIconAction(
+            "lock_open_right", "Lock/Unlock all ROIs", checkable=True, parent=self
+        )
+        tb.add_action("Lock/Unlock all ROIs", self.lock_all_action, self)
+
+        def _lock_all(checked: bool):
+            # checked -> everything locked (movable = False)
+            for r in self.controller.rois:
+                r.movable = not checked
+            new_icon = material_icon(
+                "lock" if checked else "lock_open_right", size=(20, 20), convert_to_pixmap=False
+            )
+            self.lock_all_action.action.setIcon(new_icon)
+
+        self.lock_all_action.action.toggled.connect(_lock_all)
+
         # colormap widget
         self.cmap = BECColorMapWidget(cmap=self.controller.colormap)
         tb.addWidget(QWidget())  # spacer
@@ -241,11 +282,24 @@ class ROIPropertyTree(BECWidget, QWidget):
 
     # --------------------------------------------------------- controller slots
     def _on_roi_added(self, roi: BaseROI):
+        # check the global setting from the toolbar
+        if self.lock_all_action.action.isChecked():
+            roi.movable = False
         # parent row with blank action column, name in ROI column
         parent = QTreeWidgetItem(self.tree, ["", "", ""])
         parent.setText(self.COL_ROI, roi.label)
         parent.setFlags(parent.flags() | Qt.ItemIsEditable)
-        # --- delete button in actions column ---
+        # --- actions widget (lock/unlock + delete) ---
+        actions_widget = QWidget()
+        actions_layout = QHBoxLayout(actions_widget)
+        actions_layout.setContentsMargins(0, 0, 0, 0)
+        actions_layout.setSpacing(3)
+
+        # lock / unlock toggle
+        lock_btn = ROILockButton(roi, parent=self)
+        actions_layout.addWidget(lock_btn)
+
+        # delete button
         del_btn = QToolButton()
         delete_icon = material_icon(
             "delete",
@@ -255,8 +309,11 @@ class ROIPropertyTree(BECWidget, QWidget):
             color=self.DELETE_BUTTON_COLOR,
         )
         del_btn.setIcon(delete_icon)
-        self.tree.setItemWidget(parent, self.COL_ACTION, del_btn)
         del_btn.clicked.connect(lambda _=None, r=roi: self._delete_roi(r))
+        actions_layout.addWidget(del_btn)
+
+        # install composite widget into the tree
+        self.tree.setItemWidget(parent, self.COL_ACTION, actions_widget)
         # color button
         color_btn = ColorButtonNative(parent=self, color=roi.line_color)
         self.tree.setItemWidget(parent, self.COL_PROPS, color_btn)
@@ -308,6 +365,12 @@ class ROIPropertyTree(BECWidget, QWidget):
         for c in range(3):
             self.tree.resizeColumnToContents(c)
 
+    def _toggle_movable(self, roi: BaseROI):
+        """
+        Toggle the `movable` property of the given ROI.
+        """
+        roi.movable = not roi.movable
+
     def _on_roi_removed(self, roi: BaseROI):
         item = self.roi_items.pop(roi, None)
         if item:
@@ -344,7 +407,7 @@ if __name__ == "__main__":  # pragma: no cover
     import sys
 
     import numpy as np
-    from qtpy.QtWidgets import QApplication, QHBoxLayout, QVBoxLayout
+    from qtpy.QtWidgets import QApplication
 
     from bec_widgets.widgets.plots.image.image import Image
 

--- a/bec_widgets/widgets/plots/image/setting_widgets/image_roi_tree.py
+++ b/bec_widgets/widgets/plots/image/setting_widgets/image_roi_tree.py
@@ -235,7 +235,6 @@ class ROIPropertyTree(BECWidget, QWidget):
             self._temp_roi = None
             self._set_roi_draw_mode(None)
             # register via controller
-            final_roi.add_scale_handle()
             self.controller.add_roi(final_roi)
             return True
         return super().eventFilter(obj, event)

--- a/bec_widgets/widgets/plots/roi/image_roi.py
+++ b/bec_widgets/widgets/plots/roi/image_roi.py
@@ -127,6 +127,7 @@ class BaseROI(BECConnector):
         label: str | None = None,
         line_color: str | None = None,
         line_width: int = 5,
+        movable: bool = True,
         # all remaining pg.*ROI kwargs (pos, size, pen, …)
         **pg_kwargs,
     ):
@@ -155,6 +156,7 @@ class BaseROI(BECConnector):
             gui_id=gui_id,
             removable=True,
             invertible=True,
+            movable=movable,
             **pg_kwargs,
         )
 
@@ -162,7 +164,12 @@ class BaseROI(BECConnector):
         self._line_color = line_color or "#ffffff"
         self._line_width = line_width
         self._description = True
+        self._movable = True  # allow moving by default
         self.setPen(mkPen(self._line_color, width=self._line_width))
+
+        # Reset Handles to avoid inherited handles from pyqtgraph
+        self.remove_scale_handles()  # remove any existing handles from pyqtgraph.RectROI
+        self.add_scale_handle()  # add custom scale handles
 
     def set_parent(self, parent: Image):
         """
@@ -337,7 +344,17 @@ class BaseROI(BECConnector):
         )
 
     def add_scale_handle(self):
+        """Add scale handles to the ROI."""
         return
+
+    def remove_scale_handles(self):
+        """Remove all scale handles from the ROI."""
+        handles = self.handles
+        for i in range(len(handles)):
+            try:
+                self.removeHandle(0)
+            except IndexError:
+                continue
 
     def set_position(self, x: float, y: float):
         """
@@ -355,12 +372,7 @@ class BaseROI(BECConnector):
         if controller and self in controller.rois:
             controller.remove_roi(self)
             return  # controller will call back into this method once deregistered
-        handles = self.handles
-        for i in range(len(handles)):
-            try:
-                self.removeHandle(0)
-            except IndexError:
-                continue
+        self.remove_scale_handles()
         self.rpc_register.remove_rpc(self)
         self.parent_image.plot_item.removeItem(self)
         viewBox = self.parent_plot_item.vb
@@ -474,11 +486,6 @@ class RectangularROI(BaseROI, pg.RectROI):
         self.addScaleHandle([0.5, 1], [0.5, 0])  # bottom edge
         self.addScaleHandle([0, 0.5], [1, 0.5])  # left edge
         self.addScaleHandle([1, 0.5], [0, 0.5])  # right edge
-
-        self.handlePen = fn.mkPen("#ffff00", width=5)  # bright yellow outline
-        self.handleHoverPen = fn.mkPen("#00ffff", width=4)  # cyan, thicker when hovered
-        self.handleBrush = (200, 200, 0, 120)  # semi-transparent fill
-        self.handleHoverBrush = (0, 255, 255, 160)
 
     def _on_region_changed(self):
         """
@@ -616,6 +623,14 @@ class CircularROI(BaseROI, pg.CircleROI):
         )
         self.sigRegionChanged.connect(self._on_region_changed)
         self._adorner = LabelAdorner(self)
+        self.hoverPen = fn.mkPen(color=(255, 0, 0), width=3, style=QtCore.Qt.DashLine)
+        self.handleHoverPen = fn.mkPen("lime", width=4)
+
+    def add_scale_handle(self):
+        """
+        Adds scale handles to the circular ROI.
+        """
+        self._addHandles()  # wrapper around pg.CircleROI._addHandles
 
     def _on_region_changed(self):
         """

--- a/bec_widgets/widgets/plots/roi/image_roi.py
+++ b/bec_widgets/widgets/plots/roi/image_roi.py
@@ -107,6 +107,8 @@ class BaseROI(BECConnector):
     USER_ACCESS = [
         "label",
         "label.setter",
+        "movable",
+        "movable.setter",
         "line_color",
         "line_color.setter",
         "line_width",
@@ -164,12 +166,13 @@ class BaseROI(BECConnector):
         self._line_color = line_color or "#ffffff"
         self._line_width = line_width
         self._description = True
-        self._movable = True  # allow moving by default
+        self._movable = movable
         self.setPen(mkPen(self._line_color, width=self._line_width))
 
         # Reset Handles to avoid inherited handles from pyqtgraph
         self.remove_scale_handles()  # remove any existing handles from pyqtgraph.RectROI
-        self.add_scale_handle()  # add custom scale handles
+        if movable:
+            self.add_scale_handle()  # add custom scale handles
 
     def set_parent(self, parent: Image):
         """
@@ -188,6 +191,39 @@ class BaseROI(BECConnector):
             Image: The parent image object, or None if no parent is set.
         """
         return self.parent_image
+
+    @property
+    def movable(self) -> bool:
+        """
+        Gets whether this ROI is movable.
+
+        Returns:
+            bool: True if the ROI can be moved, False otherwise.
+        """
+        return self._movable
+
+    @movable.setter
+    def movable(self, value: bool):
+        """
+        Sets whether this ROI is movable.
+
+        If the new value is different from the current value, this method updates
+        the internal state and emits the penChanged signal.
+
+        Args:
+            value (bool): True to make the ROI movable, False to make it fixed.
+        """
+        if value != self._movable:
+            self._movable = value
+            # All relevant properties from pyqtgraph to block movement
+            self.translatable = value
+            self.rotatable = value
+            self.resizable = value
+            self.removable = value
+            if value:
+                self.add_scale_handle()  # add custom scale handles
+            else:
+                self.remove_scale_handles()  # remove custom scale handles
 
     @property
     def label(self) -> str:
@@ -411,6 +447,7 @@ class RectangularROI(BaseROI, pg.RectROI):
         label: str | None = None,
         line_color: str | None = None,
         line_width: int = 5,
+        movable: bool = True,
         resize_handles: bool = True,
         **extra_pg,
     ):
@@ -441,6 +478,7 @@ class RectangularROI(BaseROI, pg.RectROI):
             pos=pos,
             size=size,
             pen=pen,
+            movable=movable,
             **extra_pg,
         )
 
@@ -588,6 +626,7 @@ class CircularROI(BaseROI, pg.CircleROI):
         label: str | None = None,
         line_color: str | None = None,
         line_width: int = 5,
+        movable: bool = True,
         **extra_pg,
     ):
         """
@@ -619,6 +658,7 @@ class CircularROI(BaseROI, pg.CircleROI):
             pos=pos,
             size=size,
             pen=pen,
+            movable=movable,
             **extra_pg,
         )
         self.sigRegionChanged.connect(self._on_region_changed)

--- a/bec_widgets/widgets/plots/roi/image_roi.py
+++ b/bec_widgets/widgets/plots/roi/image_roi.py
@@ -104,6 +104,7 @@ class BaseROI(BECConnector):
 
     nameChanged = Signal(str)
     penChanged = Signal()
+    movableChanged = Signal(bool)
     USER_ACCESS = [
         "label",
         "label.setter",
@@ -224,6 +225,7 @@ class BaseROI(BECConnector):
                 self.add_scale_handle()  # add custom scale handles
             else:
                 self.remove_scale_handles()  # remove custom scale handles
+            self.movableChanged.emit(value)
 
     @property
     def label(self) -> str:

--- a/tests/unit_tests/test_image_roi_tree.py
+++ b/tests/unit_tests/test_image_roi_tree.py
@@ -148,10 +148,10 @@ def test_delete_roi_button(roi_tree, image_widget, qtbot):
     roi = image_widget.add_roi(kind="rect", name="to_delete")
     item = roi_tree.roi_items[roi]
 
-    # Get the delete button
-    del_btn = roi_tree.tree.itemWidget(item, roi_tree.COL_ACTION)
+    action_widget = roi_tree.tree.itemWidget(item, roi_tree.COL_ACTION)
+    layout = action_widget.layout()
 
-    # Click the delete button
+    del_btn = layout.itemAt(1).widget()
     del_btn.click()
     qtbot.wait(200)
 
@@ -331,3 +331,67 @@ def test_add_roi_from_toolbar(qtbot, mocked_client):
 
     # Verify it's a circle ROI
     assert isinstance(new_roi, CircularROI)
+
+
+def test_roi_lock_button(roi_tree, image_widget, qtbot):
+    """Verify the individual lock button toggles ROI.movable."""
+    roi = image_widget.add_roi(kind="rect", name="lock_test")
+    item = roi_tree.roi_items[roi]
+
+    # Lock button is the first widget in the Actions layout
+    action_widget = roi_tree.tree.itemWidget(item, roi_tree.COL_ACTION)
+    lock_btn = action_widget.layout().itemAt(0).widget()
+
+    # Initially unlocked
+    assert roi.movable
+    assert not lock_btn.isChecked()
+
+    # Lock it
+    lock_btn.click()
+    qtbot.wait(200)
+    assert not roi.movable
+    assert lock_btn.isChecked()
+
+    # Unlock again
+    lock_btn.click()
+    qtbot.wait(200)
+    assert roi.movable
+    assert not lock_btn.isChecked()
+
+
+def test_global_lock_all_button(roi_tree, image_widget, qtbot):
+    """Verify the toolbar lock-all action locks/unlocks every ROI."""
+    roi1 = image_widget.add_roi(kind="rect", name="g1")
+    roi2 = image_widget.add_roi(kind="circle", name="g2")
+
+    lock_all = roi_tree.lock_all_action.action
+
+    # Start unlocked
+    assert roi1.movable and roi2.movable
+    assert not lock_all.isChecked()
+
+    # Toggle → lock everything
+    lock_all.trigger()
+    qtbot.wait(200)
+    assert lock_all.isChecked()
+    assert not roi1.movable and not roi2.movable
+
+    # Toggle again → unlock everything
+    lock_all.trigger()
+    qtbot.wait(200)
+    assert not lock_all.isChecked()
+    assert roi1.movable and roi2.movable
+
+
+def test_new_roi_respects_global_lock(roi_tree, image_widget, qtbot):
+    """When the global lock-all toggle is active, newly added ROIs start locked."""
+    # Enable global lock
+    roi_tree.lock_all_action.action.setChecked(True)
+    qtbot.wait(100)
+
+    # Add ROI after lock enabled
+    roi = image_widget.add_roi(kind="rect", name="new_locked")
+
+    assert not roi.movable
+    # Disable global lock again
+    roi_tree.lock_all_action.action.setChecked(False)

--- a/tests/unit_tests/test_image_rois.py
+++ b/tests/unit_tests/test_image_rois.py
@@ -205,3 +205,29 @@ def test_roi_set_position(bec_image_widget_with_roi):
         pos = roi.pos()
         assert int(pos.x()) == 10
         assert int(pos.y()) == 15
+
+
+def test_roi_movable_property(bec_image_widget_with_roi, qtbot):
+    """Verify BaseROI.movable toggles flags, handles, and emits a signal."""
+    _widget, roi, _ = bec_image_widget_with_roi
+
+    # defaults – ROI is movable
+    assert roi.movable
+    assert roi.translatable and roi.rotatable and roi.resizable and roi.removable
+    assert len(roi.handles) > 0
+
+    # lock it
+    with qtbot.waitSignal(roi.movableChanged) as blocker:
+        roi.movable = False
+    assert blocker.args == [False]
+    assert not roi.movable
+    assert not (roi.translatable or roi.rotatable or roi.resizable or roi.removable)
+    assert len(roi.handles) == 0
+
+    # unlock again
+    with qtbot.waitSignal(roi.movableChanged) as blocker:
+        roi.movable = True
+    assert blocker.args == [True]
+    assert roi.movable
+    assert roi.translatable and roi.rotatable and roi.resizable and roi.removable
+    assert len(roi.handles) > 0


### PR DESCRIPTION
## Description

Option to disable moving rois by mouse.

## Related Issues

- closes #639 

## Type of Change

- ROIs can be locked from RPC and during creation
- ROIs can be locked/unlocked through Gui Tree manager in Image widget

## How to test

- Add some rois to the image widget
- lock/unlock them by GUI or by `roi.movable:bool`