### PR TITLE
Feat/device browser improvements

### DIFF
--- a/bec_widgets/widgets/services/device_browser/device_browser.py
+++ b/bec_widgets/widgets/services/device_browser/device_browser.py
@@ -4,12 +4,13 @@ from functools import partial
 
 from bec_lib.callback_handler import EventType
 from bec_lib.config_helper import ConfigHelper
+from bec_lib.endpoints import MessageEndpoints
 from bec_lib.logger import bec_logger
-from bec_lib.messages import ConfigAction
+from bec_lib.messages import ConfigAction, ScanStatusMessage
 from bec_qthemes import material_icon
 from pyqtgraph import SignalProxy
 from qtpy.QtCore import QSize, QThreadPool, Signal
-from qtpy.QtWidgets import QListWidget, QListWidgetItem, QVBoxLayout, QWidget
+from qtpy.QtWidgets import QLabel, QListWidget, QListWidgetItem, QToolButton, QVBoxLayout, QWidget
 
 from bec_widgets.cli.rpc.rpc_register import RPCRegister
 from bec_widgets.utils.bec_widget import BECWidget
@@ -30,6 +31,7 @@ class DeviceBrowser(BECWidget, QWidget):
     """
 
     devices_changed: Signal = Signal()
+    editing_enabled: Signal = Signal(bool)
     device_update: Signal = Signal(str, dict)
     PLUGIN = True
     ICON_NAME = "lists"
@@ -47,7 +49,7 @@ class DeviceBrowser(BECWidget, QWidget):
         self._config_helper = ConfigHelper(self.client.connector, self.client._service_name)
         self._q_threadpool = QThreadPool()
         self.ui = None
-        self.ini_ui()
+        self.init_ui()
         self.dev_list: QListWidget = self.ui.device_list
         self.dev_list.setVerticalScrollMode(QListWidget.ScrollMode.ScrollPerPixel)
         self.proxy_device_update = SignalProxy(
@@ -56,14 +58,20 @@ class DeviceBrowser(BECWidget, QWidget):
         self.bec_dispatcher.client.callbacks.register(
             EventType.DEVICE_UPDATE, self.on_device_update
         )
+        self.bec_dispatcher.client.callbacks.register(
+            EventType.SCAN_STATUS, self.scan_status_changed
+        )
+
         self.devices_changed.connect(self.update_device_list)
         self.ui.add_button.clicked.connect(self._create_add_dialog)
         self.ui.add_button.setIcon(material_icon("add", size=(20, 20), convert_to_pixmap=False))
 
+        self.init_warning_label()
+
         self.init_device_list()
         self.update_device_list()
 
-    def ini_ui(self) -> None:
+    def init_ui(self) -> None:
         """
         Initialize the UI by loading the UI file and setting the layout.
         """
@@ -72,6 +80,15 @@ class DeviceBrowser(BECWidget, QWidget):
         self.ui = UILoader(self).loader(ui_file_path)
         layout.addWidget(self.ui)
         self.setLayout(layout)
+
+    def init_warning_label(self):
+        self.ui.scan_running_warning.setText("Warning: editing diabled while scan is running!")
+        self.ui.scan_running_warning.setStyleSheet(
+            "background-color: #fcba03; color: rgb(0, 0, 0);"
+        )
+        scan_status = self.bec_dispatcher.client.connector.get(MessageEndpoints.scan_status())
+        initial_status = scan_status.status if scan_status is not None else "closed"
+        self.set_editing_mode(initial_status not in ["open", "paused"])
 
     def _create_add_dialog(self):
         dialog = DeviceConfigDialog(parent=self, device=None, action="add")
@@ -120,6 +137,7 @@ class DeviceBrowser(BECWidget, QWidget):
         )
         device_item.expansion_state_changed.connect(partial(_updatesize, item, device_item))
         device_item.imminent_deletion.connect(partial(_remove_item, item))
+        self.editing_enabled.connect(device_item.set_editable)
         self.device_update.connect(device_item.config_update)
         tooltip = self.dev[device]._config.get("description", "")
         device_item.setToolTip(tooltip)
@@ -129,6 +147,17 @@ class DeviceBrowser(BECWidget, QWidget):
         self.dev_list.setItemWidget(item, device_item)
         self.dev_list.addItem(item)
         self._device_items[device] = item
+
+    @SafeSlot(bool)
+    def scan_status_changed(self, scan_info: dict, _: dict):
+        """disable editing when scans are running and enable editing when they are finished"""
+        msg = ScanStatusMessage.model_validate(scan_info)
+        self.set_editing_mode(msg.status not in ["open", "paused"])
+
+    def set_editing_mode(self, enabled: bool):
+        self.ui.add_button.setEnabled(enabled)
+        self.ui.scan_running_warning.setHidden(enabled)
+        self.editing_enabled.emit(enabled)
 
     @SafeSlot()
     def reset_device_list(self) -> None:

--- a/bec_widgets/widgets/services/device_browser/device_browser.py
+++ b/bec_widgets/widgets/services/device_browser/device_browser.py
@@ -1,7 +1,9 @@
 import os
 import re
 from functools import partial
+from typing import Callable
 
+import bec_lib
 from bec_lib.callback_handler import EventType
 from bec_lib.config_helper import ConfigHelper
 from bec_lib.endpoints import MessageEndpoints
@@ -10,7 +12,14 @@ from bec_lib.messages import ConfigAction, ScanStatusMessage
 from bec_qthemes import material_icon
 from pyqtgraph import SignalProxy
 from qtpy.QtCore import QSize, QThreadPool, Signal
-from qtpy.QtWidgets import QLabel, QListWidget, QListWidgetItem, QToolButton, QVBoxLayout, QWidget
+from qtpy.QtWidgets import (
+    QFileDialog,
+    QListWidget,
+    QListWidgetItem,
+    QToolButton,
+    QVBoxLayout,
+    QWidget,
+)
 
 from bec_widgets.cli.rpc.rpc_register import RPCRegister
 from bec_widgets.utils.bec_widget import BECWidget
@@ -61,12 +70,14 @@ class DeviceBrowser(BECWidget, QWidget):
         self.bec_dispatcher.client.callbacks.register(
             EventType.SCAN_STATUS, self.scan_status_changed
         )
+        self._default_config_dir = os.path.abspath(
+            os.path.join(os.path.dirname(bec_lib.__file__), "./configs/")
+        )
 
         self.devices_changed.connect(self.update_device_list)
-        self.ui.add_button.clicked.connect(self._create_add_dialog)
-        self.ui.add_button.setIcon(material_icon("add", size=(20, 20), convert_to_pixmap=False))
 
         self.init_warning_label()
+        self.init_tool_buttons()
 
         self.init_device_list()
         self.update_device_list()
@@ -89,6 +100,18 @@ class DeviceBrowser(BECWidget, QWidget):
         scan_status = self.bec_dispatcher.client.connector.get(MessageEndpoints.scan_status())
         initial_status = scan_status.status if scan_status is not None else "closed"
         self.set_editing_mode(initial_status not in ["open", "paused"])
+
+    def init_tool_buttons(self):
+        def _setup_button(button: QToolButton, icon: str, slot: Callable, tooltip: str = ""):
+            button.clicked.connect(slot)
+            button.setIcon(material_icon(icon, size=(20, 20), convert_to_pixmap=False))
+            button.setToolTip(tooltip)
+
+        _setup_button(self.ui.add_button, "add", self._create_add_dialog, "add new device")
+        _setup_button(self.ui.save_button, "save", self._save_to_file, "save config to file")
+        _setup_button(
+            self.ui.import_button, "input", self._load_from_file, "append/merge config from file"
+        )
 
     def _create_add_dialog(self):
         dialog = DeviceConfigDialog(parent=self, device=None, action="add")
@@ -148,7 +171,7 @@ class DeviceBrowser(BECWidget, QWidget):
         self.dev_list.addItem(item)
         self._device_items[device] = item
 
-    @SafeSlot(bool)
+    @SafeSlot(dict, dict)
     def scan_status_changed(self, scan_info: dict, _: dict):
         """disable editing when scans are running and enable editing when they are finished"""
         msg = ScanStatusMessage.model_validate(scan_info)
@@ -189,6 +212,22 @@ class DeviceBrowser(BECWidget, QWidget):
             return
         for device in self.dev:
             self._device_items[device].setHidden(not self.regex.search(device))
+
+    @SafeSlot()
+    def _load_from_file(self):
+        file_path, _ = QFileDialog.getOpenFileName(
+            self, "Update config from file", self._default_config_dir, "Config files (*.yml *.yaml)"
+        )
+        if file_path:
+            self._config_helper.update_session_with_file(file_path)
+
+    @SafeSlot()
+    def _save_to_file(self):
+        file_path, _ = QFileDialog.getSaveFileName(
+            self, "Save config to file", self._default_config_dir, "Config files (*.yml *.yaml)"
+        )
+        if file_path:
+            self._config_helper.save_current_session(file_path)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/bec_widgets/widgets/services/device_browser/device_browser.ui
+++ b/bec_widgets/widgets/services/device_browser/device_browser.ui
@@ -51,6 +51,20 @@
              </property>
             </widget>
            </item>
+           <item>
+            <widget class="QToolButton" name="save_button">
+             <property name="text">
+              <string>...</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QToolButton" name="import_button">
+             <property name="text">
+              <string>...</string>
+             </property>
+            </widget>
+           </item>
           </layout>
          </widget>
         </item>

--- a/bec_widgets/widgets/services/device_browser/device_browser.ui
+++ b/bec_widgets/widgets/services/device_browser/device_browser.ui
@@ -57,6 +57,16 @@
        </layout>
       </item>
       <item>
+       <widget class="QLabel" name="scan_running_warning">
+        <property name="styleSheet">
+         <string notr="true"/>
+        </property>
+        <property name="text">
+         <string>warning</string>
+        </property>
+       </widget>
+      </item>
+      <item>
        <widget class="QListWidget" name="device_list"/>
       </item>
      </layout>

--- a/bec_widgets/widgets/services/device_browser/device_item/config_communicator.py
+++ b/bec_widgets/widgets/services/device_browser/device_item/config_communicator.py
@@ -39,9 +39,10 @@ class CommunicateConfigAction(QRunnable):
                     raise ValueError(
                         "Must be updating a device or be supplied a name for a new device"
                     )
-                if "deviceConfig" not in self.config:
+                if "deviceConfig" not in self.config or self.action in ["add", "remove"]:
                     self.process_simple_action(dev_name)
                 else:
+                    # updating an existing device, but need to recreate it for this change
                     self.process_remove_readd(dev_name)
             else:
                 raise ValueError(f"action {self.action} is not supported")

--- a/bec_widgets/widgets/services/device_browser/device_item/config_communicator.py
+++ b/bec_widgets/widgets/services/device_browser/device_item/config_communicator.py
@@ -24,8 +24,10 @@ class CommunicateConfigAction(QRunnable):
     ) -> None:
         super().__init__()
         self.config_helper = config_helper
+        if action in ["add", "update"] and config is None:
+            raise ValueError("Must supply config to add or update a device")
         self.device = device
-        self.config = config
+        self.config = config or {}
         self.action = action
         self.signals = _CommSignals()
 
@@ -37,24 +39,34 @@ class CommunicateConfigAction(QRunnable):
                     raise ValueError(
                         "Must be updating a device or be supplied a name for a new device"
                     )
-                req_args = {
-                    "action": self.action,
-                    "config": {dev_name: self.config},
-                    "wait_for_response": False,
-                }
-                timeout = (
-                    self.config_helper.suggested_timeout_s(self.config)
-                    if self.config is not None
-                    else 20
-                )
-                RID = self.config_helper.send_config_request(**req_args)
-                logger.info("Waiting for config reply")
-                reply = self.config_helper.wait_for_config_reply(RID, timeout=timeout)
-                self.config_helper.handle_update_reply(reply, RID, timeout)
-                logger.info("Done updating config!")
+                if "deviceConfig" not in self.config:
+                    self.process_simple_action(dev_name)
+                else:
+                    self.process_remove_readd(dev_name)
             else:
                 raise ValueError(f"action {self.action} is not supported")
         except Exception as e:
             self.signals.error.emit(e)
         else:
             self.signals.done.emit()
+
+    def process_simple_action(self, dev_name: str, action: ConfigAction | None = None):
+        req_args = {
+            "action": action or self.action,
+            "config": {dev_name: self.config},
+            "wait_for_response": False,
+        }
+        timeout = (
+            self.config_helper.suggested_timeout_s(self.config) if self.config is not None else 20
+        )
+        RID = self.config_helper.send_config_request(**req_args)
+        logger.info("Waiting for config reply")
+        reply = self.config_helper.wait_for_config_reply(RID, timeout=timeout)
+        self.config_helper.handle_update_reply(reply, RID, timeout)
+        logger.info("Done updating config!")
+
+    def process_remove_readd(self, dev_name: str):
+        logger.info(f"Removing and readding device: {dev_name}")
+        self.process_simple_action(dev_name, "remove")
+        self.process_simple_action(dev_name, "add")
+        logger.info(f"Reinstated {dev_name} successfully!")

--- a/bec_widgets/widgets/services/device_browser/device_item/device_config_dialog.py
+++ b/bec_widgets/widgets/services/device_browser/device_item/device_config_dialog.py
@@ -68,7 +68,7 @@ class DeviceConfigDialog(BECWidget, QDialog):
             self.client.connector, self.client._service_name
         )
         self._device = device
-        self._action = action
+        self._action: Literal["update", "add"] = action
         self._q_threadpool = threadpool or QThreadPool()
         self.setWindowTitle(f"Edit config for: {device}")
         self._container = QStackedLayout()
@@ -168,10 +168,9 @@ class DeviceConfigDialog(BECWidget, QDialog):
         diff = {
             k: v for k, v in new_config.items() if self._initial_config.get(k) != new_config.get(k)
         }
-        if self._initial_config["deviceConfig"] in [{}, None] and new_config["deviceConfig"] in [
-            {},
-            None,
-        ]:
+        if self._initial_config.get("deviceConfig") in [{}, None] and new_config.get(
+            "deviceConfig"
+        ) in [{}, None]:
             diff.pop("deviceConfig", None)
         if diff.get("deviceConfig") is not None:
             # TODO: special cased in some parts of device manager but not others, should
@@ -222,7 +221,7 @@ class DeviceConfigDialog(BECWidget, QDialog):
             self._proc_device_config_change(updated_config)
 
     def _proc_device_config_change(self, config: dict):
-        logger.info(f"Sending request to update device config: {config}")
+        logger.info(f"Sending request to {self._action} device config: {config}")
 
         self._start_waiting_display()
         communicate_update = CommunicateConfigAction(

--- a/bec_widgets/widgets/services/device_browser/device_item/device_config_dialog.py
+++ b/bec_widgets/widgets/services/device_browser/device_item/device_config_dialog.py
@@ -168,6 +168,11 @@ class DeviceConfigDialog(BECWidget, QDialog):
         diff = {
             k: v for k, v in new_config.items() if self._initial_config.get(k) != new_config.get(k)
         }
+        if self._initial_config["deviceConfig"] in [{}, None] and new_config["deviceConfig"] in [
+            {},
+            None,
+        ]:
+            diff.pop("deviceConfig", None)
         if diff.get("deviceConfig") is not None:
             # TODO: special cased in some parts of device manager but not others, should
             # be removed in config update as with below issue
@@ -176,6 +181,11 @@ class DeviceConfigDialog(BECWidget, QDialog):
             diff["deviceConfig"] = {
                 k: _try_literal_eval(str(v)) for k, v in diff["deviceConfig"].items() if k != ""
             }
+
+        # Due to above issues, if deviceConfig changes we must remove and recreate the device - so we need the whole config
+        if "deviceConfig" in diff:
+            new_config["deviceConfig"] = diff["deviceConfig"]
+            return new_config
         return diff
 
     @SafeSlot(bool)

--- a/bec_widgets/widgets/services/device_browser/device_item/device_item.py
+++ b/bec_widgets/widgets/services/device_browser/device_item/device_item.py
@@ -140,6 +140,11 @@ class DeviceItem(ExpandableGroupFrame):
         self.adjustSize()
         self.broadcast_size_hint.emit(self.sizeHint())
 
+    @SafeSlot(bool)
+    def set_editable(self, enabled: bool):
+        self.edit_button.setEnabled(enabled)
+        self.delete_button.setEnabled(enabled)
+
     @SafeSlot(str, dict)
     def config_update(self, action: ConfigAction, content: dict) -> None:
         if self.device in content:

--- a/tests/unit_tests/test_config_communicator.py
+++ b/tests/unit_tests/test_config_communicator.py
@@ -1,5 +1,6 @@
-from unittest.mock import ANY, MagicMock
+from unittest.mock import ANY, MagicMock, call
 
+import pytest
 from bec_lib.config_helper import ConfigHelper
 
 from bec_widgets.widgets.services.device_browser.device_item.config_communicator import (
@@ -20,9 +21,41 @@ def test_must_have_a_name(qtbot):
     qtbot.waitUntil(lambda: error_occurred, timeout=100)
 
 
+@pytest.mark.parametrize(
+    ["action", "config", "error"],
+    [("update", None, True), ("remove", None, False), ("add", {}, False)],
+)
+def test_action_config_match(action, config, error):
+    def init():
+        return CommunicateConfigAction(
+            ConfigHelper(MagicMock()), device="test", config=config, action=action
+        )
+
+    if error:
+        with pytest.raises(ValueError):
+            init()
+    else:
+        assert init()
+
+
 def test_wait_for_reply_on_RID():
     ch = MagicMock(spec=ConfigHelper)
     ch.send_config_request.return_value = "abcde"
     cca = CommunicateConfigAction(config_helper=ch, device="samx", config={}, action="update")
     cca.run()
-    ch.wait_for_config_reply.assert_called_with("abcde", timeout=ANY)
+    ch.wait_for_config_reply.assert_called_once_with("abcde", timeout=ANY)
+
+
+def test_remove_readd_with_device_config(qtbot):
+    ch = MagicMock(spec=ConfigHelper)
+    ch.send_config_request.return_value = "abcde"
+    cca = CommunicateConfigAction(
+        config_helper=ch, device="samx", config={"deviceConfig": {"arg": "val"}}, action="update"
+    )
+    cca.run()
+    ch.send_config_request.assert_has_calls(
+        [
+            call(action="remove", config=ANY, wait_for_response=False),
+            call(action="add", config=ANY, wait_for_response=False),
+        ]
+    )

--- a/tests/unit_tests/test_device_config_form_dialog.py
+++ b/tests/unit_tests/test_device_config_form_dialog.py
@@ -120,6 +120,37 @@ def test_update_cycle(update_dialog, qtbot):
     )
 
 
+@pytest.mark.parametrize(
+    ["changes", "result"],
+    [
+        ({}, {}),
+        ({"readOnly": True}, {"readOnly": True}),
+        ({"readOnly": False}, {}),
+        ({"readOnly": True, "description": "test"}, {"readOnly": True, "description": "test"}),
+        (
+            {"deviceConfig": {"param1": "'val1'"}},
+            {
+                "enabled": True,
+                "deviceClass": "TestDevice",
+                "deviceConfig": {"param1": "val1"},
+                "readoutPriority": "monitored",
+                "description": None,
+                "readOnly": False,
+                "softwareTrigger": False,
+                "deviceTags": set(),
+                "userParameter": {},
+                "name": "test_device",
+            },
+        ),
+        ({"deviceConfig": {}}, {}),
+    ],
+)
+def test_update_with_modified_deviceconfig(update_dialog, changes, result):
+    for k, v in changes.items():
+        update_dialog._form.widget_dict[k].setValue(v)
+    assert update_dialog.updated_config() == result
+
+
 def test_add_form_init_without_name(add_dialog, qtbot):
     assert (name_widget := add_dialog._form.widget_dict.get("name")) is not None
     assert isinstance(name_widget, StrFormItem)


### PR DESCRIPTION
- save and load configs to file (closes #749 )
- warn and disable buttons when a scan is running
- deal with `deviceConfig` changes by destroying and recreating the device