### PR TITLE
fix: update signal label for device_edit changes

### DIFF
--- a/bec_widgets/widgets/control/device_input/base_classes/device_signal_input_base.py
+++ b/bec_widgets/widgets/control/device_input/base_classes/device_signal_input_base.py
@@ -69,7 +69,7 @@ class DeviceSignalInputBase(BECWidget):
         Args:
             signal (str): signal name.
         """
-        if self.validate_signal(signal) is True:
+        if self.validate_signal(signal):
             WidgetIO.set_value(widget=self, value=signal)
             self.config.default = signal
         else:

--- a/bec_widgets/widgets/control/device_input/signal_combobox/signal_combobox.py
+++ b/bec_widgets/widgets/control/device_input/signal_combobox/signal_combobox.py
@@ -142,6 +142,10 @@ class SignalComboBox(DeviceSignalInputBase, QComboBox):
             return
         self.device_signal_changed.emit(text)
 
+    @property
+    def selected_signal_comp_name(self) -> str:
+        return dict(self.signals).get(self.currentText(), {}).get("component_name", "")
+
 
 if __name__ == "__main__":  # pragma: no cover
     # pylint: disable=import-outside-toplevel

--- a/bec_widgets/widgets/utility/signal_label/signal_label.py
+++ b/bec_widgets/widgets/utility/signal_label/signal_label.py
@@ -10,7 +10,6 @@ from bec_qthemes import material_icon
 from qtpy.QtCore import Signal as QSignal
 from qtpy.QtWidgets import (
     QApplication,
-    QComboBox,
     QDialog,
     QDialogButtonBox,
     QGroupBox,
@@ -121,7 +120,9 @@ class ChoiceDialog(QDialog):
             self._signal_field.clear()
 
     def accept(self):
-        self.accepted_output.emit(self._device_field.text(), self._signal_field.currentText())
+        self.accepted_output.emit(
+            self._device_field.text(), self._signal_field.selected_signal_comp_name
+        )
         return super().accept()
 
 

--- a/tests/unit_tests/test_signal_label.py
+++ b/tests/unit_tests/test_signal_label.py
@@ -142,6 +142,7 @@ def test_choose_signal_dialog_sends_choices(signal_label: SignalLabel, qtbot):
     qtbot.waitUntil(dialog.button_box.button(QDialogButtonBox.Ok).isVisible, timeout=500)
     dialog._device_field.dev["test device"] = MagicMock()
     dialog._device_field.setText("test device")
+    dialog._signal_field._signals = [("test signal", {"component_name": "test signal"})]
     dialog._signal_field.addItem("test signal")
     dialog._signal_field.setCurrentIndex(0)
     qtbot.mouseClick(dialog.button_box.button(QDialogButtonBox.Ok), QtCore.Qt.LeftButton)
@@ -154,6 +155,7 @@ def test_dialog_handler_updates_devices(signal_label: SignalLabel, qtbot):
     qtbot.waitUntil(dialog.button_box.button(QDialogButtonBox.Ok).isVisible, timeout=500)
     dialog._device_field.dev["flux_capacitor"] = MagicMock()
     dialog._device_field.setText("flux_capacitor")
+    dialog._signal_field._signals = [("spin_speed", {"component_name": "spin_speed"})]
     dialog._signal_field.addItem("spin_speed")
     dialog._signal_field.setCurrentIndex(0)
     qtbot.mouseClick(dialog.button_box.button(QDialogButtonBox.Ok), QtCore.Qt.LeftButton)


### PR DESCRIPTION
`SignalComboBox` was changed to output text like `"samx (readback)"` but `signal_label` was not updated to match. Added a property to access the component name for this use case. Fixes #773 
