### PR TITLE
fix(waveform): autorange is applied with 150ms delay after curve is added

### DIFF
--- a/bec_widgets/widgets/plots/waveform/waveform.py
+++ b/bec_widgets/widgets/plots/waveform/waveform.py
@@ -908,6 +908,10 @@ class Waveform(PlotBase):
             self.roi_enable.emit(True)  # Enable the ROI toolbar action
             self.request_dap()  # Request DAP update directly without blocking proxy
 
+        QTimer.singleShot(
+            150, self.auto_range
+        )  # autorange with a delay to ensure the plot is updated
+
         return curve
 
     def _add_curve_object(self, name: str, config: CurveConfig) -> Curve:


### PR DESCRIPTION
## Description

Autorange was not applied when new curves were added which causes some confusion when newly added curves were outside of the range. Delay has to be applied because pyqtgraph has some problem scalling y axis if curve is not fully rendered.

## Related Issues

- closes #810 
