### PR TITLE
Fix/heatmap

### DIFF
--- a/bec_widgets/utils/crosshair.py
+++ b/bec_widgets/utils/crosshair.py
@@ -6,7 +6,7 @@ from typing import Any
 import numpy as np
 import pyqtgraph as pg
 from qtpy.QtCore import QObject, QPointF, Qt, Signal
-from qtpy.QtGui import QTransform
+from qtpy.QtGui import QCursor, QTransform
 from qtpy.QtWidgets import QApplication
 
 from bec_widgets.utils.error_popups import SafeSlot
@@ -282,6 +282,34 @@ class Crosshair(QObject):
                 self.marker_2d_col.skip_auto_range = True
                 self.plot_item.addItem(self.marker_2d_col)
 
+    @SafeSlot()
+    def update_markers_on_image_change(self):
+        """
+        Update markers when the image changes, e.g. when the
+        image shape or transformation changes.
+        """
+        for item in self.items:
+            if not isinstance(item, pg.ImageItem):
+                continue
+            if self.marker_2d_row is not None:
+                self.marker_2d_row.setSize([item.image.shape[0], 1])
+                self.marker_2d_row.setTransform(item.image_transform)
+            if self.marker_2d_col is not None:
+                self.marker_2d_col.setSize([1, item.image.shape[1]])
+                self.marker_2d_col.setTransform(item.image_transform)
+            # Get the current mouse position
+            views = self.plot_item.vb.scene().views()
+            if not views:
+                return
+            view = views[0]
+            global_pos = QCursor.pos()
+            view_pos = view.mapFromGlobal(global_pos)
+            scene_pos = view.mapToScene(view_pos)
+
+            if self.plot_item.vb.sceneBoundingRect().contains(scene_pos):
+                plot_pt = self.plot_item.vb.mapSceneToView(scene_pos)
+                self.mouse_moved(manual_pos=(plot_pt.x(), plot_pt.y()))
+
     def snap_to_data(
         self, x: float, y: float
     ) -> tuple[None, None] | tuple[defaultdict[Any, list], defaultdict[Any, list]]:
@@ -382,67 +410,74 @@ class Crosshair(QObject):
 
         return list_x[original_index], list_y[original_index]
 
-    def mouse_moved(self, event):
-        """Handles the mouse moved event, updating the crosshair position and emitting signals.
+    @SafeSlot(object, tuple)
+    def mouse_moved(self, event=None, manual_pos=None):
+        """
+        Handles the mouse moved event, updating the crosshair position and emitting signals.
 
         Args:
-            event: The mouse moved event
+            event(object): The mouse moved event, which contains the scene position.
+            manual_pos(tuple, optional): A tuple containing the (x, y) coordinates to manually set the crosshair position.
         """
-        pos = event[0]
+        # Determine target (x, y) in *plot* coordinates
+        if manual_pos is not None:
+            x, y = manual_pos
+        else:
+            if event is None:
+                return  # nothing to do
+            scene_pos = event[0]  # SignalProxy bundle
+            if not self.plot_item.vb.sceneBoundingRect().contains(scene_pos):
+                return
+            view_pos = self.plot_item.vb.mapSceneToView(scene_pos)
+            x, y = view_pos.x(), view_pos.y()
+
+        # Update cross‑hair visuals
+        self.v_line.setPos(x)
+        self.h_line.setPos(y)
+
         self.update_markers()
-        if self.plot_item.vb.sceneBoundingRect().contains(pos):
-            mouse_point = self.plot_item.vb.mapSceneToView(pos)
-            x, y = mouse_point.x(), mouse_point.y()
-            self.v_line.setPos(x)
-            self.h_line.setPos(y)
-            scaled_x, scaled_y = self.scale_emitted_coordinates(mouse_point.x(), mouse_point.y())
-            self.crosshairChanged.emit((scaled_x, scaled_y))
-            self.positionChanged.emit((x, y))
+        scaled_x, scaled_y = self.scale_emitted_coordinates(x, y)
+        self.crosshairChanged.emit((scaled_x, scaled_y))
+        self.positionChanged.emit((x, y))
 
-            x_snap_values, y_snap_values = self.snap_to_data(x, y)
-            if x_snap_values is None or y_snap_values is None:
-                return
-            if all(v is None for v in x_snap_values.values()) or all(
-                v is None for v in y_snap_values.values()
-            ):
-                # not sure how we got here, but just to be safe...
-                return
+        snap_x_vals, snap_y_vals = self.snap_to_data(x, y)
+        if snap_x_vals is None or snap_y_vals is None:
+            return
+        if all(v is None for v in snap_x_vals.values()) or all(
+            v is None for v in snap_y_vals.values()
+        ):
+            return
 
-            precision = self._current_precision()
-            for item in self.items:
-                if isinstance(item, pg.PlotDataItem):
-                    name = item.name() or str(id(item))
-                    x, y = x_snap_values[name], y_snap_values[name]
-                    if x is None or y is None:
-                        continue
-                    self.marker_moved_1d[name].setData([x], [y])
-                    x_snapped_scaled, y_snapped_scaled = self.scale_emitted_coordinates(x, y)
-                    coordinate_to_emit = (
-                        name,
-                        round(x_snapped_scaled, precision),
-                        round(y_snapped_scaled, precision),
-                    )
-                    self.coordinatesChanged1D.emit(coordinate_to_emit)
-                elif isinstance(item, pg.ImageItem):
-                    name = item.objectName() or str(id(item))
-                    x, y = x_snap_values[name], y_snap_values[name]
-                    if x is None or y is None:
-                        continue
+        precision = self._current_precision()
 
-                    # Compute offsets that respect the image's transform so the ROIs
-                    if isinstance(item, ImageItem) and item.image_transform is not None:
-                        row, col = self._get_transformed_position(x, y, item.image_transform)
-
-                        self.marker_2d_row.setPos(row)
-                        self.marker_2d_col.setPos(col)
-                    else:
-                        self.marker_2d_row.setPos([0, y])
-                        self.marker_2d_col.setPos([x, 0])
-
-                    coordinate_to_emit = (name, x, y)
-                    self.coordinatesChanged2D.emit(coordinate_to_emit)
-                else:
+        for item in self.items:
+            if isinstance(item, pg.PlotDataItem):
+                name = item.name() or str(id(item))
+                sx, sy = snap_x_vals[name], snap_y_vals[name]
+                if sx is None or sy is None:
                     continue
+                self.marker_moved_1d[name].setData([sx], [sy])
+                sx_s, sy_s = self.scale_emitted_coordinates(sx, sy)
+                self.coordinatesChanged1D.emit(
+                    (name, round(sx_s, precision), round(sy_s, precision))
+                )
+
+            elif isinstance(item, pg.ImageItem):
+                name = item.objectName() or str(id(item))
+                px, py = snap_x_vals[name], snap_y_vals[name]
+                if px is None or py is None:
+                    continue
+
+                # Respect image transforms
+                if isinstance(item, ImageItem) and item.image_transform is not None:
+                    row, col = self._get_transformed_position(px, py, item.image_transform)
+                    self.marker_2d_row.setPos(row)
+                    self.marker_2d_col.setPos(col)
+                else:
+                    self.marker_2d_row.setPos([0, py])
+                    self.marker_2d_col.setPos([px, 0])
+
+                self.coordinatesChanged2D.emit((name, px, py))
 
     def mouse_clicked(self, event):
         """Handles the mouse clicked event, updating the crosshair position and emitting signals.

--- a/bec_widgets/widgets/plots/heatmap/heatmap.py
+++ b/bec_widgets/widgets/plots/heatmap/heatmap.py
@@ -431,6 +431,8 @@ class Heatmap(ImageBase):
         if self._color_bar is not None:
             self._color_bar.blockSignals(False)
         self.image_updated.emit()
+        if self.crosshair is not None:
+            self.crosshair.update_markers_on_image_change()
 
     def get_image_data(
         self,
@@ -457,14 +459,19 @@ class Heatmap(ImageBase):
             return None, None
 
         if msg.scan_name == "grid_scan":
-            return self.get_grid_scan_image(z_data, msg)
-        if msg.scan_type == "step" and msg.info["positions"]:
-            if len(z_data) < 4:
-                # LinearNDInterpolator requires at least 4 points to interpolate
-                return None, None
-            return self.get_step_scan_image(x_data, y_data, z_data, msg)
-        logger.warning(f"Scan type {msg.scan_name} not supported.")
-        return None, None
+            # We only support the grid scan mode if both scanning motors
+            # are configured in the heatmap config.
+            device_x = self._image_config.x_device.entry
+            device_y = self._image_config.y_device.entry
+            if (
+                device_x in msg.request_inputs["arg_bundle"]
+                and device_y in msg.request_inputs["arg_bundle"]
+            ):
+                return self.get_grid_scan_image(z_data, msg)
+        if len(z_data) < 4:
+            # LinearNDInterpolator requires at least 4 points to interpolate
+            return None, None
+        return self.get_step_scan_image(x_data, y_data, z_data, msg)
 
     def get_grid_scan_image(
         self, z_data: list[float], msg: messages.ScanStatusMessage
@@ -560,17 +567,16 @@ class Heatmap(ImageBase):
         Returns:
             tuple[np.ndarray, QTransform]: The image data and the QTransform.
         """
-
-        grid_x, grid_y, transform = self.get_image_grid(msg.scan_id)
+        xy_data = np.column_stack((x_data, y_data))
+        grid_x, grid_y, transform = self.get_image_grid(xy_data)
 
         # Interpolate the z data onto the grid
-        interp = LinearNDInterpolator(np.column_stack((x_data, y_data)), z_data)
+        interp = LinearNDInterpolator(xy_data, z_data)
         grid_z = interp(grid_x, grid_y)
 
         return grid_z, transform
 
-    @functools.lru_cache(maxsize=2)
-    def get_image_grid(self, _scan_id) -> tuple[np.ndarray, np.ndarray, QTransform]:
+    def get_image_grid(self, positions) -> tuple[np.ndarray, np.ndarray, QTransform]:
         """
         LRU-cached calculation of the grid for the image. The lru cache is indexed by the scan_id
         to avoid recalculating the grid for the same scan.
@@ -581,8 +587,6 @@ class Heatmap(ImageBase):
         Returns:
             tuple[np.ndarray, np.ndarray, QTransform]: The grid x and y coordinates and the QTransform.
         """
-        msg = self.status_message
-        positions = np.asarray(msg.info["positions"])
 
         width, height = self.estimate_image_resolution(positions)
 
@@ -608,7 +612,8 @@ class Heatmap(ImageBase):
 
         return grid_x, grid_y, transform
 
-    def estimate_image_resolution(self, coords: np.ndarray) -> tuple[int, int]:
+    @staticmethod
+    def estimate_image_resolution(coords: np.ndarray) -> tuple[int, int]:
         """
         Estimate the number of pixels needed for the image based on the coordinates.
 

--- a/tests/unit_tests/test_heatmap_widget.py
+++ b/tests/unit_tests/test_heatmap_widget.py
@@ -62,8 +62,15 @@ def test_heatmap_get_image_data_missing_data(heatmap_widget):
 
 def test_heatmap_get_image_data_grid_scan(heatmap_widget):
     scan_msg = messages.ScanStatusMessage(
-        scan_id="123", status="open", scan_name="grid_scan", metadata={}, info={}
+        scan_id="123",
+        status="open",
+        scan_name="grid_scan",
+        metadata={},
+        info={},
+        request_inputs={"arg_bundle": ["samx", -5, 5, 10, "samy", -5, 5, 10], "kwargs": {}},
     )
+    heatmap_widget.plot(x_name="samx", y_name="samy", z_name="bpm4i")
+
     heatmap_widget.status_message = scan_msg
     with mock.patch.object(heatmap_widget, "get_grid_scan_image") as mock_get_grid_scan_image:
         heatmap_widget.get_image_data(x_data=[1, 2], y_data=[3, 4], z_data=[5, 6])


### PR DESCRIPTION
## Description

This PR solves two problems:

* The heatmap now supports arbitrary shapes without relying on the scan status position array to pre-allocate the ROI. 
* The crosshair markers can be updated in runtime, even within a running scan. This is used in the heatmap widget as the image size updates continuously. 


closes #760 

## Definition of Done
- [x] Documentation is up-to-date.

