### PR TITLE
fix(waveform): curve tree elements must clean up signal combobox

### DIFF
--- a/bec_widgets/widgets/plots/waveform/settings/curve_settings/curve_tree.py
+++ b/bec_widgets/widgets/plots/waveform/settings/curve_settings/curve_tree.py
@@ -580,7 +580,4 @@ class CurveTree(BECWidget, QWidget):
         all_items = list(self.all_items)
         for item in all_items:
             item.remove_self()
-
-    def closeEvent(self, event):
-        self.cleanup()
-        return super().closeEvent(event)
+        super().cleanup()

--- a/bec_widgets/widgets/plots/waveform/settings/curve_settings/curve_tree.py
+++ b/bec_widgets/widgets/plots/waveform/settings/curve_settings/curve_tree.py
@@ -263,6 +263,11 @@ class CurveRow(QTreeWidgetItem):
             self.device_edit.deleteLater()
             self.device_edit = None
 
+        if getattr(self, "entry_edit", None) is not None:
+            self.entry_edit.close()
+            self.entry_edit.deleteLater()
+            self.entry_edit = None
+
         if getattr(self, "dap_combo", None) is not None:
             self.dap_combo.close()
             self.dap_combo.deleteLater()


### PR DESCRIPTION
## Description

Now that the curve tree contains also a combobox for the signal entry, the corresponding combobox must be added to the cleanup. 

I also noticed that the curve tree cleanup manually intercepted the close event and swallowed the cleanup call. I changed it now such that the curve tree also propagates the cleanup call to its parent (BECWidget). The manual interception was not needed IMO. 

## Related Issues

closes #730 

## How to test

- Run unit tests
- Open the waveform widget, add and remove curve items and close the widget again. The launcher should pop up again.

## Potential side effects

It's the cleanup in Qt... you never know. None, I hope!

## Definition of Done
- [x] Documentation is up-to-date.

