### PR TITLE
fix(signal input base): DeviceSignalInputBase cleanup

### DIFF
--- a/bec_widgets/widgets/control/device_input/base_classes/device_signal_input_base.py
+++ b/bec_widgets/widgets/control/device_input/base_classes/device_signal_input_base.py
@@ -55,7 +55,7 @@ class DeviceSignalInputBase(BECWidget):
         self._hinted_signals = []
         self._normal_signals = []
         self._config_signals = []
-        self.bec_dispatcher.client.callbacks.register(
+        self._device_update_register = self.bec_dispatcher.client.callbacks.register(
             EventType.DEVICE_UPDATE, self.update_signals_from_filters
         )
 
@@ -289,3 +289,10 @@ class DeviceSignalInputBase(BECWidget):
         if config is None:
             return DeviceSignalInputBaseConfig(widget_class=self.__class__.__name__)
         return DeviceSignalInputBaseConfig.model_validate(config)
+
+    def cleanup(self):
+        """
+        Cleanup the widget.
+        """
+        self.bec_dispatcher.client.callbacks.remove(self._device_update_register)
+        super().cleanup()

--- a/tests/unit_tests/test_device_signal_input.py
+++ b/tests/unit_tests/test_device_signal_input.py
@@ -144,3 +144,12 @@ def test_signal_lineedit(device_signal_line_edit):
     assert device_signal_line_edit._is_valid_input is True
     device_signal_line_edit.setText("invalid")
     assert device_signal_line_edit._is_valid_input is False
+
+
+def test_device_signal_input_base_cleanup(qtbot, mocked_client):
+
+    widget = DeviceInputWidget(client=mocked_client)
+    widget.close()
+    widget.deleteLater()
+
+    mocked_client.callbacks.remove.assert_called_once_with(widget._device_update_register)


### PR DESCRIPTION
## Description

This PR fixes a bug that became more apparent after merging #717 and #728 and thus using the `DeviceSignalInputBase` class frequently. The bug was caused by not properly removing callback from the client status updates, leading to `c++ object already deleted` messages. 

## How to test

- Run unit tests
- Open the waveform widget, open the curve settings dialog and close it again. Reload the config. No error messages should appear. 

## Definition of Done
- [x] Documentation is up-to-date.

