### PR TITLE
test: assert config for equality, not identity

### DIFF
--- a/tests/unit_tests/test_rpc_server.py
+++ b/tests/unit_tests/test_rpc_server.py
@@ -29,4 +29,4 @@ def test_gui_server_get_service_config(gui_server):
     """
     Test that the server is started with the correct arguments.
     """
-    assert gui_server._get_service_config().config is ServiceConfig().config
+    assert gui_server._get_service_config().config == ServiceConfig().config


### PR DESCRIPTION
## Description

Fixes an issue in the service config test that relies on checking the identity of the config (dictionary) instead of checking for the same content. 

## Definition of Done
- [x] Documentation is up-to-date.

