### PR TITLE
Feature/scan progress bar - implementation to BECMainWindow

### DIFF
--- a/bec_widgets/applications/launch_window.py
+++ b/bec_widgets/applications/launch_window.py
@@ -542,7 +542,7 @@ class LaunchWindow(BECMainWindow):
         remaining_connections = [
             connection for connection in connections.values() if connection.parent_id != self.gui_id
         ]
-        return len(remaining_connections) <= 1
+        return len(remaining_connections) <= 2
 
     def _turn_off_the_lights(self, connections: dict):
         """

--- a/bec_widgets/cli/client.py
+++ b/bec_widgets/cli/client.py
@@ -474,6 +474,20 @@ class BECProgressBar(RPCBase):
         >>> progressbar.label_template = "$value / $percentage %"
         """
 
+    @property
+    @rpc_call
+    def state(self):
+        """
+        None
+        """
+
+    @state.setter
+    @rpc_call
+    def state(self):
+        """
+        None
+        """
+
     @rpc_call
     def _get_label(self) -> str:
         """

--- a/bec_widgets/cli/client.py
+++ b/bec_widgets/cli/client.py
@@ -3245,6 +3245,16 @@ class ScanControl(RPCBase):
         """
 
 
+class ScanProgressBar(RPCBase):
+    """Widget to display a progress bar that is hooked up to the scan progress of a scan."""
+
+    @rpc_call
+    def remove(self):
+        """
+        Cleanup the BECConnector
+        """
+
+
 class ScatterCurve(RPCBase):
     """Scatter curve item for the scatter waveform widget."""
 

--- a/bec_widgets/widgets/containers/main_window/main_window.py
+++ b/bec_widgets/widgets/containers/main_window/main_window.py
@@ -13,6 +13,7 @@ from bec_widgets.utils.error_popups import SafeSlot
 from bec_widgets.utils.widget_io import WidgetHierarchy
 from bec_widgets.widgets.containers.main_window.addons.scroll_label import ScrollLabel
 from bec_widgets.widgets.containers.main_window.addons.web_links import BECWebLinksMixin
+from bec_widgets.widgets.progress.scan_progressbar.scan_progressbar import ScanProgressBar
 
 MODULE_PATH = os.path.dirname(bec_widgets.__file__)
 
@@ -84,6 +85,12 @@ class BECMainWindow(BECWidget, QMainWindow):
         self._client_info_expire_timer = QTimer(self)
         self._client_info_expire_timer.setSingleShot(True)
         self._client_info_expire_timer.timeout.connect(lambda: self._client_info_label.setText(""))
+
+        self._add_separator()
+        self._scan_progress_bar = ScanProgressBar(self, one_line_design=True)
+        self._scan_progress_bar.show_elapsed_time = False
+        self._scan_progress_bar.show_remaining_time = False
+        status_bar.addWidget(self._scan_progress_bar)
 
     def _add_separator(self):
         """
@@ -283,6 +290,8 @@ class BECMainWindow(BECWidget, QMainWindow):
             self._client_info_expire_timer.stop()
         # Status bar widgets cleanup
         self._client_info_label.cleanup()
+        self._scan_progress_bar.close()
+        self._scan_progress_bar.deleteLater()
         super().cleanup()
 
 
@@ -296,4 +305,5 @@ if __name__ == "__main__":
     app = QApplication(sys.argv)
     main_window = UILaunchWindow()
     main_window.show()
+    main_window.resize(800, 600)
     sys.exit(app.exec())

--- a/bec_widgets/widgets/containers/main_window/main_window.py
+++ b/bec_widgets/widgets/containers/main_window/main_window.py
@@ -90,6 +90,10 @@ class BECMainWindow(BECWidget, QMainWindow):
         self._scan_progress_bar = ScanProgressBar(self, one_line_design=True)
         self._scan_progress_bar.show_elapsed_time = False
         self._scan_progress_bar.show_remaining_time = False
+        self._scan_progress_bar.show_source_label = False
+        self._scan_progress_bar.progressbar.label_template = ""
+        self._scan_progress_bar.progressbar.setFixedWidth(80)
+        self._scan_progress_bar.progressbar.setFixedHeight(8)
         status_bar.addWidget(self._scan_progress_bar)
 
     def _add_separator(self):

--- a/bec_widgets/widgets/containers/main_window/main_window.py
+++ b/bec_widgets/widgets/containers/main_window/main_window.py
@@ -1,9 +1,28 @@
+from __future__ import annotations
+
 import os
 
 from bec_lib.endpoints import MessageEndpoints
-from qtpy.QtCore import QEvent, QSize, Qt, QTimer
+from qtpy.QtCore import (
+    QAbstractAnimation,
+    QEasingCurve,
+    QEvent,
+    QPropertyAnimation,
+    QSize,
+    Qt,
+    QTimer,
+)
 from qtpy.QtGui import QAction, QActionGroup, QIcon
-from qtpy.QtWidgets import QApplication, QFrame, QLabel, QMainWindow, QStyle, QVBoxLayout, QWidget
+from qtpy.QtWidgets import (
+    QApplication,
+    QFrame,
+    QHBoxLayout,
+    QLabel,
+    QMainWindow,
+    QStyle,
+    QVBoxLayout,
+    QWidget,
+)
 
 import bec_widgets
 from bec_widgets.utils import UILoader
@@ -21,6 +40,8 @@ MODULE_PATH = os.path.dirname(bec_widgets.__file__)
 class BECMainWindow(BECWidget, QMainWindow):
     RPC = False
     PLUGIN = False
+    SCAN_PROGRESS_WIDTH = 100  # px
+    STATUS_BAR_WIDGETS_EXPIRE_TIME = 60_000  # milliseconds
 
     def __init__(
         self,
@@ -34,6 +55,7 @@ class BECMainWindow(BECWidget, QMainWindow):
         super().__init__(parent=parent, gui_id=gui_id, **kwargs)
 
         self.app = QApplication.instance()
+        self.status_bar = self.statusBar()
         self.setWindowTitle(window_title)
         self._init_ui()
         self._connect_to_theme_change()
@@ -62,14 +84,13 @@ class BECMainWindow(BECWidget, QMainWindow):
         """
         Prepare the BEC specific widgets in the status bar.
         """
-        status_bar = self.statusBar()
 
         # Left: App‑ID label
         self._app_id_label = QLabel()
         self._app_id_label.setAlignment(
             Qt.AlignmentFlag.AlignHCenter | Qt.AlignmentFlag.AlignVCenter
         )
-        status_bar.addWidget(self._app_id_label)
+        self.status_bar.addWidget(self._app_id_label)
 
         # Add a separator after the app ID label
         self._add_separator()
@@ -79,26 +100,100 @@ class BECMainWindow(BECWidget, QMainWindow):
         self._client_info_label.setAlignment(
             Qt.AlignmentFlag.AlignHCenter | Qt.AlignmentFlag.AlignVCenter
         )
-        status_bar.addWidget(self._client_info_label, 1)
+        self.status_bar.addWidget(self._client_info_label, 1)
 
         # Timer to automatically clear client messages once they expire
         self._client_info_expire_timer = QTimer(self)
         self._client_info_expire_timer.setSingleShot(True)
         self._client_info_expire_timer.timeout.connect(lambda: self._client_info_label.setText(""))
 
-        self._add_separator()
+        # Add scan_progress bar with display logic
+        self._add_scan_progress_bar()
+
+    ################################################################################
+    # Progress‑bar helpers
+    def _add_scan_progress_bar(self):
+
+        # --- Progress bar -------------------------------------------------
+        # Scan progress bar minimalistic design setup
         self._scan_progress_bar = ScanProgressBar(self, one_line_design=True)
         self._scan_progress_bar.show_elapsed_time = False
         self._scan_progress_bar.show_remaining_time = False
         self._scan_progress_bar.show_source_label = False
         self._scan_progress_bar.progressbar.label_template = ""
-        self._scan_progress_bar.progressbar.setFixedWidth(80)
         self._scan_progress_bar.progressbar.setFixedHeight(8)
-        status_bar.addWidget(self._scan_progress_bar)
+        self._scan_progress_bar.progressbar.setFixedWidth(80)
 
-    def _add_separator(self):
+        # Bundle the progress bar with a separator
+        separator = self._add_separator(separate_object=True)
+        self._scan_progress_bar_with_separator = QWidget()
+        self._scan_progress_bar_with_separator.layout = QHBoxLayout(
+            self._scan_progress_bar_with_separator
+        )
+        self._scan_progress_bar_with_separator.layout.setContentsMargins(0, 0, 0, 0)
+        self._scan_progress_bar_with_separator.layout.setSpacing(0)
+        self._scan_progress_bar_with_separator.layout.addWidget(separator)
+        self._scan_progress_bar_with_separator.layout.addWidget(self._scan_progress_bar)
+
+        # Set Size
+        self._scan_progress_bar_target_width = self.SCAN_PROGRESS_WIDTH
+        self._scan_progress_bar_with_separator.setMaximumWidth(self._scan_progress_bar_target_width)
+
+        self.status_bar.addWidget(self._scan_progress_bar_with_separator)
+
+        # Visibility logic
+        self._scan_progress_bar_with_separator.hide()
+        self._scan_progress_bar_with_separator.setMaximumWidth(0)
+
+        # Timer for hiding logic
+        self._scan_progress_hide_timer = QTimer(self)
+        self._scan_progress_hide_timer.setSingleShot(True)
+        self._scan_progress_hide_timer.setInterval(self.STATUS_BAR_WIDGETS_EXPIRE_TIME)
+        self._scan_progress_hide_timer.timeout.connect(self._animate_hide_scan_progress_bar)
+
+        # Show / hide behaviour
+        self._scan_progress_bar.progress_started.connect(self._show_scan_progress_bar)
+        self._scan_progress_bar.progress_finished.connect(self._delay_hide_scan_progress_bar)
+
+    def _show_scan_progress_bar(self):
+        if self._scan_progress_hide_timer.isActive():
+            self._scan_progress_hide_timer.stop()
+        if self._scan_progress_bar_with_separator.isVisible():
+            return
+
+        # Make visible and reset width
+        self._scan_progress_bar_with_separator.show()
+        self._scan_progress_bar_with_separator.setMaximumWidth(0)
+
+        self._show_container_anim = QPropertyAnimation(
+            self._scan_progress_bar_with_separator, b"maximumWidth", self
+        )
+        self._show_container_anim.setDuration(300)
+        self._show_container_anim.setStartValue(0)
+        self._show_container_anim.setEndValue(self._scan_progress_bar_target_width)
+        self._show_container_anim.setEasingCurve(QEasingCurve.OutCubic)
+        self._show_container_anim.start()
+
+    def _delay_hide_scan_progress_bar(self):
+        """Start the countdown to hide the scan progress bar."""
+        if hasattr(self, "_scan_progress_hide_timer"):
+            self._scan_progress_hide_timer.start()
+
+    def _animate_hide_scan_progress_bar(self):
+        """Shrink container to the right, then hide."""
+        self._hide_container_anim = QPropertyAnimation(
+            self._scan_progress_bar_with_separator, b"maximumWidth", self
+        )
+        self._hide_container_anim.setDuration(300)
+        self._hide_container_anim.setStartValue(self._scan_progress_bar_with_separator.width())
+        self._hide_container_anim.setEndValue(0)
+        self._hide_container_anim.setEasingCurve(QEasingCurve.InCubic)
+        self._hide_container_anim.finished.connect(self._scan_progress_bar_with_separator.hide)
+        self._hide_container_anim.start()
+
+    def _add_separator(self, separate_object: bool = False) -> QWidget | None:
         """
-        Add a vertically centred separator to the status bar.
+        Add a vertically centred separator to the status bar or just return it as a separate object.
         """
         status_bar = self.statusBar()
 
@@ -117,6 +212,8 @@ class BECMainWindow(BECWidget, QMainWindow):
         vbox.addStretch()
         wrapper.setFixedWidth(line.sizeHint().width())
 
+        if separate_object:
+            return wrapper
         status_bar.addWidget(wrapper)
 
     def _init_bec_icon(self):
@@ -290,8 +387,12 @@ class BECMainWindow(BECWidget, QMainWindow):
                     child.close()
                     child.deleteLater()
 
+        # Timer cleanup
         if hasattr(self, "_client_info_expire_timer") and self._client_info_expire_timer.isActive():
             self._client_info_expire_timer.stop()
+        if hasattr(self, "_scan_progress_hide_timer") and self._scan_progress_hide_timer.isActive():
+            self._scan_progress_hide_timer.stop()
+
         # Status bar widgets cleanup
         self._client_info_label.cleanup()
         self._scan_progress_bar.close()

--- a/bec_widgets/widgets/progress/bec_progressbar/bec_progressbar.py
+++ b/bec_widgets/widgets/progress/bec_progressbar/bec_progressbar.py
@@ -58,17 +58,19 @@ class BECProgressBar(BECWidget, QWidget):
 
         # label on top of the progress bar
         self.center_label = QLabel(self)
-        self.center_label.setAlignment(Qt.AlignCenter)
+        self.center_label.setAlignment(Qt.AlignHCenter)
         self.center_label.setStyleSheet("color: white;")
         self.center_label.setMinimumSize(0, 0)
 
         layout = QVBoxLayout(self)
-        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setContentsMargins(10, 0, 10, 0)
         layout.setSpacing(0)
         layout.addWidget(self.center_label)
+        layout.setAlignment(self.center_label, Qt.AlignCenter)
         self.setLayout(layout)
 
         self.update()
+        self._adjust_label_width()
 
     @SafeProperty(
         str, doc="The template for the center label. Use $value, $maximum, and $percentage."
@@ -87,6 +89,7 @@ class BECProgressBar(BECWidget, QWidget):
     @label_template.setter
     def label_template(self, template):
         self._label_template = template
+        self._adjust_label_width()
         self.set_value(self._user_value)
         self.update()
 
@@ -109,6 +112,18 @@ class BECProgressBar(BECWidget, QWidget):
             maximum=self._user_maximum,
             percentage=int((self.map_value(self._user_value) / self._maximum) * 100),
         )
+
+    def _adjust_label_width(self):
+        """
+        Reserve enough horizontal space for the center label so the widget
+        doesn't resize as the text grows during progress.
+        """
+        template = Template(self._label_template)
+        sample_text = template.safe_substitute(
+            value=self._user_maximum, maximum=self._user_maximum, percentage=100
+        )
+        width = self.center_label.fontMetrics().horizontalAdvance(sample_text)
+        self.center_label.setFixedWidth(width)
 
     @SafeSlot(float)
     @SafeSlot(int)
@@ -226,6 +241,7 @@ class BECProgressBar(BECWidget, QWidget):
             maximum (float): The maximum value.
         """
         self._user_maximum = maximum
+        self._adjust_label_width()
         self.set_value(self._user_value)  # Update the value to fit the new range
         self.update()
 

--- a/bec_widgets/widgets/progress/bec_progressbar/bec_progressbar.py
+++ b/bec_widgets/widgets/progress/bec_progressbar/bec_progressbar.py
@@ -1,12 +1,13 @@
 import sys
 from string import Template
 
-from qtpy.QtCore import Property, QEasingCurve, QPropertyAnimation, QRectF, Qt, QTimer, Slot
+from qtpy.QtCore import QEasingCurve, QPropertyAnimation, QRectF, Qt, QTimer
 from qtpy.QtGui import QColor, QPainter, QPainterPath
 from qtpy.QtWidgets import QApplication, QLabel, QVBoxLayout, QWidget
 
 from bec_widgets.utils.bec_widget import BECWidget
 from bec_widgets.utils.colors import get_accent_colors
+from bec_widgets.utils.error_popups import SafeProperty, SafeSlot
 
 
 class BECProgressBar(BECWidget, QWidget):
@@ -69,7 +70,9 @@ class BECProgressBar(BECWidget, QWidget):
 
         self.update()
 
-    @Property(str, doc="The template for the center label. Use $value, $maximum, and $percentage.")
+    @SafeProperty(
+        str, doc="The template for the center label. Use $value, $maximum, and $percentage."
+    )
     def label_template(self):
         """
         The template for the center label. Use $value, $maximum, and $percentage to insert the values.
@@ -87,7 +90,7 @@ class BECProgressBar(BECWidget, QWidget):
         self.set_value(self._user_value)
         self.update()
 
-    @Property(float, designable=False)
+    @SafeProperty(float, designable=False)
     def _progressbar_value(self):
         """
         The current value of the progress bar.
@@ -107,8 +110,8 @@ class BECProgressBar(BECWidget, QWidget):
             percentage=int((self.map_value(self._user_value) / self._maximum) * 100),
         )
 
-    @Slot(float)
-    @Slot(int)
+    @SafeSlot(float)
+    @SafeSlot(int)
     def set_value(self, value):
         """
         Set the value of the progress bar.
@@ -125,7 +128,7 @@ class BECProgressBar(BECWidget, QWidget):
         self.center_label.setText(self._update_template())
         self.animate_progress()
 
-    @Property(float)
+    @SafeProperty(float)
     def padding_left_right(self) -> float:
         return self._padding_left_right
 
@@ -178,7 +181,7 @@ class BECProgressBar(BECWidget, QWidget):
         self._value_animation.setEndValue(self._target_value)
         self._value_animation.start()
 
-    @Property(float)
+    @SafeProperty(float)
     def maximum(self):
         """
         The maximum value of the progress bar.
@@ -192,7 +195,7 @@ class BECProgressBar(BECWidget, QWidget):
         """
         self.set_maximum(maximum)
 
-    @Property(float)
+    @SafeProperty(float)
     def minimum(self):
         """
         The minimum value of the progress bar.
@@ -203,7 +206,7 @@ class BECProgressBar(BECWidget, QWidget):
     def minimum(self, minimum: float):
         self.set_minimum(minimum)
 
-    @Property(float)
+    @SafeProperty(float)
     def initial_value(self):
         """
         The initial value of the progress bar.
@@ -214,7 +217,7 @@ class BECProgressBar(BECWidget, QWidget):
     def initial_value(self, value: float):
         self.set_value(value)
 
-    @Slot(float)
+    @SafeSlot(float)
     def set_maximum(self, maximum: float):
         """
         Set the maximum value of the progress bar.
@@ -226,7 +229,7 @@ class BECProgressBar(BECWidget, QWidget):
         self.set_value(self._user_value)  # Update the value to fit the new range
         self.update()
 
-    @Slot(float)
+    @SafeSlot(float)
     def set_minimum(self, minimum: float):
         """
         Set the minimum value of the progress bar.

--- a/bec_widgets/widgets/progress/bec_progressbar/bec_progressbar.py
+++ b/bec_widgets/widgets/progress/bec_progressbar/bec_progressbar.py
@@ -50,6 +50,7 @@ class BECProgressBar(BECWidget, QWidget):
         self._border_color = QColor(50, 50, 50)
 
         # layout settings
+        self._padding_left_right = 10
         self._value_animation = QPropertyAnimation(self, b"_progressbar_value")
         self._value_animation.setDuration(200)
         self._value_animation.setEasingCurve(QEasingCurve.Type.OutCubic)
@@ -124,10 +125,19 @@ class BECProgressBar(BECWidget, QWidget):
         self.center_label.setText(self._update_template())
         self.animate_progress()
 
+    @Property(float)
+    def padding_left_right(self) -> float:
+        return self._padding_left_right
+
+    @padding_left_right.setter
+    def padding_left_right(self, padding: float):
+        self._padding_left_right = padding
+        self.update()
+
     def paintEvent(self, event):
         painter = QPainter(self)
         painter.setRenderHint(QPainter.Antialiasing)
-        rect = self.rect().adjusted(10, 0, -10, -1)
+        rect = self.rect().adjusted(self._padding_left_right, 0, -self._padding_left_right, -1)
 
         # Draw background
         painter.setBrush(self._background_color)

--- a/bec_widgets/widgets/progress/bec_progressbar/bec_progressbar.py
+++ b/bec_widgets/widgets/progress/bec_progressbar/bec_progressbar.py
@@ -1,8 +1,26 @@
 import sys
+from enum import Enum
 from string import Template
 
 from qtpy.QtCore import QEasingCurve, QPropertyAnimation, QRectF, Qt, QTimer
 from qtpy.QtGui import QColor, QPainter, QPainterPath
+
+
+class ProgressState(Enum):
+    NORMAL = "normal"
+    PAUSED = "paused"
+    INTERRUPTED = "interrupted"
+    COMPLETED = "completed"
+
+
+PROGRESS_STATE_COLORS = {
+    ProgressState.NORMAL: QColor("#2979ff"),  # blue  – normal progress
+    ProgressState.PAUSED: QColor("#ffca28"),  # orange/amber – paused
+    ProgressState.INTERRUPTED: QColor("#ff5252"),  # red – interrupted
+    ProgressState.COMPLETED: QColor("#00e676"),  # green – finished
+}
+# ---------------------------------------------------------------------------
+
 from qtpy.QtWidgets import QApplication, QLabel, QVBoxLayout, QWidget
 
 from bec_widgets.utils.bec_widget import BECWidget
@@ -22,6 +40,8 @@ class BECProgressBar(BECWidget, QWidget):
         "set_minimum",
         "label_template",
         "label_template.setter",
+        "state",
+        "state.setter",
         "_get_label",
     ]
     ICON_NAME = "page_control"
@@ -49,6 +69,12 @@ class BECProgressBar(BECWidget, QWidget):
 
         self._completed_color = accent_colors.success
         self._border_color = QColor(50, 50, 50)
+        # Corner‑rounding: base radius in pixels (auto‑reduced if bar is small)
+        self._corner_radius = 10
+
+        # Progress‑bar state handling
+        self._state = ProgressState.NORMAL
+        self._state_colors = dict(PROGRESS_STATE_COLORS)
 
         # layout settings
         self._padding_left_right = 10
@@ -141,7 +167,42 @@ class BECProgressBar(BECWidget, QWidget):
         self._target_value = self.map_value(value)
         self._user_value = value
         self.center_label.setText(self._update_template())
+        # Update state automatically unless paused or interrupted
+        if self._state not in (ProgressState.PAUSED, ProgressState.INTERRUPTED):
+            self._state = (
+                ProgressState.COMPLETED
+                if self._user_value >= self._user_maximum
+                else ProgressState.NORMAL
+            )
         self.animate_progress()
+
+    @SafeProperty(object, doc="Current visual state of the progress bar.")
+    def state(self):
+        return self._state
+
+    @state.setter
+    def state(self, state):
+        """
+        Set the visual state of the progress bar.
+
+        Args:
+            state(ProgressState | str): The state to set. Can be one of the
+        """
+        if isinstance(state, str):
+            state = ProgressState(state.lower())
+        if not isinstance(state, ProgressState):
+            raise ValueError("state must be a ProgressState or its value")
+        self._state = state
+        self.update()
+
+    @SafeProperty(float, doc="Base corner radius in pixels (auto‑scaled down on small bars).")
+    def corner_radius(self) -> float:
+        return self._corner_radius
+
+    @corner_radius.setter
+    def corner_radius(self, radius: float):
+        self._corner_radius = max(0.0, radius)
+        self.update()
 
     @SafeProperty(float)
     def padding_left_right(self) -> float:
@@ -157,28 +218,37 @@ class BECProgressBar(BECWidget, QWidget):
         painter.setRenderHint(QPainter.Antialiasing)
         rect = self.rect().adjusted(self._padding_left_right, 0, -self._padding_left_right, -1)
 
+        # Corner radius adapts to widget height so it never exceeds half the bar’s thickness
+        radius = min(self._corner_radius, rect.height() / 2)
+
         # Draw background
         painter.setBrush(self._background_color)
         painter.setPen(Qt.NoPen)
-        painter.drawRoundedRect(rect, 10, 10)  # Rounded corners
+        painter.drawRoundedRect(rect, radius, radius)  # Rounded corners
 
         # Draw border
         painter.setBrush(Qt.NoBrush)
         painter.setPen(self._border_color)
-        painter.drawRoundedRect(rect, 10, 10)
+        painter.drawRoundedRect(rect, radius, radius)
 
-        # Determine progress color based on completion
-        if self._value >= self._maximum:
-            current_color = self._completed_color
+        # Determine progress colour based on current state
+        if self._state == ProgressState.PAUSED:
+            current_color = self._state_colors[ProgressState.PAUSED]
+        elif self._state == ProgressState.INTERRUPTED:
+            current_color = self._state_colors[ProgressState.INTERRUPTED]
+        elif self._state == ProgressState.COMPLETED or self._value >= self._maximum:
+            current_color = self._state_colors[ProgressState.COMPLETED]
         else:
-            current_color = self._progress_color
+            current_color = self._state_colors[ProgressState.NORMAL]
 
         # Set clipping region to preserve the background's rounded corners
         progress_rect = rect.adjusted(
             0, 0, int(-rect.width() + (self._value / self._maximum) * rect.width()), 0
         )
         clip_path = QPainterPath()
-        clip_path.addRoundedRect(QRectF(rect), 10, 10)  # Clip to the background's rounded corners
+        clip_path.addRoundedRect(
+            QRectF(rect), radius, radius
+        )  # Clip to the background's rounded corners
         painter.setClipPath(clip_path)
 
         # Draw progress bar

--- a/bec_widgets/widgets/progress/bec_progressbar/bec_progressbar.py
+++ b/bec_widgets/widgets/progress/bec_progressbar/bec_progressbar.py
@@ -12,6 +12,22 @@ class ProgressState(Enum):
     INTERRUPTED = "interrupted"
     COMPLETED = "completed"
 
+    @classmethod
+    def from_bec_status(cls, status: str) -> "ProgressState":
+        """
+        Map a BEC status string (open, paused, aborted, halted, closed)
+        to the corresponding ProgressState.
+        Any unknown status falls back to NORMAL.
+        """
+        mapping = {
+            "open": cls.NORMAL,
+            "paused": cls.PAUSED,
+            "aborted": cls.INTERRUPTED,
+            "halted": cls.PAUSED,
+            "closed": cls.COMPLETED,
+        }
+        return mapping.get(status.lower(), cls.NORMAL)
+
 
 PROGRESS_STATE_COLORS = {
     ProgressState.NORMAL: QColor("#2979ff"),  # blue  – normal progress
@@ -19,7 +35,6 @@ PROGRESS_STATE_COLORS = {
     ProgressState.INTERRUPTED: QColor("#ff5252"),  # red – interrupted
     ProgressState.COMPLETED: QColor("#00e676"),  # green – finished
 }
-# ---------------------------------------------------------------------------
 
 from qtpy.QtWidgets import QApplication, QLabel, QVBoxLayout, QWidget
 

--- a/bec_widgets/widgets/progress/scan_progressbar/register_scan_progress_bar.py
+++ b/bec_widgets/widgets/progress/scan_progressbar/register_scan_progress_bar.py
@@ -1,0 +1,17 @@
+def main():  # pragma: no cover
+    from qtpy import PYSIDE6
+
+    if not PYSIDE6:
+        print("PYSIDE6 is not available in the environment. Cannot patch designer.")
+        return
+    from PySide6.QtDesigner import QPyDesignerCustomWidgetCollection
+
+    from bec_widgets.widgets.progress.scan_progressbar.scan_progress_bar_plugin import (
+        ScanProgressBarPlugin,
+    )
+
+    QPyDesignerCustomWidgetCollection.addCustomWidget(ScanProgressBarPlugin())
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/bec_widgets/widgets/progress/scan_progressbar/scan_progress_bar.pyproject
+++ b/bec_widgets/widgets/progress/scan_progressbar/scan_progress_bar.pyproject
@@ -1,0 +1,1 @@
+{'files': ['scan_progressbar.py']}

--- a/bec_widgets/widgets/progress/scan_progressbar/scan_progress_bar_plugin.py
+++ b/bec_widgets/widgets/progress/scan_progressbar/scan_progress_bar_plugin.py
@@ -1,0 +1,54 @@
+# Copyright (C) 2022 The Qt Company Ltd.
+# SPDX-License-Identifier: LicenseRef-Qt-Commercial OR BSD-3-Clause
+
+from qtpy.QtDesigner import QDesignerCustomWidgetInterface
+
+from bec_widgets.utils.bec_designer import designer_material_icon
+from bec_widgets.widgets.progress.scan_progressbar.scan_progressbar import ScanProgressBar
+
+DOM_XML = """
+<ui language='c++'>
+    <widget class='ScanProgressBar' name='scan_progress_bar'>
+    </widget>
+</ui>
+"""
+
+
+class ScanProgressBarPlugin(QDesignerCustomWidgetInterface):  # pragma: no cover
+    def __init__(self):
+        super().__init__()
+        self._form_editor = None
+
+    def createWidget(self, parent):
+        t = ScanProgressBar(parent)
+        return t
+
+    def domXml(self):
+        return DOM_XML
+
+    def group(self):
+        return "BEC Utils"
+
+    def icon(self):
+        return designer_material_icon(ScanProgressBar.ICON_NAME)
+
+    def includeFile(self):
+        return "scan_progress_bar"
+
+    def initialize(self, form_editor):
+        self._form_editor = form_editor
+
+    def isContainer(self):
+        return False
+
+    def isInitialized(self):
+        return self._form_editor is not None
+
+    def name(self):
+        return "ScanProgressBar"
+
+    def toolTip(self):
+        return "A progress bar that is hooked up to the scan progress of a scan."
+
+    def whatsThis(self):
+        return self.toolTip()

--- a/bec_widgets/widgets/progress/scan_progressbar/scan_progressbar.py
+++ b/bec_widgets/widgets/progress/scan_progressbar/scan_progressbar.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import enum
 import os
 import time
+from typing import Literal
 
 import numpy as np
 from bec_lib.endpoints import MessageEndpoints
@@ -13,6 +14,7 @@ from qtpy.QtWidgets import QVBoxLayout, QWidget
 from bec_widgets.utils.bec_widget import BECWidget
 from bec_widgets.utils.error_popups import SafeProperty, SafeSlot
 from bec_widgets.utils.ui_loader import UILoader
+from bec_widgets.widgets.progress.bec_progressbar.bec_progressbar import ProgressState
 
 logger = bec_logger.logger
 
@@ -183,13 +185,17 @@ class ScanProgressBar(BECWidget, QWidget):
         logger.info(f"Set progress source to {text}")
         self.ui.source_label.setText(text)
 
-    def on_progress_update(self, msg_content, metadata):
+    @SafeSlot(dict, dict)
+    def on_progress_update(self, msg_content: dict, metadata: dict):
         """
         Update the progress bar based on the progress message.
         """
         value = msg_content["value"]
         max_value = msg_content.get("max_value", 100)
         done = msg_content.get("done", False)
+        status: Literal["open", "paused", "aborted", "halted", "closed"] = metadata.get(
+            "status", "open"
+        )
 
         if self.task is None:
             return
@@ -198,12 +204,12 @@ class ScanProgressBar(BECWidget, QWidget):
         self.update_labels()
 
         self.progressbar.set_maximum(self.task.max_value)
+        self.progressbar.state = ProgressState.from_bec_status(status)
+        self.progressbar.set_value(self.task.value)
+
         if done:
-            self.progressbar.set_value(self.task.max_value)
             self.task = None
             return
-
-        self.progressbar.set_value(self.task.value)
 
     @SafeProperty(bool)
     def show_elapsed_time(self):

--- a/bec_widgets/widgets/progress/scan_progressbar/scan_progressbar.py
+++ b/bec_widgets/widgets/progress/scan_progressbar/scan_progressbar.py
@@ -1,0 +1,298 @@
+from __future__ import annotations
+
+import enum
+import os
+import time
+
+import numpy as np
+from bec_lib.endpoints import MessageEndpoints
+from bec_lib.logger import bec_logger
+from qtpy.QtCore import QObject, QTimer
+from qtpy.QtWidgets import QVBoxLayout, QWidget
+
+from bec_widgets.utils.bec_widget import BECWidget
+from bec_widgets.utils.error_popups import SafeProperty, SafeSlot
+from bec_widgets.utils.ui_loader import UILoader
+
+logger = bec_logger.logger
+
+
+class ProgressSource(enum.Enum):
+    """
+    Enum to define the source of the progress.
+    """
+
+    SCAN_PROGRESS = "scan_progress"
+    DEVICE_PROGRESS = "device_progress"
+
+
+class ProgressTask(QObject):
+    """
+    Class to store progress information.
+    Inspired by https://github.com/Textualize/rich/blob/master/rich/progress.py
+    """
+
+    def __init__(self, parent: QWidget, value: float = 0, max_value: float = 0, done: bool = False):
+        super().__init__(parent=parent)
+        self.start_time = time.time()
+        self.done = done
+        self.value = value
+        self.max_value = max_value
+        self._elapsed_time = 0
+
+        self.timer = QTimer(self)
+        self.timer.timeout.connect(self.update_elapsed_time)
+        self.timer.start(100)  # update the elapsed time every 100 ms
+
+    def update(self, value: float, max_value: float, done: bool = False):
+        """
+        Update the progress.
+        """
+        self.max_value = max_value
+        self.done = done
+        self.value = value
+        if done:
+            self.timer.stop()
+
+    def update_elapsed_time(self):
+        """
+        Update the time estimates. This is called every 100 ms by a QTimer.
+        """
+        self._elapsed_time += 0.1
+
+    @property
+    def percentage(self) -> float:
+        """float: Get progress of task as a percentage. If a None total was set, returns 0"""
+        if not self.max_value:
+            return 0.0
+        completed = (self.value / self.max_value) * 100.0
+        completed = min(100.0, max(0.0, completed))
+        return completed
+
+    @property
+    def speed(self) -> float:
+        """Get the estimated speed in steps per second."""
+        if self._elapsed_time == 0:
+            return 0.0
+
+        return self.value / self._elapsed_time
+
+    @property
+    def frequency(self) -> float:
+        """Get the estimated frequency in steps per second."""
+        if self.speed == 0:
+            return 0.0
+        return 1 / self.speed
+
+    @property
+    def time_elapsed(self) -> str:
+        # format the elapsed time to a string in the format HH:MM:SS
+        return self._format_time(int(self._elapsed_time))
+
+    @property
+    def remaining(self) -> float:
+        """Get the estimated remaining steps."""
+        if self.done:
+            return 0.0
+        remaining = self.max_value - self.value
+        return remaining
+
+    @property
+    def time_remaining(self) -> str:
+        """
+        Get the estimated remaining time in the format HH:MM:SS.
+        """
+        if self.done or not self.speed or not self.remaining:
+            return self._format_time(0)
+        estimate = int(np.round(self.remaining / self.speed))
+
+        return self._format_time(estimate)
+
+    def _format_time(self, seconds: float) -> str:
+        """
+        Format the time in seconds to a string in the format HH:MM:SS.
+        """
+        return f"{seconds // 3600:02}:{(seconds // 60) % 60:02}:{seconds % 60:02}"
+
+
+class ScanProgressBar(BECWidget, QWidget):
+    """
+    Widget to display a progress bar that is hooked up to the scan progress of a scan.
+    If you want to manually set the progress, it is recommended to use the BECProgressbar or QProgressbar directly.
+    """
+
+    ICON_NAME = "timelapse"
+
+    def __init__(self, parent=None, client=None, config=None, gui_id=None):
+        super().__init__(parent=parent, client=client, config=config, gui_id=gui_id)
+
+        self.get_bec_shortcuts()
+        ui_file = os.path.join(os.path.dirname(__file__), "scan_progressbar.ui")
+        self.ui = UILoader(self).loader(ui_file)
+        self.layout = QVBoxLayout(self)
+        self.layout.setSpacing(0)
+        self.layout.setContentsMargins(0, 0, 0, 0)
+        self.layout.addWidget(self.ui)
+        self.setLayout(self.layout)
+        self.progressbar = self.ui.progressbar
+
+        self.connect_to_queue()
+        self._progress_source = None
+        self.task = None
+        self.scan_number = None
+
+    def connect_to_queue(self):
+        """
+        Connect to the queue status signal.
+        """
+        self.bec_dispatcher.connect_slot(self.on_queue_update, MessageEndpoints.scan_queue_status())
+
+    def set_progress_source(self, source: ProgressSource, device=None):
+        """
+        Set the source of the progress.
+        """
+        if self._progress_source == source:
+            self.update_source_label(source, device=device)
+            return
+        if self._progress_source is not None:
+            self.bec_dispatcher.disconnect_slot(
+                self.on_progress_update,
+                (
+                    MessageEndpoints.scan_progress()
+                    if self._progress_source == ProgressSource.SCAN_PROGRESS
+                    else MessageEndpoints.device_progress(device=device)
+                ),
+            )
+        self._progress_source = source
+        self.bec_dispatcher.connect_slot(
+            self.on_progress_update,
+            (
+                MessageEndpoints.scan_progress()
+                if source == ProgressSource.SCAN_PROGRESS
+                else MessageEndpoints.device_progress(device=device)
+            ),
+        )
+        self.update_source_label(source, device=device)
+
+    def update_source_label(self, source: ProgressSource, device=None):
+        scan_text = f"Scan {self.scan_number}" if self.scan_number is not None else "Scan"
+        text = scan_text if source == ProgressSource.SCAN_PROGRESS else f"Device {device}"
+        logger.info(f"Set progress source to {text}")
+        self.ui.source_label.setText(text)
+
+    def on_progress_update(self, msg_content, metadata):
+        """
+        Update the progress bar based on the progress message.
+        """
+        value = msg_content["value"]
+        max_value = msg_content.get("max_value", 100)
+        done = msg_content.get("done", False)
+
+        if self.task is None:
+            return
+        self.task.update(value, max_value, done)
+
+        self.update_labels()
+
+        self.progressbar.set_maximum(self.task.max_value)
+        if done:
+            self.progressbar.set_value(self.task.max_value)
+            self.task = None
+            return
+
+        self.progressbar.set_value(self.task.value)
+
+    @SafeProperty(bool)
+    def show_elapsed_time(self):
+        return self.ui.elapsed_time_label.isVisible()
+
+    @show_elapsed_time.setter
+    def show_elapsed_time(self, value):
+        self.ui.elapsed_time_label.setVisible(value)
+
+    @SafeProperty(bool)
+    def show_remaining_time(self):
+        return self.ui.remaining_time_label.isVisible()
+
+    @show_remaining_time.setter
+    def show_remaining_time(self, value):
+        self.ui.remaining_time_label.setVisible(value)
+
+    @SafeProperty(bool)
+    def show_source_label(self):
+        return self.ui.source_label.isVisible()
+
+    @show_source_label.setter
+    def show_source_label(self, value):
+        self.ui.source_label.setVisible(value)
+
+    def update_labels(self):
+        """
+        Update the labels based on the progress task.
+        """
+        if self.task is None:
+            return
+
+        self.ui.elapsed_time_label.setText(self.task.time_elapsed)
+        self.ui.remaining_time_label.setText(self.task.time_remaining)
+
+    @SafeSlot(dict, dict, verify_sender=True)
+    def on_queue_update(self, msg_content, metadata):
+        """
+        Update the progress bar based on the queue status.
+        """
+        if not "queue" in msg_content:
+            return
+        primary_queue_info = msg_content["queue"].get("primary", {}).get("info", [])
+        if len(primary_queue_info) == 0:
+            return
+        scan_info = primary_queue_info[0]
+        if scan_info is None:
+            return
+        if scan_info.get("status").lower() == "running" and self.task is None:
+            self.task = ProgressTask(parent=self)
+
+        active_request_block = scan_info.get("active_request_block", {})
+        if active_request_block is None:
+            return
+
+        self.scan_number = active_request_block.get("scan_number")
+        report_instructions = active_request_block.get("report_instructions", [])
+        if not report_instructions:
+            return
+
+        # for now, let's just use the first instruction
+        instruction = report_instructions[0]
+
+        if "scan_progress" in instruction:
+            self.set_progress_source(ProgressSource.SCAN_PROGRESS)
+        elif "device_progress" in instruction:
+            device = instruction["device_progress"][0]
+            self.set_progress_source(ProgressSource.DEVICE_PROGRESS, device=device)
+
+    def cleanup(self):
+        if self.task is not None:
+            self.task.timer.stop()
+            self.close()
+            self.deleteLater()
+        if self._progress_source is not None:
+            self.bec_dispatcher.disconnect_slot(
+                self.on_progress_update,
+                (
+                    MessageEndpoints.scan_progress()
+                    if self._progress_source == ProgressSource.SCAN_PROGRESS
+                    else MessageEndpoints.device_progress(device=self._progress_source.value)
+                ),
+            )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    from qtpy.QtWidgets import QApplication
+
+    bec_logger.disabled_modules = ["bec_lib"]
+    app = QApplication([])
+
+    widget = ScanProgressBar()
+    widget.show()
+
+    app.exec_()

--- a/bec_widgets/widgets/progress/scan_progressbar/scan_progressbar.py
+++ b/bec_widgets/widgets/progress/scan_progressbar/scan_progressbar.py
@@ -123,11 +123,14 @@ class ScanProgressBar(BECWidget, QWidget):
 
     ICON_NAME = "timelapse"
 
-    def __init__(self, parent=None, client=None, config=None, gui_id=None):
+    def __init__(self, parent=None, client=None, config=None, gui_id=None, one_line_design=False):
         super().__init__(parent=parent, client=client, config=config, gui_id=gui_id)
 
         self.get_bec_shortcuts()
-        ui_file = os.path.join(os.path.dirname(__file__), "scan_progressbar.ui")
+        ui_file = os.path.join(
+            os.path.dirname(__file__),
+            "scan_progressbar_one_line.ui" if one_line_design else "scan_progressbar.ui",
+        )
         self.ui = UILoader(self).loader(ui_file)
         self.layout = QVBoxLayout(self)
         self.layout.setSpacing(0)
@@ -209,6 +212,8 @@ class ScanProgressBar(BECWidget, QWidget):
     @show_elapsed_time.setter
     def show_elapsed_time(self, value):
         self.ui.elapsed_time_label.setVisible(value)
+        if hasattr(self.ui, "dash"):
+            self.ui.dash.setVisible(value)
 
     @SafeProperty(bool)
     def show_remaining_time(self):
@@ -217,6 +222,8 @@ class ScanProgressBar(BECWidget, QWidget):
     @show_remaining_time.setter
     def show_remaining_time(self, value):
         self.ui.remaining_time_label.setVisible(value)
+        if hasattr(self.ui, "dash"):
+            self.ui.dash.setVisible(value)
 
     @SafeProperty(bool)
     def show_source_label(self):

--- a/bec_widgets/widgets/progress/scan_progressbar/scan_progressbar.py
+++ b/bec_widgets/widgets/progress/scan_progressbar/scan_progressbar.py
@@ -8,7 +8,7 @@ from typing import Literal
 import numpy as np
 from bec_lib.endpoints import MessageEndpoints
 from bec_lib.logger import bec_logger
-from qtpy.QtCore import QObject, QTimer
+from qtpy.QtCore import QObject, QTimer, Signal
 from qtpy.QtWidgets import QVBoxLayout, QWidget
 
 from bec_widgets.utils.bec_widget import BECWidget
@@ -124,6 +124,8 @@ class ScanProgressBar(BECWidget, QWidget):
     """
 
     ICON_NAME = "timelapse"
+    progress_started = Signal()
+    progress_finished = Signal()
 
     def __init__(self, parent=None, client=None, config=None, gui_id=None, one_line_design=False):
         super().__init__(parent=parent, client=client, config=config, gui_id=gui_id)
@@ -145,6 +147,7 @@ class ScanProgressBar(BECWidget, QWidget):
         self._progress_source = None
         self.task = None
         self.scan_number = None
+        self.progress_started.connect(lambda: print("Scan progress started"))
 
     def connect_to_queue(self):
         """
@@ -178,6 +181,7 @@ class ScanProgressBar(BECWidget, QWidget):
             ),
         )
         self.update_source_label(source, device=device)
+        # self.progress_started.emit()
 
     def update_source_label(self, source: ProgressSource, device=None):
         scan_text = f"Scan {self.scan_number}" if self.scan_number is not None else "Scan"
@@ -209,6 +213,7 @@ class ScanProgressBar(BECWidget, QWidget):
 
         if done:
             self.task = None
+            self.progress_finished.emit()
             return
 
     @SafeProperty(bool)
@@ -264,6 +269,7 @@ class ScanProgressBar(BECWidget, QWidget):
             return
         if scan_info.get("status").lower() == "running" and self.task is None:
             self.task = ProgressTask(parent=self)
+            self.progress_started.emit()
 
         active_request_block = scan_info.get("active_request_block", {})
         if active_request_block is None:

--- a/bec_widgets/widgets/progress/scan_progressbar/scan_progressbar.py
+++ b/bec_widgets/widgets/progress/scan_progressbar/scan_progressbar.py
@@ -291,6 +291,9 @@ class ScanProgressBar(BECWidget, QWidget):
                     else MessageEndpoints.device_progress(device=self._progress_source.value)
                 ),
             )
+        self.progressbar.close()
+        self.progressbar.deleteLater()
+        super().cleanup()
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/bec_widgets/widgets/progress/scan_progressbar/scan_progressbar.ui
+++ b/bec_widgets/widgets/progress/scan_progressbar/scan_progressbar.ui
@@ -1,0 +1,141 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>211</width>
+    <height>60</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>0</width>
+    <height>60</height>
+   </size>
+  </property>
+  <property name="maximumSize">
+   <size>
+    <width>16777215</width>
+    <height>16777215</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="spacing">
+    <number>1</number>
+   </property>
+   <property name="leftMargin">
+    <number>2</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>2</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <layout class="QHBoxLayout" name="source_layout">
+     <item>
+      <widget class="QLabel" name="source_label">
+       <property name="maximumSize">
+        <size>
+         <width>16777215</width>
+         <height>20</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>Scan</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="source_spacer">
+       <property name="orientation">
+        <enum>Qt::Orientation::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>10</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="BECProgressBar" name="progressbar">
+     <property name="padding_left_right" stdset="0">
+      <double>2.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="timer_layout">
+     <item>
+      <widget class="QLabel" name="remaining_time_label">
+       <property name="maximumSize">
+        <size>
+         <width>16777215</width>
+         <height>20</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>0:00:00</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="timer_spacer">
+       <property name="orientation">
+        <enum>Qt::Orientation::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>0</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QLabel" name="elapsed_time_label">
+       <property name="maximumSize">
+        <size>
+         <width>16777215</width>
+         <height>20</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>0:00:00</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>BECProgressBar</class>
+   <extends>QWidget</extends>
+   <header>bec_progress_bar</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/bec_widgets/widgets/progress/scan_progressbar/scan_progressbar_one_line.ui
+++ b/bec_widgets/widgets/progress/scan_progressbar/scan_progressbar_one_line.ui
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>328</width>
+    <height>24</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>0</width>
+    <height>24</height>
+   </size>
+  </property>
+  <property name="maximumSize">
+   <size>
+    <width>16777215</width>
+    <height>24</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="0,1,0">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>2</number>
+   </property>
+   <property name="rightMargin">
+    <number>2</number>
+   </property>
+   <property name="bottomMargin">
+    <number>2</number>
+   </property>
+   <item>
+    <widget class="QLabel" name="source_label">
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>20</height>
+      </size>
+     </property>
+     <property name="text">
+      <string>Scan</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="BECProgressBar" name="progressbar">
+     <property name="minimumSize">
+      <size>
+       <width>30</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="padding_left_right" stdset="0">
+      <double>5.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QLabel" name="remaining_time_label">
+       <property name="maximumSize">
+        <size>
+         <width>16777215</width>
+         <height>20</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>0:00:00</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="dash">
+       <property name="text">
+        <string>-</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignmentFlag::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="elapsed_time_label">
+       <property name="maximumSize">
+        <size>
+         <width>16777215</width>
+         <height>20</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>0:00:00</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>BECProgressBar</class>
+   <extends>QWidget</extends>
+   <header>bec_progress_bar</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,15 +13,15 @@ classifiers = [
     "Topic :: Scientific/Engineering",
 ]
 dependencies = [
-    "bec_ipython_client>=3.38, <=4.0", # needed for jupyter console
-    "bec_lib>=3.38, <=4.0",
+    "bec_ipython_client>=3.42.4, <=4.0", # needed for jupyter console
+    "bec_lib>=3.42.4, <=4.0",
     "bec_qthemes~=0.7, >=0.7",
-    "black~=25.0",                     # needed for bw-generate-cli
-    "isort~=5.13, >=5.13.2",           # needed for bw-generate-cli
+    "black~=25.0",                       # needed for bw-generate-cli
+    "isort~=5.13, >=5.13.2",             # needed for bw-generate-cli
     "pydantic~=2.0",
     "pyqtgraph~=0.13",
     "PySide6~=6.8.2",
-    "qtconsole~=5.5, >=5.5.1",         # needed for jupyter console
+    "qtconsole~=5.5, >=5.5.1",           # needed for jupyter console
     "qtpy~=2.4",
 ]
 

--- a/tests/end-2-end/test_rpc_widgets_e2e.py
+++ b/tests/end-2-end/test_rpc_widgets_e2e.py
@@ -79,7 +79,7 @@ def test_available_widgets(qtbot, connected_client_gui_obj):
     gui = connected_client_gui_obj
     dock_area = gui.bec
     # Number of top level widgets, should be 4
-    top_level_widgets_count = 4
+    top_level_widgets_count = 8
     assert len(gui._server_registry) == top_level_widgets_count
     # Number of widgets with parent_id == None, should be 2
     widgets = [

--- a/tests/unit_tests/test_bec_progressbar.py
+++ b/tests/unit_tests/test_bec_progressbar.py
@@ -1,7 +1,10 @@
 import numpy as np
 import pytest
 
-from bec_widgets.widgets.progress.bec_progressbar.bec_progressbar import BECProgressBar
+from bec_widgets.widgets.progress.bec_progressbar.bec_progressbar import (
+    BECProgressBar,
+    ProgressState,
+)
 
 
 @pytest.fixture
@@ -33,3 +36,23 @@ def test_progressbar_label(progressbar):
     progressbar.label_template = "Test: $value"
     progressbar.set_value(50)
     assert progressbar.center_label.text() == "Test: 50"
+
+
+def test_progress_state_from_bec_status():
+    """ProgressState.from_bec_status() maps BEC literals correctly."""
+    mapping = {
+        "open": ProgressState.NORMAL,
+        "paused": ProgressState.PAUSED,
+        "aborted": ProgressState.INTERRUPTED,
+        "halted": ProgressState.PAUSED,
+        "closed": ProgressState.COMPLETED,
+        "UNKNOWN": ProgressState.NORMAL,  # fallback
+    }
+    for text, expected in mapping.items():
+        assert ProgressState.from_bec_status(text) is expected
+
+
+def test_progressbar_state_setter(progressbar):
+    """Setting .state reflects internally."""
+    progressbar.state = ProgressState.PAUSED
+    assert progressbar.state is ProgressState.PAUSED

--- a/tests/unit_tests/test_launch_window.py
+++ b/tests/unit_tests/test_launch_window.py
@@ -102,7 +102,15 @@ def test_launch_window_launch_plugin_auto_update(bec_launch_window):
     [
         ({}, False),
         ({"launcher": mock.MagicMock()}, False),
-        ({"launcher": mock.MagicMock(), "dock_area": mock.MagicMock()}, True),
+        ({"launcher": mock.MagicMock(), "dock_area": mock.MagicMock()}, False),
+        (
+            {
+                "launcher": mock.MagicMock(),
+                "dock_area": mock.MagicMock(),
+                "scan_progress": mock.MagicMock(),
+            },
+            True,
+        ),
     ],
 )
 def test_gui_server_turns_off_the_lights(bec_launch_window, connections, hide):
@@ -132,7 +140,15 @@ def test_gui_server_turns_off_the_lights(bec_launch_window, connections, hide):
     [
         ({}, True),
         ({"launcher": mock.MagicMock()}, True),
-        ({"launcher": mock.MagicMock(), "dock_area": mock.MagicMock()}, False),
+        ({"launcher": mock.MagicMock(), "dock_area": mock.MagicMock()}, True),
+        (
+            {
+                "launcher": mock.MagicMock(),
+                "dock_area": mock.MagicMock(),
+                "scan_progress": mock.MagicMock(),
+            },
+            False,
+        ),
     ],
 )
 def test_launch_window_closes(bec_launch_window, connections, close_called):

--- a/tests/unit_tests/test_main_widnow.py
+++ b/tests/unit_tests/test_main_widnow.py
@@ -187,3 +187,44 @@ def test_bec_weblinks(monkeypatch):
         "https://bec.readthedocs.io/projects/bec-widgets/en/latest/",
         "https://gitlab.psi.ch/groups/bec/-/issues/",
     ]
+
+
+#################################################################
+# Tests for scan‑progress bar animations
+
+
+def test_scan_progress_bar_show_animation(qtbot, bec_main_window):
+    """
+    _show_scan_progress_bar should animate the container's maximumWidth
+    from 0 to the configured target width.
+    """
+    container = bec_main_window._scan_progress_bar_with_separator
+
+    # Pre‑condition: collapsed
+    assert container.maximumWidth() == 0
+
+    bec_main_window._show_scan_progress_bar()
+
+    target = bec_main_window._scan_progress_bar_target_width
+    qtbot.waitUntil(lambda: container.maximumWidth() == target, timeout=2000)
+
+    assert container.maximumWidth() == target
+
+
+def test_scan_progress_bar_hide_animation(qtbot, bec_main_window):
+    """
+    _animate_hide_scan_progress_bar should collapse the container back to 0 width.
+    """
+    container = bec_main_window._scan_progress_bar_with_separator
+
+    # First expand it
+    bec_main_window._show_scan_progress_bar()
+    target = bec_main_window._scan_progress_bar_target_width
+    qtbot.waitUntil(lambda: container.maximumWidth() == target, timeout=2000)
+
+    # Trigger hide animation
+    bec_main_window._animate_hide_scan_progress_bar()
+
+    qtbot.waitUntil(lambda: container.maximumWidth() == 0, timeout=2000)
+
+    assert container.maximumWidth() == 0

--- a/tests/unit_tests/test_scan_progress_bar.py
+++ b/tests/unit_tests/test_scan_progress_bar.py
@@ -1,0 +1,160 @@
+import numpy as np
+import pytest
+
+from bec_widgets.widgets.progress.bec_progressbar.bec_progressbar import (
+    BECProgressBar,
+    ProgressState,
+)
+from bec_widgets.widgets.progress.scan_progressbar.scan_progressbar import (
+    ProgressSource,
+    ProgressTask,
+    ScanProgressBar,
+)
+
+from .client_mocks import mocked_client
+
+
+@pytest.fixture
+def scan_progressbar(qtbot, mocked_client):
+    widget = ScanProgressBar(client=mocked_client)
+    qtbot.addWidget(widget)
+    qtbot.waitExposed(widget)
+    yield widget
+
+
+def test_progress_task_basic():
+    """percentage, remaining, and formatted time helpers behave as expected."""
+    task = ProgressTask(parent=None, value=50, max_value=100, done=False)
+    task.timer.stop()  # we don’t want the timer ticking in tests
+    task._elapsed_time = 10  # simulate 10 s elapsed
+
+    # 50 / 100  ⇒ 50 %
+    assert task.percentage == 50
+
+    # speed  =  value / elapsed  = 5 steps / s
+    assert np.isclose(task.speed, 5)
+
+    # remaining steps = 50 ; time_remaining ≈ 10 s
+    assert task.remaining == 50
+    assert task.time_remaining == "00:00:10"
+
+    # time_elapsed formatting
+    assert task.time_elapsed == "00:00:10"
+
+
+def test_scan_progressbar_initialization(scan_progressbar):
+    assert isinstance(scan_progressbar, ScanProgressBar)
+    assert isinstance(scan_progressbar.progressbar, BECProgressBar)
+
+
+def test_update_labels_content(scan_progressbar):
+    """update_labels() reflects ProgressTask time strings on the UI."""
+    # fabricate a task with known timings
+    task = ProgressTask(parent=scan_progressbar, value=30, max_value=100, done=False)
+    task.timer.stop()
+    task._elapsed_time = 50
+    scan_progressbar.task = task
+
+    scan_progressbar.update_labels()
+
+    assert scan_progressbar.ui.elapsed_time_label.text() == "00:00:50"
+    assert scan_progressbar.ui.remaining_time_label.text() == "00:01:57"
+
+
+def test_on_progress_update(qtbot, scan_progressbar):
+    """
+    on_progress_update() should forward new values to the embedded
+    BECProgressBar and keep ProgressTask in sync.
+    """
+    task = ProgressTask(parent=scan_progressbar, value=0, max_value=100, done=False)
+    task.timer.stop()
+    scan_progressbar.task = task
+
+    msg = {"value": 20, "max_value": 100, "done": False}
+    scan_progressbar.on_progress_update(msg, metadata={"status": "open"})
+
+    qtbot.wait(200)
+    bar = scan_progressbar.progressbar
+    assert bar._user_value == 20
+    assert bar._user_maximum == 100
+    # state reflects BEC status
+    assert bar.state is ProgressState.NORMAL
+
+
+@pytest.mark.parametrize(
+    "status, value, max_val, expected_state",
+    [
+        ("open", 10, 100, ProgressState.NORMAL),
+        ("paused", 25, 100, ProgressState.PAUSED),
+        ("aborted", 30, 100, ProgressState.INTERRUPTED),
+        ("halted", 40, 100, ProgressState.PAUSED),
+        ("closed", 100, 100, ProgressState.COMPLETED),
+    ],
+)
+def test_state_mapping_during_updates(
+    qtbot, scan_progressbar, status, value, max_val, expected_state
+):
+    """ScanProgressBar should translate BEC status → ProgressState consistently."""
+    task = ProgressTask(parent=scan_progressbar, value=0, max_value=max_val, done=False)
+    task.timer.stop()
+    scan_progressbar.task = task
+
+    scan_progressbar.on_progress_update(
+        {"value": value, "max_value": max_val, "done": status == "closed"},
+        metadata={"status": status},
+    )
+
+    assert scan_progressbar.progressbar.state is expected_state
+
+
+def test_source_label_updates(scan_progressbar):
+    """update_source_label() renders correct text for both progress sources."""
+    # device progress
+    scan_progressbar.update_source_label(ProgressSource.DEVICE_PROGRESS, device="motor")
+    assert scan_progressbar.ui.source_label.text() == "Device motor"
+
+    # scan progress (needs a scan_number for deterministic text)
+    scan_progressbar.scan_number = 5
+    scan_progressbar.update_source_label(ProgressSource.SCAN_PROGRESS)
+    assert scan_progressbar.ui.source_label.text() == "Scan 5"
+
+
+def test_set_progress_source_connections(scan_progressbar, monkeypatch):
+    """ """
+    from bec_lib.endpoints import MessageEndpoints
+
+    connect_calls = []
+    disconnect_calls = []
+
+    def fake_connect(slot, endpoint):
+        connect_calls.append(endpoint)
+
+    def fake_disconnect(slot, endpoint):
+        disconnect_calls.append(endpoint)
+
+    # Patch dispatcher methods
+    monkeypatch.setattr(scan_progressbar.bec_dispatcher, "connect_slot", fake_connect)
+    monkeypatch.setattr(scan_progressbar.bec_dispatcher, "disconnect_slot", fake_disconnect)
+
+    # switch to SCAN_PROGRESS
+    scan_progressbar.scan_number = 7
+    scan_progressbar.set_progress_source(ProgressSource.SCAN_PROGRESS)
+
+    assert scan_progressbar._progress_source == ProgressSource.SCAN_PROGRESS
+    assert scan_progressbar.ui.source_label.text() == "Scan 7"
+    assert connect_calls[-1] == MessageEndpoints.scan_progress()
+    assert disconnect_calls == []
+
+    # switch to DEVICE_PROGRESS
+    device = "motor"
+    scan_progressbar.set_progress_source(ProgressSource.DEVICE_PROGRESS, device=device)
+
+    assert scan_progressbar._progress_source == ProgressSource.DEVICE_PROGRESS
+    assert scan_progressbar.ui.source_label.text() == f"Device {device}"
+    assert connect_calls[-1] == MessageEndpoints.device_progress(device=device)
+    assert disconnect_calls == [MessageEndpoints.scan_progress()]
+
+    # calling again with the SAME source should not add new connect calls
+    prev_connect_count = len(connect_calls)
+    scan_progressbar.set_progress_source(ProgressSource.DEVICE_PROGRESS, device=device)
+    assert len(connect_calls) == prev_connect_count, "No extra connect made for same source"

--- a/tests/unit_tests/test_scan_progress_bar.py
+++ b/tests/unit_tests/test_scan_progress_bar.py
@@ -1,5 +1,8 @@
+from unittest import mock
+
 import numpy as np
 import pytest
+from bec_lib import messages
 
 from bec_widgets.widgets.progress.bec_progressbar.bec_progressbar import (
     BECProgressBar,
@@ -158,3 +161,176 @@ def test_set_progress_source_connections(scan_progressbar, monkeypatch):
     prev_connect_count = len(connect_calls)
     scan_progressbar.set_progress_source(ProgressSource.DEVICE_PROGRESS, device=device)
     assert len(connect_calls) == prev_connect_count, "No extra connect made for same source"
+
+
+def test_progressbar_queue_update(scan_progressbar):
+    """
+    Test that an empty queue update does not change the progress source.
+    """
+    msg = messages.ScanQueueStatusMessage(queue={"primary": {"info": [], "status": "RUNNING"}})
+    with mock.patch.object(scan_progressbar, "set_progress_source") as mock_set_source:
+        scan_progressbar.on_queue_update(
+            msg.content, msg.metadata, _override_slot_params={"verify_sender": False}
+        )
+        mock_set_source.assert_not_called()
+
+
+def test_progressbar_queue_update_with_scan(scan_progressbar):
+    """
+    Test that a queue update with a scan changes the progress source to SCAN_PROGRESS.
+    """
+    msg = messages.ScanQueueStatusMessage(
+        metadata={},
+        queue={
+            "primary": {
+                "info": [
+                    {
+                        "queue_id": "40831e2c-fbd1-4432-8072-ad168a7ad964",
+                        "scan_id": ["e3f50794-852c-4bb1-965e-41c585ab0aa9"],
+                        "status": "RUNNING",
+                        "active_request_block": {
+                            "msg": messages.ScanQueueMessage(
+                                metadata={
+                                    "file_suffix": None,
+                                    "file_directory": None,
+                                    "user_metadata": {"sample_name": ""},
+                                    "RID": "94949c6e-d5f2-4f01-837e-a5d36257dd5d",
+                                },
+                                scan_type="line_scan",
+                                parameter={
+                                    "args": {"samx": [-10.0, 10.0]},
+                                    "kwargs": {
+                                        "steps": 20,
+                                        "relative": False,
+                                        "exp_time": 0.1,
+                                        "burst_at_each_point": 1,
+                                        "system_config": {
+                                            "file_suffix": None,
+                                            "file_directory": None,
+                                        },
+                                    },
+                                },
+                                queue="primary",
+                            ),
+                            "scan_number": 1,
+                            "report_instructions": [{"scan_progress": 20}],
+                        },
+                    }
+                ],
+                "status": "RUNNING",
+            }
+        },
+    )
+
+    with mock.patch.object(scan_progressbar, "set_progress_source") as mock_set_source:
+        scan_progressbar.on_queue_update(
+            msg.content, msg.metadata, _override_slot_params={"verify_sender": False}
+        )
+        mock_set_source.assert_called_once_with(ProgressSource.SCAN_PROGRESS)
+
+
+def test_progressbar_queue_update_with_device(scan_progressbar):
+    """
+    Test that a queue update with a device changes the progress source to DEVICE_PROGRESS.
+    """
+    msg = messages.ScanQueueStatusMessage(
+        metadata={},
+        queue={
+            "primary": {
+                "info": [
+                    {
+                        "queue_id": "40831e2c-fbd1-4432-8072-ad168a7ad964",
+                        "scan_id": ["e3f50794-852c-4bb1-965e-41c585ab0aa9"],
+                        "status": "RUNNING",
+                        "active_request_block": {
+                            "msg": messages.ScanQueueMessage(
+                                metadata={
+                                    "file_suffix": None,
+                                    "file_directory": None,
+                                    "user_metadata": {"sample_name": ""},
+                                    "RID": "94949c6e-d5f2-4f01-837e-a5d36257dd5d",
+                                },
+                                scan_type="line_scan",
+                                parameter={
+                                    "args": {"samx": [-10.0, 10.0]},
+                                    "kwargs": {
+                                        "steps": 20,
+                                        "relative": False,
+                                        "exp_time": 0.1,
+                                        "burst_at_each_point": 1,
+                                        "system_config": {
+                                            "file_suffix": None,
+                                            "file_directory": None,
+                                        },
+                                    },
+                                },
+                                queue="primary",
+                            ),
+                            "scan_number": 1,
+                            "report_instructions": [{"device_progress": ["samx"]}],
+                        },
+                    }
+                ],
+                "status": "RUNNING",
+            }
+        },
+    )
+
+    with mock.patch.object(scan_progressbar, "set_progress_source") as mock_set_source:
+        scan_progressbar.on_queue_update(
+            msg.content, msg.metadata, _override_slot_params={"verify_sender": False}
+        )
+        mock_set_source.assert_called_once_with(ProgressSource.DEVICE_PROGRESS, device="samx")
+
+
+def test_progressbar_queue_update_with_no_scan_or_device(scan_progressbar):
+    """
+    Test that a queue update with neither scan nor device does not change the progress source.
+    """
+    msg = messages.ScanQueueStatusMessage(
+        metadata={},
+        queue={
+            "primary": {
+                "info": [
+                    {
+                        "queue_id": "40831e2c-fbd1-4432-8072-ad168a7ad964",
+                        "scan_id": ["e3f50794-852c-4bb1-965e-41c585ab0aa9"],
+                        "status": "RUNNING",
+                        "active_request_block": {
+                            "msg": messages.ScanQueueMessage(
+                                metadata={
+                                    "file_suffix": None,
+                                    "file_directory": None,
+                                    "user_metadata": {"sample_name": ""},
+                                    "RID": "94949c6e-d5f2-4f01-837e-a5d36257dd5d",
+                                },
+                                scan_type="line_scan",
+                                parameter={
+                                    "args": {"samx": [-10.0, 10.0]},
+                                    "kwargs": {
+                                        "steps": 20,
+                                        "relative": False,
+                                        "exp_time": 0.1,
+                                        "burst_at_each_point": 1,
+                                        "system_config": {
+                                            "file_suffix": None,
+                                            "file_directory": None,
+                                        },
+                                    },
+                                },
+                                queue="primary",
+                            ),
+                            "scan_number": 1,
+                        },
+                    }
+                ],
+                "status": "RUNNING",
+            }
+        },
+    )
+
+    with mock.patch.object(scan_progressbar, "set_progress_source") as mock_set_source:
+        scan_progressbar.on_queue_update(
+            msg.content, msg.metadata, _override_slot_params={"verify_sender": False}
+        )
+        mock_set_source.assert_not_called()


### PR DESCRIPTION
## Description

Introduction of new widget ScanProgressBar and implementation into BECMainWindow to bottom right corner.

## Related Issues

- closes #709 
- closes #181 

## Type of Change

- **new** ScanProgressBar
- **improvement** implementation of ScanProgressBar to BECMainWindow
- adjustments to size policy and resize logic of BECProgressBar

## How to test

- Launch BEC Gui using BECMainWindow
- Do some scan and see what happens in the bottom right corner.

## Potential side effects

I had to adjust the number of remaining connections for launcher for turning off lights, better double check the consequences.

