### PR TITLE
fix(waveform): AsyncSignal are handled with the same update mechanism as async readback; closes

### DIFF
--- a/bec_widgets/tests/utils.py
+++ b/bec_widgets/tests/utils.py
@@ -210,6 +210,39 @@ class DMMock:
         for device in devices:
             self.devices[device.name] = device
 
+    def get_bec_signals(self, signal_class_name: str):
+        """
+        Emulate DeviceManager.get_bec_signals for unit-tests.
+
+        For “AsyncSignal” we list every device whose readout_priority is
+        ReadoutPriority.ASYNC and build a minimal tuple
+        (device_name, signal_name, signal_info_dict) that matches the real
+        API shape used by Waveform._check_async_signal_found.
+        """
+        signals: list[tuple[str, str, dict]] = []
+        if signal_class_name != "AsyncSignal":
+            return signals
+
+        for device in self.devices.values():
+            if getattr(device, "readout_priority", None) == ReadoutPriority.ASYNC:
+                device_name = device.name
+                signal_name = device.name  # primary signal in our mocks
+                signal_info = {
+                    "component_name": signal_name,
+                    "obj_name": signal_name,
+                    "kind_str": "hinted",
+                    "signal_class": signal_class_name,
+                    "metadata": {
+                        "connected": True,
+                        "precision": None,
+                        "read_access": True,
+                        "timestamp": 0.0,
+                        "write_access": True,
+                    },
+                }
+                signals.append((device_name, signal_name, signal_info))
+        return signals
+
 
 DEVICES = [
     FakePositioner("samx", limits=[-10, 10], read_value=2.0),

--- a/bec_widgets/widgets/plots/waveform/waveform.py
+++ b/bec_widgets/widgets/plots/waveform/waveform.py
@@ -1246,6 +1246,23 @@ class Waveform(PlotBase):
 
         self.request_dap_update.emit()
 
+    def _check_async_signal_found(self, name: str, signal: str) -> bool:
+        """
+        Check if the async signal is found in the BEC device manager.
+
+        Args:
+            name(str): The name of the async signal.
+            signal(str): The entry of the async signal.
+
+        Returns:
+            bool: True if the async signal is found, False otherwise.
+        """
+        bec_async_signals = self.client.device_manager.get_bec_signals("AsyncSignal")
+        for entry_name, _, entry_data in bec_async_signals:
+            if entry_name == name and entry_data.get("obj_name") == signal:
+                return True
+        return False
+
     def _setup_async_curve(self, curve: Curve):
         """
         Setup async curve.
@@ -1254,20 +1271,40 @@ class Waveform(PlotBase):
             curve(Curve): The curve to set up.
         """
         name = curve.config.signal.name
-        self.bec_dispatcher.disconnect_slot(
-            self.on_async_readback, MessageEndpoints.device_async_readback(self.old_scan_id, name)
-        )
+        signal = curve.config.signal.entry
+        async_signal_found = self._check_async_signal_found(name, signal)
+
         try:
             curve.clear_data()
         except KeyError:
             logger.warning(f"Curve {name} not found in plot item.")
             pass
-        self.bec_dispatcher.connect_slot(
-            self.on_async_readback,
-            MessageEndpoints.device_async_readback(self.scan_id, name),
-            from_start=True,
-            cb_info={"scan_id": self.scan_id},
-        )
+
+        # New endpoint for async signals
+        if async_signal_found:
+            self.bec_dispatcher.disconnect_slot(
+                self.on_async_readback,
+                MessageEndpoints.device_async_signal(self.old_scan_id, name, signal),
+            )
+            self.bec_dispatcher.connect_slot(
+                self.on_async_readback,
+                MessageEndpoints.device_async_signal(self.scan_id, name, signal),
+                from_start=True,
+                cb_info={"scan_id": self.scan_id},
+            )
+
+        # old endpoint
+        else:
+            self.bec_dispatcher.disconnect_slot(
+                self.on_async_readback,
+                MessageEndpoints.device_async_readback(self.old_scan_id, name),
+            )
+            self.bec_dispatcher.connect_slot(
+                self.on_async_readback,
+                MessageEndpoints.device_async_readback(self.scan_id, name),
+                from_start=True,
+                cb_info={"scan_id": self.scan_id},
+            )
         logger.info(f"Setup async curve {name}")
 
     @SafeSlot(dict, dict, verify_sender=True)


### PR DESCRIPTION
## Description

AsyncSignal can be plotted in the waveform widget

## Type of Change

- New decision logic for async devices
- Adjustment of DMMock for unit tests (should be extended with mocked AsyncSignal to test it)

## How to test

- Add device `waveform` with `waveform_data` (simulation device) to `Waveform` widget 


## Additional Comments

Not sure how to adjust unit test to reflect AsyncSignals without making import from `ophyd_devices`, I am open to any suggested solution regarding how to adjust unit tests for that. ATM I just added method to `DMMock` which reflects the structure reported by `bec`


