### PR TITLE
fix(cli): remove stderr from cli output when not using rpc

### DIFF
--- a/bec_widgets/cli/client_utils.py
+++ b/bec_widgets/cli/client_utils.py
@@ -51,7 +51,7 @@ def _filter_output(output: str) -> str:
 
 
 def _get_output(process, logger) -> None:
-    log_func = {process.stdout: logger.debug, process.stderr: logger.error}
+    log_func = {process.stdout: logger.debug, process.stderr: logger.info}
     stream_buffer = {process.stdout: [], process.stderr: []}
     try:
         os.set_blocking(process.stdout.fileno(), False)


### PR DESCRIPTION
## Description

This PR introduces changes to suppress the logger outputs from the BEC GUI server when using cli. Otherwise, every error raised through the GUI would be forwarded to the cli. 

closes #469 
closes #522

## How to test

- Run unit tests
- Start the client and open some widgets. Provide invalid input. 


## Additional Comments

Errors raised during rpc calls are not affected by this. 

## Definition of Done
- [x] Documentation is up-to-date.

