### PR TITLE
Fix/scan control args error

### DIFF
--- a/bec_widgets/widgets/control/scan_control/scan_control.py
+++ b/bec_widgets/widgets/control/scan_control/scan_control.py
@@ -206,26 +206,23 @@ class ScanControl(BECWidget, QWidget):
         enabled = self.toggle.checked
         current_scan = self.comboBox_scan_selection.currentText()
         if enabled:
-            history = self.client.connector.lrange(MessageEndpoints.scan_queue_history(), 0, -1)
+            history = self.client.connector.xread(MessageEndpoints.scan_history(), from_start=True)
 
             for scan in history:
-                scan_name = scan.content["info"]["request_blocks"][-1]["msg"].content["scan_type"]
+                scan_data = scan.get("data")
+                if scan_data is None:
+                    continue
+                scan_name = scan_data.scan_name
                 if scan_name == current_scan:
-                    args_dict = scan.content["info"]["request_blocks"][-1]["msg"].content[
-                        "parameter"
-                    ]["args"]
-                    args_list = []
-                    for key, value in args_dict.items():
-                        args_list.append(key)
-                        args_list.extend(value)
+                    args_list = scan_data.request_inputs.get("arg_bundle", [])
                     if len(args_list) > 1 and self.arg_box is not None:
                         self.arg_box.set_parameters(args_list)
-                    kwargs = scan.content["info"]["request_blocks"][-1]["msg"].content["parameter"][
-                        "kwargs"
-                    ]
-                    if kwargs and self.kwarg_boxes:
+                    inputs = scan_data.request_inputs.get("inputs", {})
+                    kwargs = scan_data.request_inputs.get("kwargs", {})
+                    kwarg_box_inputs = {**inputs, **kwargs}
+                    if kwarg_box_inputs and self.kwarg_boxes:
                         for box in self.kwarg_boxes:
-                            box.set_parameters(kwargs)
+                            box.set_parameters(kwarg_box_inputs)
                     self.last_scan_found = True
                     break
                 else:

--- a/bec_widgets/widgets/control/scan_control/scan_control.py
+++ b/bec_widgets/widgets/control/scan_control/scan_control.py
@@ -203,32 +203,37 @@ class ScanControl(BECWidget, QWidget):
         """
         Requests the last executed scan parameters from BEC and restores them to the scan control widget.
         """
-        enabled = self.toggle.checked
-        current_scan = self.comboBox_scan_selection.currentText()
-        if enabled:
-            history = self.client.connector.xread(MessageEndpoints.scan_history(), from_start=True)
+        self.last_scan_found = False
+        if not self.toggle.checked:
+            return
 
-            for scan in history:
-                scan_data = scan.get("data")
-                if scan_data is None:
-                    continue
-                scan_name = scan_data.scan_name
-                if scan_name == current_scan:
-                    args_list = scan_data.request_inputs.get("arg_bundle", [])
-                    if len(args_list) > 1 and self.arg_box is not None:
-                        self.arg_box.set_parameters(args_list)
-                    inputs = scan_data.request_inputs.get("inputs", {})
-                    kwargs = scan_data.request_inputs.get("kwargs", {})
-                    kwarg_box_inputs = {**inputs, **kwargs}
-                    if kwarg_box_inputs and self.kwarg_boxes:
-                        for box in self.kwarg_boxes:
-                            box.set_parameters(kwarg_box_inputs)
-                    self.last_scan_found = True
-                    break
-                else:
-                    self.last_scan_found = False
-        else:
-            self.last_scan_found = False
+        current_scan = self.comboBox_scan_selection.currentText()
+        history = self.client.connector.xread(
+            MessageEndpoints.scan_history(), from_start=True, user_id=self.object_name
+        )
+
+        for scan in history:
+            scan_data = scan.get("data")
+            if not scan_data:
+                continue
+
+            if scan_data.scan_name != current_scan:
+                continue
+
+            ri = getattr(scan_data, "request_inputs", {}) or {}
+            args_list = ri.get("arg_bundle", [])
+            if args_list and self.arg_box:
+                self.arg_box.set_parameters(args_list)
+
+            inputs = ri.get("inputs", {})
+            kwargs = ri.get("kwargs", {})
+            merged = {**inputs, **kwargs}
+            if merged and self.kwarg_boxes:
+                for box in self.kwarg_boxes:
+                    box.set_parameters(merged)
+
+            self.last_scan_found = True
+            break
 
     @SafeProperty(str)
     def current_scan(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
 ]
 dependencies = [
     "bec_ipython_client>=3.42.4, <=4.0", # needed for jupyter console
-    "bec_lib>=3.42.4, <=4.0",
+    "bec_lib>=3.44, <=4.0",
     "bec_qthemes~=0.7, >=0.7",
     "black~=25.0",                       # needed for bw-generate-cli
     "isort~=5.13, >=5.13.2",             # needed for bw-generate-cli

--- a/tests/unit_tests/test_scan_control.py
+++ b/tests/unit_tests/test_scan_control.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from bec_lib.endpoints import MessageEndpoints
-from bec_lib.messages import AvailableResourceMessage, ScanQueueHistoryMessage, ScanQueueMessage
+from bec_lib.messages import AvailableResourceMessage, ScanHistoryMessage
 from qtpy.QtCore import QModelIndex, Qt
 
 from bec_widgets.utils.forms_from_types.items import StrFormItem
@@ -221,82 +221,36 @@ available_scans_message = AvailableResourceMessage(
     }
 )
 
-scan_history = ScanQueueHistoryMessage(
+scan_history = ScanHistoryMessage(
     metadata={},
-    status="COMPLETED",
-    queue_id="94d7cb39-aa70-4060-92de-addcfb64e3c0",
-    info={
-        "queue_id": "94d7cb39-aa70-4060-92de-addcfb64e3c0",
-        "scan_id": ["bc2aa11f-24f6-44d6-8717-95e97fb43015"],
-        "is_scan": [True],
-        "request_blocks": [
-            {
-                "msg": ScanQueueMessage(
-                    metadata={
-                        "file_suffix": None,
-                        "file_directory": None,
-                        "user_metadata": {},
-                        "RID": "99321ef7-00ac-4e0c-9120-ce689bd88a4d",
-                    },
-                    scan_type="line_scan",
-                    parameter={
-                        "args": {"samx": [0.0, 2.0]},
-                        "kwargs": {
-                            "steps": 10,
-                            "relative": False,
-                            "exp_time": 2.0,
-                            "burst_at_each_point": 1,
-                            "system_config": {"file_suffix": None, "file_directory": None},
-                        },
-                    },
-                    queue="primary",
-                ),
-                "RID": "99321ef7-00ac-4e0c-9120-ce689bd88a4d",
-                "scan_motors": ["samx"],
-                "readout_priority": {
-                    "monitored": ["samx"],
-                    "baseline": [],
-                    "on_request": [],
-                    "async": [],
-                },
-                "is_scan": True,
-                "scan_number": 176,
-                "scan_id": "bc2aa11f-24f6-44d6-8717-95e97fb43015",
-                "metadata": {
-                    "file_suffix": None,
-                    "file_directory": None,
-                    "user_metadata": {},
-                    "RID": "99321ef7-00ac-4e0c-9120-ce689bd88a4d",
-                },
-                "content": {
-                    "scan_type": "line_scan",
-                    "parameter": {
-                        "args": {"samx": [0.0, 2.0]},
-                        "kwargs": {
-                            "steps": 10,
-                            "relative": False,
-                            "exp_time": 2.0,
-                            "burst_at_each_point": 1,
-                            "system_config": {"file_suffix": None, "file_directory": None},
-                        },
-                    },
-                    "queue": "primary",
-                },
-                "report_instructions": [{"scan_progress": 10}],
-            }
-        ],
-        "scan_number": [176],
-        "status": "COMPLETED",
-        "active_request_block": None,
+    scan_id="79cbef20-9ebe-45bb-a44c-f518be27a25c",
+    scan_number=1,
+    dataset_number=1,
+    file_path="/somepath/scan_1.h5",
+    exit_status="closed",
+    start_time=1750618470.936856,
+    end_time=1750618473.668227,
+    scan_name="line_scan",
+    num_points=100,
+    request_inputs={
+        "arg_bundle": ["samx", 0.0, 2.0],
+        "inputs": {},
+        "kwargs": {
+            "steps": 10,
+            "exp_time": 2,
+            "relative": False,
+            "system_config": {"file_suffix": None, "file_directory": None},
+        },
     },
-    queue="primary",
 )
 
 
 @pytest.fixture(scope="function")
 def scan_control(qtbot, mocked_client):  # , mock_dev):
     mocked_client.connector.set(MessageEndpoints.available_scans(), available_scans_message)
-    mocked_client.connector.lpush(MessageEndpoints.scan_queue_history(), scan_history)
+    mocked_client.connector.xadd(
+        topic=MessageEndpoints.scan_history(), msg_dict={"data": scan_history}
+    )
     widget = ScanControl(client=mocked_client)
     qtbot.addWidget(widget)
     qtbot.waitExposed(widget)


### PR DESCRIPTION
## Description

Scan parameters are fetched from scan_history endpoint. Has to be merged after https://github.com/bec-project/bec/pull/535

## Related Issues

- closes #707 

## How to test

- Run unit tests
- Open ScanControl widget
- run some scans, at least one 'line_scan' and one 'fermat_scan' from CLI
- try to restore parameters of these scans in the widget

## TODO
- [x] adjust unit tests

