### PR TITLE
feat(sbb monitor): add sbb monitor widget

### DIFF
--- a/bec_widgets/cli/client.py
+++ b/bec_widgets/cli/client.py
@@ -49,6 +49,7 @@ _Widgets = {
     "ResetButton": "ResetButton",
     "ResumeButton": "ResumeButton",
     "RingProgressBar": "RingProgressBar",
+    "SBBMonitor": "SBBMonitor",
     "ScanControl": "ScanControl",
     "ScatterWaveform": "ScatterWaveform",
     "SignalComboBox": "SignalComboBox",
@@ -3247,6 +3248,12 @@ class RingProgressBar(RPCBase):
         Returns:
             bool: True if scan segment updates are enabled.
         """
+
+
+class SBBMonitor(RPCBase):
+    """A widget to display the SBB monitor website."""
+
+    ...
 
 
 class ScanControl(RPCBase):

--- a/bec_widgets/widgets/containers/dock/dock_area.py
+++ b/bec_widgets/widgets/containers/dock/dock_area.py
@@ -169,6 +169,9 @@ class BECDockArea(BECWidget, QWidget):
                             tooltip="Add LogPanel - Disabled",
                             filled=True,
                         ),
+                        "sbb_monitor": MaterialIconAction(
+                            icon_name="train", tooltip="Add SBB Monitor", filled=True
+                        ),
                     },
                 ),
                 "separator_2": SeparatorAction(),
@@ -238,6 +241,9 @@ class BECDockArea(BECWidget, QWidget):
         # self.toolbar.widgets["menu_utils"].widgets["log_panel"].triggered.connect(
         #     lambda: self._create_widget_from_toolbar(widget_name="LogPanel")
         # )
+        self.toolbar.widgets["menu_utils"].widgets["sbb_monitor"].triggered.connect(
+            lambda: self._create_widget_from_toolbar(widget_name="SBBMonitor")
+        )
 
         # Icons
         self.toolbar.widgets["attach_all"].action.triggered.connect(self.attach_all)

--- a/bec_widgets/widgets/editors/sbb_monitor/register_sbb_monitor.py
+++ b/bec_widgets/widgets/editors/sbb_monitor/register_sbb_monitor.py
@@ -1,0 +1,15 @@
+def main():  # pragma: no cover
+    from qtpy import PYSIDE6
+
+    if not PYSIDE6:
+        print("PYSIDE6 is not available in the environment. Cannot patch designer.")
+        return
+    from PySide6.QtDesigner import QPyDesignerCustomWidgetCollection
+
+    from bec_widgets.widgets.editors.sbb_monitor.sbb_monitor_plugin import SBBMonitorPlugin
+
+    QPyDesignerCustomWidgetCollection.addCustomWidget(SBBMonitorPlugin())
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/bec_widgets/widgets/editors/sbb_monitor/sbb_monitor.py
+++ b/bec_widgets/widgets/editors/sbb_monitor/sbb_monitor.py
@@ -1,0 +1,15 @@
+from bec_widgets.widgets.editors.website.website import WebsiteWidget
+
+
+class SBBMonitor(WebsiteWidget):
+    """
+    A widget to display the SBB monitor website.
+    """
+
+    PLUGIN = True
+    ICON_NAME = "train"
+    USER_ACCESS = []
+
+    def __init__(self, parent=None, **kwargs):
+        url = "https://free.oevplus.ch/monitor/?viewType=splitView&layout=1&showClock=true&showPerron=true&stationGroup1Title=Villigen%2C%20PSI%20West&stationGroup2Title=Siggenthal-Würenlingen&station_1_id=85%3A3592&station_1_name=Villigen%2C%20PSI%20West&station_1_quantity=5&station_1_group=1&station_2_id=85%3A3502&station_2_name=Siggenthal-Würenlingen&station_2_quantity=5&station_2_group=2"
+        super().__init__(parent=parent, url=url, **kwargs)

--- a/bec_widgets/widgets/editors/sbb_monitor/sbb_monitor_plugin.py
+++ b/bec_widgets/widgets/editors/sbb_monitor/sbb_monitor_plugin.py
@@ -1,0 +1,54 @@
+# Copyright (C) 2022 The Qt Company Ltd.
+# SPDX-License-Identifier: LicenseRef-Qt-Commercial OR BSD-3-Clause
+
+from qtpy.QtDesigner import QDesignerCustomWidgetInterface
+
+from bec_widgets.utils.bec_designer import designer_material_icon
+from bec_widgets.widgets.editors.sbb_monitor.sbb_monitor import SBBMonitor
+
+DOM_XML = """
+<ui language='c++'>
+    <widget class='SBBMonitor' name='sbb_monitor'>
+    </widget>
+</ui>
+"""
+
+
+class SBBMonitorPlugin(QDesignerCustomWidgetInterface):  # pragma: no cover
+    def __init__(self):
+        super().__init__()
+        self._form_editor = None
+
+    def createWidget(self, parent):
+        t = SBBMonitor(parent)
+        return t
+
+    def domXml(self):
+        return DOM_XML
+
+    def group(self):
+        return ""
+
+    def icon(self):
+        return designer_material_icon(SBBMonitor.ICON_NAME)
+
+    def includeFile(self):
+        return "sbb_monitor"
+
+    def initialize(self, form_editor):
+        self._form_editor = form_editor
+
+    def isContainer(self):
+        return False
+
+    def isInitialized(self):
+        return self._form_editor is not None
+
+    def name(self):
+        return "SBBMonitor"
+
+    def toolTip(self):
+        return ""
+
+    def whatsThis(self):
+        return self.toolTip()


### PR DESCRIPTION
## Description

This PR adds a utility widget for displaying the SBB monitor, similar to the one at the gates to PSI West / East. I think for BL scientists and users, this could be a very useful widget. 

SBB provides a unified monitoring tool that can be simply embedded using a url. (I wish more companies would do that!)

## Type of Change

- Add new SBBMonitor widget
- Expose the widget through the dock area

## How to test

- Run unit tests
- Open the SBBMonitor in designer or DockArea

## Screenshots / GIFs (if applicable)

<img width="912" alt="image" src="https://github.com/user-attachments/assets/6c5ef842-92d6-44fa-bf4c-330e3de7f92d" />


## Definition of Done
- [x] Documentation is up-to-date.

