### PR TITLE
fix(image_roi_tree): changing color dialog from ColorButtonNative is open once

### DIFF
--- a/bec_widgets/widgets/plots/image/setting_widgets/image_roi_tree.py
+++ b/bec_widgets/widgets/plots/image/setting_widgets/image_roi_tree.py
@@ -363,7 +363,9 @@ class ROIPropertyTree(BECWidget, QWidget):
         # color button
         color_btn = ColorButtonNative(parent=self, color=roi.line_color)
         self.tree.setItemWidget(parent, self.COL_PROPS, color_btn)
-        color_btn.clicked.connect(lambda: self._pick_color(roi, color_btn))
+        color_btn.color_changed.connect(
+            lambda new_color, r=roi: setattr(r, "line_color", new_color)
+        )
 
         # child rows (3 columns: action, ROI, properties)
         QTreeWidgetItem(parent, ["", "Type", roi.__class__.__name__])


### PR DESCRIPTION
## Description

There was a bug that when user wanted to change the color of roi the dialog would appear twice.
