### PR TITLE
fix(cli): ensure guis are not started twice

### DIFF
--- a/bec_widgets/cli/client_utils.py
+++ b/bec_widgets/cli/client_utils.py
@@ -151,8 +151,10 @@ def wait_for_server(client: BECGuiClient):
             raise RuntimeError("GUI is not alive")
     try:
         if client._gui_started_event.wait(timeout=timeout):
-            client._gui_started_timer.cancel()
-            client._gui_started_timer.join()
+            if client._gui_started_timer is not None:
+                # cancel the timer, we are done
+                client._gui_started_timer.cancel()
+                client._gui_started_timer.join()
         else:
             raise TimeoutError("Could not connect to GUI server")
     finally:
@@ -261,13 +263,20 @@ class BECGuiClient(RPCBase):
 
     def start(self, wait: bool = False) -> None:
         """Start the GUI server."""
+        logger.warning("Using <gui>.start() is deprecated, use <gui>.show() instead.")
         return self._start(wait=wait)
 
-    def show(self):
-        """Show the GUI window."""
+    def show(self, wait=True) -> None:
+        """
+        Show the GUI window.
+        If the GUI server is not running, it will be started.
+
+        Args:
+            wait(bool): Whether to wait for the server to start. Defaults to True.
+        """
         if self._check_if_server_is_alive():
             return self._show_all()
-        return self.start(wait=True)
+        return self._start(wait=wait)
 
     def hide(self):
         """Hide the GUI window."""
@@ -382,6 +391,9 @@ class BECGuiClient(RPCBase):
         """
         Start the GUI server, and execute callback when it is launched
         """
+        if self._gui_is_alive():
+            self._gui_started_event.set()
+            return
         if self._process is None or self._process.poll() is not None:
             logger.success("GUI starting...")
             self._startup_timeout = 5
@@ -524,7 +536,7 @@ if __name__ == "__main__":  # pragma: no cover
         # Test the client_utils.py module
         gui = BECGuiClient()
 
-        gui.start(wait=True)
+        gui.show(wait=True)
         gui.new().new(widget="Waveform")
         time.sleep(10)
     finally:

--- a/tests/unit_tests/test_client_utils.py
+++ b/tests/unit_tests/test_client_utils.py
@@ -67,7 +67,7 @@ def test_client_utils_passes_client_config_to_server(bec_dispatcher):
         mixin._client = bec_dispatcher.client
         mixin._gui_id = "gui_id"
         mixin._gui_is_alive = mock.MagicMock()
-        mixin._gui_is_alive.side_effect = [True]
+        mixin._gui_is_alive.side_effect = [False, False, True]
 
         try:
             yield mixin


### PR DESCRIPTION
## Description

This PR fixes an issue that caused multiple guis to be started, even if a GUI with the same ID already exists. 

I also marked `start()` as deprecated as the functionality is fully covered by `show()`. We can update the ipython client in bec once we've merged it. 

## Related Issues

## How to test

- Run unit tests
- Start the GUI server (default id 'test') and connect with the ipython client using `bec --gui-id test`. It should not start a new GUI, even without specifying the --nogui option. 

## Definition of Done
- [x] Documentation is up-to-date.

