### PR TITLE
fix(rpc_base): rpc_call wrapper passes full_name for Devices indeed of name

### DIFF
--- a/bec_widgets/cli/rpc/rpc_base.py
+++ b/bec_widgets/cli/rpc/rpc_base.py
@@ -7,6 +7,7 @@ from functools import wraps
 from typing import TYPE_CHECKING, Any, cast
 
 from bec_lib.client import BECClient
+from bec_lib.device import DeviceBaseWithConfig
 from bec_lib.endpoints import MessageEndpoints
 from bec_lib.utils.import_utils import lazy_import, lazy_import_from
 
@@ -49,12 +50,22 @@ def rpc_call(func):
 
         out = []
         for arg in args:
-            if hasattr(arg, "name"):
+            if isinstance(
+                arg, DeviceBaseWithConfig
+            ):  # if dev.<device> is passed to GUI, it passes full_name
+                if hasattr(arg, "full_name"):
+                    arg = arg.full_name
+            elif hasattr(arg, "name"):
                 arg = arg.name
             out.append(arg)
         args = tuple(out)
         for key, val in kwargs.items():
-            if hasattr(val, "name"):
+            if isinstance(
+                val, DeviceBaseWithConfig
+            ):  # if dev.<device> is passed to GUI, it passes full_name
+                if hasattr(val, "full_name"):
+                    kwargs[key] = val.full_name
+            elif hasattr(val, "name"):
                 kwargs[key] = val.name
         if not self._root._gui_is_alive():
             raise RuntimeError("GUI is not alive")

--- a/bec_widgets/cli/rpc/rpc_base.py
+++ b/bec_widgets/cli/rpc/rpc_base.py
@@ -25,6 +25,20 @@ else:
 # pylint: disable=protected-access
 
 
+def _name_arg(arg):
+    if isinstance(arg, DeviceBaseWithConfig):
+        # if dev.<device> is passed to GUI, it passes full_name
+        if hasattr(arg, "full_name"):
+            return arg.full_name
+    elif hasattr(arg, "name"):
+        return arg.name
+    return arg
+
+
+def _transform_args_kwargs(args, kwargs) -> tuple[tuple, dict]:
+    return tuple(_name_arg(arg) for arg in args), {k: _name_arg(v) for k, v in kwargs.items()}
+
+
 def rpc_call(func):
     """
     A decorator for calling a function on the server.
@@ -48,25 +62,7 @@ def rpc_call(func):
                 return None  # func(*args, **kwargs)
             caller_frame = caller_frame.f_back
 
-        out = []
-        for arg in args:
-            if isinstance(
-                arg, DeviceBaseWithConfig
-            ):  # if dev.<device> is passed to GUI, it passes full_name
-                if hasattr(arg, "full_name"):
-                    arg = arg.full_name
-            elif hasattr(arg, "name"):
-                arg = arg.name
-            out.append(arg)
-        args = tuple(out)
-        for key, val in kwargs.items():
-            if isinstance(
-                val, DeviceBaseWithConfig
-            ):  # if dev.<device> is passed to GUI, it passes full_name
-                if hasattr(val, "full_name"):
-                    kwargs[key] = val.full_name
-            elif hasattr(val, "name"):
-                kwargs[key] = val.name
+        args, kwargs = _transform_args_kwargs(args, kwargs)
         if not self._root._gui_is_alive():
             raise RuntimeError("GUI is not alive")
         return self._run_rpc(func.__name__, *args, **kwargs)

--- a/bec_widgets/utils/entry_validator.py
+++ b/bec_widgets/utils/entry_validator.py
@@ -28,6 +28,10 @@ class EntryValidator:
         if not available_entries:
             available_entries = [name]
 
+        # edge case for if name is passed instead of full_name, should not happen
+        if entry in signals_dict:
+            entry = signals_dict[entry].get("obj_name", entry)
+
         if entry is None or entry == "":
             entry = next(iter(device._hints), name) if hasattr(device, "_hints") else name
         if entry not in available_entries:

--- a/tests/end-2-end/test_plotting_framework_e2e.py
+++ b/tests/end-2-end/test_plotting_framework_e2e.py
@@ -254,3 +254,35 @@ def test_dap_rpc(qtbot, bec_client_lib, connected_client_gui_obj):
     res.wait()
 
     qtbot.waitUntil(wait_for_fit, timeout=10000)
+
+
+def test_waveform_passing_device(qtbot, bec_client_lib, connected_client_gui_obj):
+    gui = connected_client_gui_obj
+    client = bec_client_lib
+    dev = client.device_manager.devices
+    scans = client.scans
+
+    dock = gui.bec
+    wf = dock.new("wf_dock").new("Waveform")
+    c1 = wf.plot(
+        y_name=dev.samx, y_entry=dev.samx.setpoint
+    )  # using setpoint to not use readback signal
+
+    assert c1.object_name == "samx_samx_setpoint"
+
+    status = scans.line_scan(dev.samx, -5, 5, steps=5, exp_time=0.05, relative=False)
+    status.wait()
+
+    # Wait for the scan to finish and the data to be available in history
+    # Wait until scan_id is in history
+    def _wait_for_scan_in_history():
+        if len(client.history) == 0:
+            return False
+        # Once items appear in storage, the last one hast to be the one we just scanned
+        return client.history[-1].metadata.bec["scan_id"] == status.scan.scan_id
+
+    qtbot.waitUntil(_wait_for_scan_in_history, timeout=10000)
+    last_scan_data = client.history[-1]
+    # check plotted data
+    x_data, y_data = c1.get_data()
+    assert np.array_equal(y_data, last_scan_data.devices.samx.samx_setpoint.read().get("value"))

--- a/tests/unit_tests/test_rpc_base.py
+++ b/tests/unit_tests/test_rpc_base.py
@@ -1,6 +1,14 @@
-import pytest
+from unittest.mock import MagicMock
 
-from bec_widgets.cli.rpc.rpc_base import DeletedWidgetError, RPCBase, RPCReference
+import pytest
+from bec_lib.device import DeviceBaseWithConfig, Signal
+
+from bec_widgets.cli.rpc.rpc_base import (
+    DeletedWidgetError,
+    RPCBase,
+    RPCReference,
+    _transform_args_kwargs,
+)
 
 
 @pytest.fixture
@@ -26,3 +34,20 @@ def test_rpc_base(rpc_base):
 
     with pytest.raises(DeletedWidgetError):
         ref._root  # Object no longer referenced in registry
+
+
+def test_transform_args_kwargs():
+    device_mock = MagicMock(spec=DeviceBaseWithConfig)
+    device_mock.full_name = "full name"
+    fallthrough_device_mock = MagicMock()
+    fallthrough_device_mock.name = "short name"
+    string_arg = "string_arg"
+    signal_mock = MagicMock(spec=Signal)
+    signal_mock.full_name = "full name"
+
+    args, kwargs = _transform_args_kwargs(
+        (device_mock, fallthrough_device_mock, string_arg, signal_mock),
+        {"a": device_mock, "b": fallthrough_device_mock, "c": string_arg, "d": signal_mock},
+    )
+    assert args == ("full name", "short name", "string_arg", "full name")
+    assert kwargs == {"a": "full name", "b": "short name", "c": "string_arg", "d": "full name"}


### PR DESCRIPTION
## Description

Hotfix for passing `dev.<device>.<signal>` to CLI for plotting for example. Now @rpc_call passes `full_name` instead of `name` for devices and signals.

## Related Issues

- closes #792 