### PR TITLE
Feature/plot selection combobox

### DIFF
--- a/bec_widgets/tests/utils.py
+++ b/bec_widgets/tests/utils.py
@@ -96,9 +96,21 @@ class FakePositioner(BECPositioner):
         }
         self._info = {
             "signals": {
-                "readback": {"kind_str": "hinted"},  # hinted
-                "setpoint": {"kind_str": "normal"},  # normal
-                "velocity": {"kind_str": "config"},  # config
+                "readback": {
+                    "kind_str": "hinted",
+                    "component_name": "readback",
+                    "obj_name": self.name,
+                },  # hinted
+                "setpoint": {
+                    "kind_str": "normal",
+                    "component_name": "setpoint",
+                    "obj_name": f"{self.name}_setpoint",
+                },  # normal
+                "velocity": {
+                    "kind_str": "config",
+                    "component_name": "velocity",
+                    "obj_name": f"{self.name}_velocity",
+                },  # config
             }
         }
         self.signals = {

--- a/bec_widgets/utils/filter_io.py
+++ b/bec_widgets/utils/filter_io.py
@@ -8,6 +8,8 @@ from bec_lib.logger import bec_logger
 from qtpy.QtCore import QStringListModel
 from qtpy.QtWidgets import QComboBox, QCompleter, QLineEdit
 
+from bec_widgets.utils.ophyd_kind_util import Kind
+
 logger = bec_logger.logger
 
 
@@ -35,6 +37,23 @@ class WidgetFilterHandler(ABC):
         Returns:
             bool: True if the input text is in the filtered selection
         """
+
+    @abstractmethod
+    def update_with_kind(
+        self, kind: Kind, signal_filter: set, device_info: dict, device_name: str
+    ) -> list[str | tuple]:
+        """Update the selection based on the kind of signal.
+
+        Args:
+            kind (Kind): The kind of signal to filter.
+            signal_filter (set): Set of signal kinds to filter.
+            device_info (dict): Dictionary containing device information.
+            device_name (str): Name of the device.
+
+        Returns:
+            list[str | tuple]: A list of filtered signals based on the kind.
+        """
+        # This method should be implemented in subclasses or extended as needed
 
 
 class LineEditFilterHandler(WidgetFilterHandler):
@@ -69,6 +88,27 @@ class LineEditFilterHandler(WidgetFilterHandler):
         model_data = [model.data(model.index(i)) for i in range(model.rowCount())]
         return text in model_data
 
+    def update_with_kind(
+        self, kind: Kind, signal_filter: set, device_info: dict, device_name: str
+    ) -> list[str | tuple]:
+        """Update the selection based on the kind of signal.
+
+        Args:
+            kind (Kind): The kind of signal to filter.
+            signal_filter (set): Set of signal kinds to filter.
+            device_info (dict): Dictionary containing device information.
+            device_name (str): Name of the device.
+
+        Returns:
+            list[str | tuple]: A list of filtered signals based on the kind.
+        """
+
+        return [
+            signal
+            for signal, signal_info in device_info.items()
+            if kind in signal_filter and (signal_info.get("kind_str", None) == str(kind.name))
+        ]
+
 
 class ComboBoxFilterHandler(WidgetFilterHandler):
     """Handler for QComboBox widget"""
@@ -101,6 +141,40 @@ class ComboBoxFilterHandler(WidgetFilterHandler):
             bool: True if the input text is in the filtered selection
         """
         return text in [widget.itemText(i) for i in range(widget.count())]
+
+    def update_with_kind(
+        self, kind: Kind, signal_filter: set, device_info: dict, device_name: str
+    ) -> list[str | tuple]:
+        """Update the selection based on the kind of signal.
+
+        Args:
+            kind (Kind): The kind of signal to filter.
+            signal_filter (set): Set of signal kinds to filter.
+            device_info (dict): Dictionary containing device information.
+            device_name (str): Name of the device.
+
+        Returns:
+            list[str | tuple]: A list of filtered signals based on the kind.
+        """
+        out = []
+        for signal, signal_info in device_info.items():
+            if kind not in signal_filter or (signal_info.get("kind_str", None) != str(kind.name)):
+                continue
+            obj_name = signal_info.get("obj_name", "")
+            component_name = signal_info.get("component_name", "")
+            signal_wo_device = obj_name.removeprefix(f"{device_name}_")
+            if not signal_wo_device:
+                signal_wo_device = obj_name
+
+            if signal_wo_device != signal and component_name.replace(".", "_") != signal_wo_device:
+                # If the object name is not the same as the signal name, we use the object name
+                # to display in the combobox.
+                out.append((f"{signal_wo_device} ({signal})", signal_info))
+            else:
+                # If the object name is the same as the signal name, we do not change it.
+                out.append((signal, signal_info))
+
+        return out
 
 
 class FilterIO:
@@ -151,6 +225,35 @@ class FilterIO:
                 f"No matching handler for widget type: {type(widget)} in handler list {FilterIO._handlers}"
             )
         return None
+
+    @staticmethod
+    def update_with_kind(
+        widget, kind: Kind, signal_filter: set, device_info: dict, device_name: str
+    ) -> list[str | tuple]:
+        """
+        Update the selection based on the kind of signal.
+
+        Args:
+            widget: Widget instance.
+            kind (Kind): The kind of signal to filter.
+            signal_filter (set): Set of signal kinds to filter.
+            device_info (dict): Dictionary containing device information.
+            device_name (str): Name of the device.
+
+        Returns:
+            list[str | tuple]: A list of filtered signals based on the kind.
+        """
+        handler_class = FilterIO._find_handler(widget)
+        if handler_class:
+            return handler_class().update_with_kind(
+                kind=kind,
+                signal_filter=signal_filter,
+                device_info=device_info,
+                device_name=device_name,
+            )
+        raise ValueError(
+            f"No matching handler for widget type: {type(widget)} in handler list {FilterIO._handlers}"
+        )
 
     @staticmethod
     def _find_handler(widget):

--- a/bec_widgets/utils/filter_io.py
+++ b/bec_widgets/utils/filter_io.py
@@ -15,11 +15,13 @@ class WidgetFilterHandler(ABC):
     """Abstract base class for widget filter handlers"""
 
     @abstractmethod
-    def set_selection(self, widget, selection: list) -> None:
+    def set_selection(self, widget, selection: list[str | tuple]) -> None:
         """Set the filtered_selection for the widget
 
         Args:
-            selection (list): Filtered selection of items
+            widget: Widget instance
+            selection (list[str | tuple]): Filtered selection of items.
+                If tuple, it contains (text, data) pairs.
         """
 
     @abstractmethod
@@ -38,13 +40,16 @@ class WidgetFilterHandler(ABC):
 class LineEditFilterHandler(WidgetFilterHandler):
     """Handler for QLineEdit widget"""
 
-    def set_selection(self, widget: QLineEdit, selection: list) -> None:
+    def set_selection(self, widget: QLineEdit, selection: list[str | tuple]) -> None:
         """Set the selection for the widget to the completer model
 
         Args:
             widget (QLineEdit): The QLineEdit widget
-            selection (list): Filtered selection of items
+            selection (list[str | tuple]): Filtered selection of items. If tuple, it contains (text, data) pairs.
         """
+        if isinstance(selection, tuple):
+            # If selection is a tuple, it contains (text, data) pairs
+            selection = [text for text, _ in selection]
         if not isinstance(widget.completer, QCompleter):
             completer = QCompleter(widget)
             widget.setCompleter(completer)
@@ -68,15 +73,22 @@ class LineEditFilterHandler(WidgetFilterHandler):
 class ComboBoxFilterHandler(WidgetFilterHandler):
     """Handler for QComboBox widget"""
 
-    def set_selection(self, widget: QComboBox, selection: list) -> None:
+    def set_selection(self, widget: QComboBox, selection: list[str | tuple]) -> None:
         """Set the selection for the widget to the completer model
 
         Args:
             widget (QComboBox): The QComboBox widget
-            selection (list): Filtered selection of items
+            selection (list[str | tuple]): Filtered selection of items. If tuple, it contains (text, data) pairs.
         """
         widget.clear()
-        widget.addItems(selection)
+        if len(selection) == 0:
+            return
+        for element in selection:
+            if isinstance(element, str):
+                widget.addItem(element)
+            elif isinstance(element, tuple):
+                # If element is a tuple, it contains (text, data) pairs
+                widget.addItem(*element)
 
     def check_input(self, widget: QComboBox, text: str) -> bool:
         """Check if the input text is in the filtered selection
@@ -99,13 +111,14 @@ class FilterIO:
     _handlers = {QLineEdit: LineEditFilterHandler, QComboBox: ComboBoxFilterHandler}
 
     @staticmethod
-    def set_selection(widget, selection: list, ignore_errors=True):
+    def set_selection(widget, selection: list[str | tuple], ignore_errors=True):
         """
         Retrieve value from the widget instance.
 
         Args:
             widget: Widget instance.
-            selection(list): List of filtered selection items.
+            selection (list[str | tuple]): Filtered selection of items.
+                If tuple, it contains (text, data) pairs.
             ignore_errors(bool, optional): Whether to ignore if no handler is found.
         """
         handler_class = FilterIO._find_handler(widget)

--- a/bec_widgets/widgets/control/device_input/base_classes/device_input_base.py
+++ b/bec_widgets/widgets/control/device_input/base_classes/device_input_base.py
@@ -6,10 +6,10 @@ from bec_lib.device import ComputedSignal, Device, Positioner, ReadoutPriority
 from bec_lib.device import Signal as BECSignal
 from bec_lib.logger import bec_logger
 from pydantic import field_validator
-from qtpy.QtCore import Property, Signal, Slot
 
 from bec_widgets.utils import ConnectionConfig
 from bec_widgets.utils.bec_widget import BECWidget
+from bec_widgets.utils.error_popups import SafeProperty, SafeSlot
 from bec_widgets.utils.filter_io import FilterIO
 from bec_widgets.utils.widget_io import WidgetIO
 
@@ -100,7 +100,7 @@ class DeviceInputBase(BECWidget):
 
     ### QtSlots ###
 
-    @Slot(str)
+    @SafeSlot(str)
     def set_device(self, device: str):
         """
         Set the device.
@@ -114,7 +114,7 @@ class DeviceInputBase(BECWidget):
         else:
             logger.warning(f"Device {device} is not in the filtered selection.")
 
-    @Slot()
+    @SafeSlot()
     def update_devices_from_filters(self):
         """Update the devices based on the current filter selection
         in self.device_filter and self.readout_filter. If apply_filter is False,
@@ -133,7 +133,7 @@ class DeviceInputBase(BECWidget):
         self.devices = [device.name for device in devs]
         self.set_device(current_device)
 
-    @Slot(list)
+    @SafeSlot(list)
     def set_available_devices(self, devices: list[str]):
         """
         Set the devices. If a device in the list is not valid, it will not be considered.
@@ -146,7 +146,7 @@ class DeviceInputBase(BECWidget):
 
     ### QtProperties ###
 
-    @Property(
+    @SafeProperty(
         "QStringList",
         doc="List of devices. If updated, it will disable the apply filters property.",
     )
@@ -165,7 +165,7 @@ class DeviceInputBase(BECWidget):
         self.config.devices = value
         FilterIO.set_selection(widget=self, selection=value)
 
-    @Property(str)
+    @SafeProperty(str)
     def default(self):
         """Get the default device name. If set through this property, it will update only if the device is within the filtered selection."""
         return self.config.default
@@ -177,7 +177,7 @@ class DeviceInputBase(BECWidget):
         self.config.default = value
         WidgetIO.set_value(widget=self, value=value)
 
-    @Property(bool)
+    @SafeProperty(bool)
     def apply_filter(self):
         """Apply the filters on the devices."""
         return self.config.apply_filter
@@ -187,7 +187,7 @@ class DeviceInputBase(BECWidget):
         self.config.apply_filter = value
         self.update_devices_from_filters()
 
-    @Property(bool)
+    @SafeProperty(bool)
     def filter_to_device(self):
         """Include devices in filters."""
         return BECDeviceFilter.DEVICE in self.device_filter
@@ -200,7 +200,7 @@ class DeviceInputBase(BECWidget):
             self._device_filter.remove(BECDeviceFilter.DEVICE)
         self.update_devices_from_filters()
 
-    @Property(bool)
+    @SafeProperty(bool)
     def filter_to_positioner(self):
         """Include devices of type Positioner in filters."""
         return BECDeviceFilter.POSITIONER in self.device_filter
@@ -213,7 +213,7 @@ class DeviceInputBase(BECWidget):
             self._device_filter.remove(BECDeviceFilter.POSITIONER)
         self.update_devices_from_filters()
 
-    @Property(bool)
+    @SafeProperty(bool)
     def filter_to_signal(self):
         """Include devices of type Signal in filters."""
         return BECDeviceFilter.SIGNAL in self.device_filter
@@ -226,7 +226,7 @@ class DeviceInputBase(BECWidget):
             self._device_filter.remove(BECDeviceFilter.SIGNAL)
         self.update_devices_from_filters()
 
-    @Property(bool)
+    @SafeProperty(bool)
     def filter_to_computed_signal(self):
         """Include devices of type ComputedSignal in filters."""
         return BECDeviceFilter.COMPUTED_SIGNAL in self.device_filter
@@ -239,7 +239,7 @@ class DeviceInputBase(BECWidget):
             self._device_filter.remove(BECDeviceFilter.COMPUTED_SIGNAL)
         self.update_devices_from_filters()
 
-    @Property(bool)
+    @SafeProperty(bool)
     def readout_monitored(self):
         """Include devices with readout priority Monitored in filters."""
         return ReadoutPriority.MONITORED in self.readout_filter
@@ -252,7 +252,7 @@ class DeviceInputBase(BECWidget):
             self._readout_filter.remove(ReadoutPriority.MONITORED)
         self.update_devices_from_filters()
 
-    @Property(bool)
+    @SafeProperty(bool)
     def readout_baseline(self):
         """Include devices with readout priority Baseline in filters."""
         return ReadoutPriority.BASELINE in self.readout_filter
@@ -265,7 +265,7 @@ class DeviceInputBase(BECWidget):
             self._readout_filter.remove(ReadoutPriority.BASELINE)
         self.update_devices_from_filters()
 
-    @Property(bool)
+    @SafeProperty(bool)
     def readout_async(self):
         """Include devices with readout priority Async in filters."""
         return ReadoutPriority.ASYNC in self.readout_filter
@@ -278,7 +278,7 @@ class DeviceInputBase(BECWidget):
             self._readout_filter.remove(ReadoutPriority.ASYNC)
         self.update_devices_from_filters()
 
-    @Property(bool)
+    @SafeProperty(bool)
     def readout_continuous(self):
         """Include devices with readout priority continuous in filters."""
         return ReadoutPriority.CONTINUOUS in self.readout_filter
@@ -291,7 +291,7 @@ class DeviceInputBase(BECWidget):
             self._readout_filter.remove(ReadoutPriority.CONTINUOUS)
         self.update_devices_from_filters()
 
-    @Property(bool)
+    @SafeProperty(bool)
     def readout_on_request(self):
         """Include devices with readout priority OnRequest in filters."""
         return ReadoutPriority.ON_REQUEST in self.readout_filter

--- a/bec_widgets/widgets/control/device_input/base_classes/device_signal_input_base.py
+++ b/bec_widgets/widgets/control/device_input/base_classes/device_signal_input_base.py
@@ -6,7 +6,7 @@ from qtpy.QtCore import Property
 from bec_widgets.utils import ConnectionConfig
 from bec_widgets.utils.bec_widget import BECWidget
 from bec_widgets.utils.error_popups import SafeSlot
-from bec_widgets.utils.filter_io import FilterIO
+from bec_widgets.utils.filter_io import FilterIO, LineEditFilterHandler
 from bec_widgets.utils.ophyd_kind_util import Kind
 from bec_widgets.utils.widget_io import WidgetIO
 
@@ -108,25 +108,32 @@ class DeviceSignalInputBase(BECWidget):
         if not self.validate_device(self._device):
             self._device = None
             self.config.device = self._device
-            return
-        device = self.get_device_object(self._device)
-        # See above convention for Signals and ComputedSignals
-        if isinstance(device, Signal):
-            self._signals = [self._device]
-            self._hinted_signals = [self._device]
+            self._signals = []
+            self._hinted_signals = []
             self._normal_signals = []
             self._config_signals = []
             FilterIO.set_selection(widget=self, selection=self._signals)
             return
+        device = self.get_device_object(self._device)
         device_info = device._info.get("signals", {})
 
+        # See above convention for Signals and ComputedSignals
+        if isinstance(device, Signal):
+            self._signals = [(self._device, {})]
+            self._hinted_signals = [(self._device, {})]
+            self._normal_signals = []
+            self._config_signals = []
+            FilterIO.set_selection(widget=self, selection=self._signals)
+            return
+
         def _update(kind: Kind):
-            return [
-                signal
-                for signal, signal_info in device_info.items()
-                if kind in self.signal_filter
-                and (signal_info.get("kind_str", None) == str(kind.name))
-            ]
+            return FilterIO.update_with_kind(
+                widget=self,
+                kind=kind,
+                signal_filter=self.signal_filter,
+                device_info=device_info,
+                device_name=self._device,
+            )
 
         self._hinted_signals = _update(Kind.hinted)
         self._normal_signals = _update(Kind.normal)
@@ -271,8 +278,11 @@ class DeviceSignalInputBase(BECWidget):
         Args:
             signal(str): Signal to validate.
         """
-        if signal in self.signals:
-            return True
+        for entry in self.signals:
+            if isinstance(entry, tuple):
+                entry = entry[0]
+            if entry == signal:
+                return True
         return False
 
     def _process_config_input(self, config: DeviceSignalInputBaseConfig | dict | None):

--- a/bec_widgets/widgets/control/device_input/device_combobox/device_combobox.py
+++ b/bec_widgets/widgets/control/device_input/device_combobox/device_combobox.py
@@ -34,6 +34,7 @@ class DeviceComboBox(DeviceInputBase, QComboBox):
     PLUGIN = True
 
     device_selected = Signal(str)
+    device_reset = Signal()
     device_config_update = Signal()
 
     def __init__(
@@ -147,6 +148,7 @@ class DeviceComboBox(DeviceInputBase, QComboBox):
             self.device_selected.emit(input_text)
         else:
             self._is_valid_input = False
+            self.device_reset.emit()
         self.update()
 
     def validate_device(self, device: str) -> bool:  # type: ignore[override]

--- a/bec_widgets/widgets/control/device_input/signal_combobox/signal_combobox.py
+++ b/bec_widgets/widgets/control/device_input/signal_combobox/signal_combobox.py
@@ -90,6 +90,14 @@ class SignalComboBox(DeviceSignalInputBase, QComboBox):
                 self.insertItem(0, "Hinted Signals")
                 self.model().item(0).setEnabled(False)
 
+    @SafeSlot()
+    def reset_selection(self):
+        """Reset the selection of the combobox."""
+        self.clear()
+        self.setItemText(0, "Select a device")
+        self.update_signals_from_filters()
+        self.device_signal_changed.emit("")
+
     @SafeSlot(str)
     def on_text_changed(self, text: str):
         """Slot for text changed. If a device is selected and the signal is changed and valid it emits a signal.

--- a/bec_widgets/widgets/control/device_input/signal_combobox/signal_combobox.py
+++ b/bec_widgets/widgets/control/device_input/signal_combobox/signal_combobox.py
@@ -110,11 +110,7 @@ class SignalComboBox(DeviceSignalInputBase, QComboBox):
             return
         if self.validate_signal(text) is False:
             return
-        if text == "readback" and isinstance(self.get_device_object(self.device), Positioner):
-            device_signal = self.device
-        else:
-            device_signal = f"{self.device}_{text}"
-        self.device_signal_changed.emit(device_signal)
+        self.device_signal_changed.emit(text)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/bec_widgets/widgets/plots/waveform/settings/curve_settings/curve_setting.py
+++ b/bec_widgets/widgets/plots/waveform/settings/curve_settings/curve_setting.py
@@ -35,8 +35,6 @@ class CurveSetting(SettingWidget):
         self._init_x_box()
         self._init_y_box()
 
-        self.setFixedWidth(580)  # TODO height is still debate
-
     def _init_x_box(self):
         self.x_axis_box = QGroupBox("X Axis")
         self.x_axis_box.layout = QHBoxLayout(self.x_axis_box)

--- a/bec_widgets/widgets/plots/waveform/settings/curve_settings/curve_setting.py
+++ b/bec_widgets/widgets/plots/waveform/settings/curve_settings/curve_setting.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from qtpy.QtCore import QSize
 from qtpy.QtWidgets import (
     QComboBox,
     QGroupBox,
@@ -34,6 +35,12 @@ class CurveSetting(SettingWidget):
 
         self._init_x_box()
         self._init_y_box()
+
+    def sizeHint(self) -> QSize:
+        """
+        Returns the size hint for the settings widget.
+        """
+        return QSize(800, 500)
 
     def _init_x_box(self):
         self.x_axis_box = QGroupBox("X Axis")

--- a/bec_widgets/widgets/plots/waveform/settings/curve_settings/curve_setting.py
+++ b/bec_widgets/widgets/plots/waveform/settings/curve_settings/curve_setting.py
@@ -102,7 +102,7 @@ class CurveSetting(SettingWidget):
 
         self.layout.addWidget(self.y_axis_box)
 
-    @SafeSlot()
+    @SafeSlot(popup_error=True)
     def accept_changes(self):
         """
         Accepts the changes made in the settings widget and applies them to the target widget.

--- a/bec_widgets/widgets/plots/waveform/settings/curve_settings/curve_tree.py
+++ b/bec_widgets/widgets/plots/waveform/settings/curve_settings/curve_tree.py
@@ -5,13 +5,12 @@ from typing import TYPE_CHECKING
 
 from bec_lib.logger import bec_logger
 from bec_qthemes._icon.material_icons import material_icon
-from qtpy.QtGui import QColor
+from qtpy.QtCore import Qt
 from qtpy.QtWidgets import (
-    QColorDialog,
     QComboBox,
     QHBoxLayout,
+    QHeaderView,
     QLabel,
-    QLineEdit,
     QPushButton,
     QSizePolicy,
     QSpinBox,
@@ -27,9 +26,8 @@ from bec_widgets.utils import ConnectionConfig, EntryValidator
 from bec_widgets.utils.bec_widget import BECWidget
 from bec_widgets.utils.colors import Colors
 from bec_widgets.utils.toolbar import MaterialIconAction, ModularToolBar
-from bec_widgets.widgets.control.device_input.device_line_edit.device_line_edit import (
-    DeviceLineEdit,
-)
+from bec_widgets.widgets.control.device_input.device_combobox.device_combobox import DeviceComboBox
+from bec_widgets.widgets.control.device_input.signal_combobox.signal_combobox import SignalComboBox
 from bec_widgets.widgets.dap.dap_combo_box.dap_combo_box import DapComboBox
 from bec_widgets.widgets.plots.waveform.curve import CurveConfig, DeviceSignal
 from bec_widgets.widgets.utility.visual.color_button_native.color_button_native import (
@@ -125,11 +123,40 @@ class CurveRow(QTreeWidgetItem):
         """Create columns 1 and 2. For device rows, we have device/entry edits; for dap rows, label/model combo."""
         if self.source == "device":
             # Device row: columns 1..2 are device line edits
-            self.device_edit = DeviceLineEdit(parent=self.tree)
-            self.entry_edit = QLineEdit(parent=self.tree)  # TODO in future will be signal line edit
+            self.device_edit = DeviceComboBox(parent=self.tree)
+            self.device_edit.insertItem(0, "")
+            self.device_edit.setEditable(True)
+            self.entry_edit = SignalComboBox(parent=self.tree)
+            self.entry_edit.include_config_signals = False
+            self.entry_edit.insertItem(0, "")
+            self.entry_edit.setEditable(True)
+            self.device_edit.currentTextChanged.connect(self.entry_edit.set_device)
+            self.device_edit.device_reset.connect(self.entry_edit.reset_selection)
             if self.config.signal:
-                self.device_edit.setText(self.config.signal.name or "")
-                self.entry_edit.setText(self.config.signal.entry or "")
+                device_index = self.device_edit.findText(self.config.signal.name or "")
+                if device_index >= 0:
+                    self.device_edit.setCurrentIndex(device_index)
+                    # Force the entry_edit to update based on the device name
+                    self.device_edit.currentTextChanged.emit(self.device_edit.currentText())
+                else:
+                    # If the device name is not found, set the first enabled item
+                    self.device_edit.setCurrentIndex(0)
+
+                for i in range(self.entry_edit.count()):
+                    entry_data = self.entry_edit.itemData(i)
+                    if entry_data and entry_data.get("obj_name") == self.config.signal.entry:
+                        # If the device name matches an object name, set it
+                        self.entry_edit.setCurrentIndex(i)
+                        break
+                else:
+                    # If no match found, set the first enabled item
+                    for i in range(self.entry_edit.count()):
+                        model = self.entry_edit.model()
+                        if model.flags(model.index(i, 0)) & Qt.ItemIsEnabled:
+                            self.entry_edit.setCurrentIndex(i)
+                            break
+                    else:
+                        self.entry_edit.setCurrentIndex(0)
 
             self.tree.setItemWidget(self, 1, self.device_edit)
             self.tree.setItemWidget(self, 2, self.entry_edit)
@@ -268,13 +295,22 @@ class CurveRow(QTreeWidgetItem):
             # Gather device name/entry
             device_name = ""
             device_entry = ""
+
+            ## TODO: Move this to itemData
             if hasattr(self, "device_edit"):
-                device_name = self.device_edit.text()
+                device_name = self.device_edit.currentText()
             if hasattr(self, "entry_edit"):
-                device_entry = self.entry_validator.validate_signal(
-                    name=device_name, entry=self.entry_edit.text()
-                )
-                self.entry_edit.setText(device_entry)
+                device_entry = self.entry_edit.currentText()
+                index = self.entry_edit.findText(device_entry)
+                if index > -1:
+                    device_entry_info = self.entry_edit.itemData(index)
+                    if device_entry_info:
+                        device_entry = device_entry_info.get("obj_name", device_entry)
+                else:
+                    device_entry = self.entry_validator.validate_signal(
+                        name=device_name, entry=device_entry
+                    )
+
             self.config.signal = DeviceSignal(name=device_name, entry=device_entry)
             self.config.source = "device"
             self.config.label = f"{device_name}-{device_entry}"
@@ -390,13 +426,20 @@ class CurveTree(BECWidget, QWidget):
         self.tree = QTreeWidget()
         self.tree.setColumnCount(7)
         self.tree.setHeaderLabels(["Actions", "Name", "Entry", "Color", "Style", "Width", "Symbol"])
+
+        header = self.tree.header()
+        for idx in range(self.tree.columnCount()):
+            if idx in (1, 2):  # Device name and entry should stretch
+                header.setSectionResizeMode(idx, QHeaderView.Stretch)
+            else:
+                header.setSectionResizeMode(idx, QHeaderView.Fixed)
+        header.setStretchLastSection(False)
         self.tree.setColumnWidth(0, 90)
-        self.tree.setColumnWidth(1, 100)
-        self.tree.setColumnWidth(2, 100)
         self.tree.setColumnWidth(3, 70)
         self.tree.setColumnWidth(4, 80)
-        self.tree.setColumnWidth(5, 40)
-        self.tree.setColumnWidth(6, 40)
+        self.tree.setColumnWidth(5, 50)
+        self.tree.setColumnWidth(6, 50)
+
         self.layout.addWidget(self.tree)
 
     def _init_color_buffer(self, size: int):

--- a/bec_widgets/widgets/plots/waveform/waveform.py
+++ b/bec_widgets/widgets/plots/waveform/waveform.py
@@ -330,7 +330,6 @@ class Waveform(PlotBase):
             self.curve_settings_dialog = SettingsDialog(
                 self, settings_widget=curve_setting, window_title="Curve Settings", modal=False
             )
-            self.curve_settings_dialog.setFixedWidth(580)
             # When the dialog is closed, update the toolbar icon and clear the reference
             self.curve_settings_dialog.finished.connect(self._curve_settings_closed)
             self.curve_settings_dialog.show()

--- a/tests/end-2-end/user_interaction/test_user_interaction_e2e.py
+++ b/tests/end-2-end/user_interaction/test_user_interaction_e2e.py
@@ -12,12 +12,11 @@ may not be created immediately after the rpc call is made.
 from __future__ import annotations
 
 import random
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pytest
 
-from bec_widgets.cli.client import BECDockArea
 from bec_widgets.cli.rpc.rpc_base import RPCBase, RPCReference
 
 PYTEST_TIMEOUT = 50
@@ -321,20 +320,20 @@ def test_widgets_e2e_signal_combobox(qtbot, connected_client_gui_obj, random_gen
     gui = connected_client_gui_obj
     bec = gui._client
     # Create dock_area, dock, widget
-    dock, widget = create_widget(qtbot, gui, gui.available_widgets.SignalComboBox)
-    dock: client.BECDock
+    _, widget = create_widget(qtbot, gui, gui.available_widgets.SignalComboBox)
     widget: client.SignalComboBox
 
     widget.set_device("samx")
+    info = bec.device_manager.devices.samx._info["signals"]
     assert widget.signals == [
-        "readback",
-        "setpoint",
-        "motor_is_moving",
-        "velocity",
-        "acceleration",
-        "tolerance",
+        ["samx (readback)", info.get("readback")],
+        ["setpoint", info.get("setpoint")],
+        ["motor_is_moving", info.get("motor_is_moving")],
+        ["velocity", info.get("velocity")],
+        ["acceleration", info.get("acceleration")],
+        ["tolerance", info.get("tolerance")],
     ]
-    widget.set_signal("readback")
+    widget.set_signal("samx (readback)")
 
     # Test removing the widget, or leaving it open for the next test
     maybe_remove_dock_area(qtbot, gui=gui, random_int_gen=random_generator_from_seed)

--- a/tests/unit_tests/test_device_signal_input.py
+++ b/tests/unit_tests/test_device_signal_input.py
@@ -94,18 +94,6 @@ def test_device_signal_qproperties(device_signal_base):
     assert device_signal_base._signal_filter == {Kind.config, Kind.normal}
 
 
-def test_device_signal_set_device(device_signal_base):
-    """Test if the set_device method works correctly"""
-    device_signal_base.include_hinted_signals = True
-    device_signal_base.set_device("samx")
-    assert device_signal_base.device == "samx"
-    assert device_signal_base.signals == ["readback"]
-    device_signal_base.include_normal_signals = True
-    assert device_signal_base.signals == ["readback", "setpoint"]
-    device_signal_base.include_config_signals = True
-    assert device_signal_base.signals == ["readback", "setpoint", "velocity"]
-
-
 def test_signal_combobox(qtbot, device_signal_combobox):
     """Test the signal_combobox"""
     container = []
@@ -120,17 +108,25 @@ def test_signal_combobox(qtbot, device_signal_combobox):
     device_signal_combobox.include_config_signals = True
     assert device_signal_combobox.signals == []
     device_signal_combobox.set_device("samx")
-    assert device_signal_combobox.signals == ["readback", "setpoint", "velocity"]
+    samx = device_signal_combobox.dev.samx
+    assert device_signal_combobox.signals == [
+        ("samx (readback)", samx._info["signals"].get("readback")),
+        ("setpoint", samx._info["signals"].get("setpoint")),
+        ("velocity", samx._info["signals"].get("velocity")),
+    ]
     qtbot.wait(100)
-    assert container == ["samx"]
+    assert container == ["samx (readback)"]
     # Set the type of class from the FakeDevice to Signal
-    fake_signal = FakeSignal(name="fake_signal")
+    fake_signal = FakeSignal(name="fake_signal", info={"device_info": {"signals": {}}})
     device_signal_combobox.client.device_manager.add_devices([fake_signal])
     device_signal_combobox.set_device("fake_signal")
-    assert device_signal_combobox.signals == ["fake_signal"]
+    fake_signal = device_signal_combobox.dev.fake_signal
+    assert device_signal_combobox.signals == [
+        ("fake_signal", fake_signal._info["signals"].get("fake_signal", {}))
+    ]
     assert device_signal_combobox._config_signals == []
     assert device_signal_combobox._normal_signals == []
-    assert device_signal_combobox._hinted_signals == ["fake_signal"]
+    assert device_signal_combobox._hinted_signals == [("fake_signal", {})]
 
 
 def test_signal_lineedit(device_signal_line_edit):


### PR DESCRIPTION
## Description

This PR replaces the line edits in the settings dialog of the waveform with a combobox with editing enabled, allowing users to select elements either through clicking or typing. Moreover, selecting a device will automatically populate the signal combobox. 

## Related Issues

closes #460 
closes #714

## Type of Change

- Curve settings dialog now uses the DeviceCombobox and the SignalCombobox for selecting signals to plot. 
- The displayed item of the SignalCombobox has been changed to a more reduced version. E.g. instead of the full signal entry `samx_setpoint`, it simply displays `setpoint`. If the readback got renamed to the device name (`samx` instead of `samx_readback`), the combobox displays `samx (readback)` instead. 
- The dialog window is now resizable, allowing for a larger view in case of long signal names. However, all columns except for device and signal name remain at a fixed size. 

## How to test

- Run unit tests
- Open the waveform widget 

## Potential side effects

The combobox now also contains user data, filled with the signal info. This is necessary to uniquely identify a signal from its displayed name.

## Screenshots / GIFs (if applicable)

<img width="813" alt="image" src="https://github.com/user-attachments/assets/c69d2f97-28e2-4b20-88c8-cfc2f7fd6c31" />

<img width="809" alt="image" src="https://github.com/user-attachments/assets/205c588f-c9e3-4752-9e66-3c435246b1df" />


## Definition of Done
- [x] Documentation is up-to-date.

