### PR TITLE
Scroll Label expire from ClientInfoMessage

### DIFF
--- a/bec_widgets/widgets/containers/main_window/addons/scroll_label.py
+++ b/bec_widgets/widgets/containers/main_window/addons/scroll_label.py
@@ -25,17 +25,29 @@ class ScrollLabel(QLabel):
         self._step_px = step_px
 
     def setText(self, text):
+        """
+        Overridden to ensure that new text replaces the current one
+        immediately.
+        If the label was already scrolling (or in its delay phase),
+        the next message starts **without** the extra delay.
+        """
+        # Determine whether the widget was already in a scrolling cycle
+        was_scrolling = self._timer.isActive() or self._delay_timer.isActive()
+
         super().setText(text)
+
         fm = QFontMetrics(self.font())
         self._text_width = fm.horizontalAdvance(text)
         self._offset = 0
-        self._update_timer()
+
+        # Skip the delay when we were already scrolling
+        self._update_timer(skip_delay=was_scrolling)
 
     def resizeEvent(self, event):
         super().resizeEvent(event)
         self._update_timer()
 
-    def _update_timer(self):
+    def _update_timer(self, *, skip_delay: bool = False):
         """
         Decide whether to start or stop scrolling.
 
@@ -46,10 +58,19 @@ class ScrollLabel(QLabel):
         needs_scroll = self._text_width > self.width()
 
         if needs_scroll:
+            # Reset any running timers
             if self._timer.isActive():
                 self._timer.stop()
+            if self._delay_timer.isActive():
+                self._delay_timer.stop()
+
             self._offset = 0
-            if not self._delay_timer.isActive():
+
+            # Start scrolling immediately when we should skip the delay,
+            # otherwise apply the configured delay_ms interval
+            if skip_delay:
+                self._timer.start()
+            else:
                 self._delay_timer.start()
         else:
             if self._delay_timer.isActive():

--- a/bec_widgets/widgets/containers/main_window/main_window.py
+++ b/bec_widgets/widgets/containers/main_window/main_window.py
@@ -1,7 +1,7 @@
 import os
 
 from bec_lib.endpoints import MessageEndpoints
-from qtpy.QtCore import QEvent, QSize, Qt
+from qtpy.QtCore import QEvent, QSize, Qt, QTimer
 from qtpy.QtGui import QAction, QActionGroup, QIcon
 from qtpy.QtWidgets import QApplication, QFrame, QLabel, QMainWindow, QStyle, QVBoxLayout, QWidget
 
@@ -79,6 +79,11 @@ class BECMainWindow(BECWidget, QMainWindow):
             Qt.AlignmentFlag.AlignHCenter | Qt.AlignmentFlag.AlignVCenter
         )
         status_bar.addWidget(self._client_info_label, 1)
+
+        # Timer to automatically clear client messages once they expire
+        self._client_info_expire_timer = QTimer(self)
+        self._client_info_expire_timer.setSingleShot(True)
+        self._client_info_expire_timer.timeout.connect(lambda: self._client_info_label.setText(""))
 
     def _add_separator(self):
         """
@@ -222,8 +227,23 @@ class BECMainWindow(BECWidget, QMainWindow):
 
     @SafeSlot(dict, dict)
     def display_client_message(self, msg: dict, meta: dict):
+        """
+        Display a client message in the status bar.
+
+        Args:
+            msg(dict): The message to display, should contain:
+            meta(dict): Metadata about the message, usually empty.
+        """
+        # self._client_info_label.setText("")
         message = msg.get("message", "")
+        expiration = msg.get("expire", 0)  # 0 → never expire
         self._client_info_label.setText(message)
+
+        # Restart the expiration timer if necessary
+        if hasattr(self, "_client_info_expire_timer") and self._client_info_expire_timer.isActive():
+            self._client_info_expire_timer.stop()
+        if expiration and expiration > 0:
+            self._client_info_expire_timer.start(int(expiration * 1000))
 
     ################################################################################
     # General and Cleanup Methods
@@ -259,6 +279,8 @@ class BECMainWindow(BECWidget, QMainWindow):
                     child.close()
                     child.deleteLater()
 
+        if hasattr(self, "_client_info_expire_timer") and self._client_info_expire_timer.isActive():
+            self._client_info_expire_timer.stop()
         # Status bar widgets cleanup
         self._client_info_label.cleanup()
         super().cleanup()
@@ -266,3 +288,12 @@ class BECMainWindow(BECWidget, QMainWindow):
 
 class UILaunchWindow(BECMainWindow):
     RPC = True
+
+
+if __name__ == "__main__":
+    import sys
+
+    app = QApplication(sys.argv)
+    main_window = UILaunchWindow()
+    main_window.show()
+    sys.exit(app.exec())

--- a/tests/unit_tests/test_main_widnow.py
+++ b/tests/unit_tests/test_main_widnow.py
@@ -112,6 +112,60 @@ def test_scroll_label_paint_event(qtbot):
     assert not pixmap.isNull()
 
 
+def test_display_client_message_with_expiration(qtbot, bec_main_window):
+    """
+    A message with a finite 'expire' value should disappear once the timer
+    fires.
+    """
+    test_msg = "This message should vanish fast"
+    expire_sec = 0.2
+
+    bec_main_window.display_client_message({"message": test_msg, "expire": expire_sec}, {})
+
+    assert bec_main_window._client_info_expire_timer.isActive()
+    assert bec_main_window._client_info_label.text() == test_msg
+
+    qtbot.waitUntil(lambda: not bec_main_window._client_info_expire_timer.isActive(), timeout=1000)
+
+    assert bec_main_window._client_info_label.text() == ""
+
+
+def test_display_client_message_no_expiration(qtbot, bec_main_window):
+    """
+    A message with 'expire' == 0 must persist and never start the timer.
+    """
+    test_msg = "Persistent status message"
+
+    bec_main_window.display_client_message({"message": test_msg, "expire": 0}, {})
+
+    assert not bec_main_window._client_info_expire_timer.isActive()
+    assert bec_main_window._client_info_label.text() == test_msg
+
+    qtbot.wait(500)
+    assert bec_main_window._client_info_label.text() == test_msg
+
+
+def test_display_client_message_overwrite_resets_timer(qtbot, bec_main_window):
+    """
+    Sending a second message while the expiration timer is active should
+    overwrite the first and stop the timer if the second one is persistent.
+    """
+    first_msg = "First (temporary)"
+    second_msg = "Second (persistent)"
+
+    bec_main_window.display_client_message({"message": first_msg, "expire": 0.3}, {})
+    qtbot.wait(200)
+    assert bec_main_window._client_info_expire_timer.isActive()
+
+    bec_main_window.display_client_message({"message": second_msg, "expire": 0}, {})
+
+    assert not bec_main_window._client_info_expire_timer.isActive()
+    assert bec_main_window._client_info_label.text() == second_msg
+
+    qtbot.wait(400)
+    assert bec_main_window._client_info_label.text() == second_msg
+
+
 #################################################################
 # Tests for BECWebLinksMixin (webbrowser opening)
 


### PR DESCRIPTION
## Description

Add expiration time from the ClientInfoMessage and fix small bug when you update message to label to not wait for scroll timer.

## Related Issues

- closes #705 

## How to test

- Push some messages with expire time, default is 60s 
