### PR TITLE
Qt Ads

### DIFF
--- a/bec_widgets/__init__.py
+++ b/bec_widgets/__init__.py
@@ -1,6 +1,8 @@
 import os
 import sys
 
+import PySide6QtAds as QtAds
+
 from bec_widgets.utils.bec_widget import BECWidget
 from bec_widgets.utils.error_popups import SafeProperty, SafeSlot
 
@@ -8,5 +10,11 @@ if sys.platform.startswith("linux"):
     qt_platform = os.environ.get("QT_QPA_PLATFORM", "")
     if qt_platform != "offscreen":
         os.environ["QT_QPA_PLATFORM"] = "xcb"
+
+# Default QtAds configuration
+QtAds.CDockManager.setConfigFlag(QtAds.CDockManager.eConfigFlag.FocusHighlighting, True)
+QtAds.CDockManager.setConfigFlag(
+    QtAds.CDockManager.eConfigFlag.RetainTabSizeWhenCloseButtonHidden, True
+)
 
 __all__ = ["BECWidget", "SafeSlot", "SafeProperty"]

--- a/bec_widgets/__init__.py
+++ b/bec_widgets/__init__.py
@@ -1,4 +1,12 @@
+import os
+import sys
+
 from bec_widgets.utils.bec_widget import BECWidget
 from bec_widgets.utils.error_popups import SafeProperty, SafeSlot
+
+if sys.platform.startswith("linux"):
+    qt_platform = os.environ.get("QT_QPA_PLATFORM", "")
+    if qt_platform != "offscreen":
+        os.environ["QT_QPA_PLATFORM"] = "xcb"
 
 __all__ = ["BECWidget", "SafeSlot", "SafeProperty"]

--- a/bec_widgets/cli/client.py
+++ b/bec_widgets/cli/client.py
@@ -106,6 +106,18 @@ class AbortButton(RPCBase):
         Cleanup the BECConnector
         """
 
+    @rpc_call
+    def attach(self):
+        """
+        None
+        """
+
+    @rpc_call
+    def detach(self):
+        """
+        Detach the widget from its parent dock widget (if widget is in the dock), making it a floating widget.
+        """
+
 
 class AutoUpdates(RPCBase):
     @property
@@ -442,6 +454,18 @@ class BECMainWindow(RPCBase):
         Cleanup the BECConnector
         """
 
+    @rpc_call
+    def attach(self):
+        """
+        None
+        """
+
+    @rpc_call
+    def detach(self):
+        """
+        Detach the widget from its parent dock widget (if widget is in the dock), making it a floating widget.
+        """
+
 
 class BECProgressBar(RPCBase):
     """A custom progress bar with smooth transitions. The displayed text can be customized using a template."""
@@ -525,6 +549,18 @@ class BECQueue(RPCBase):
         Cleanup the BECConnector
         """
 
+    @rpc_call
+    def attach(self):
+        """
+        None
+        """
+
+    @rpc_call
+    def detach(self):
+        """
+        Detach the widget from its parent dock widget (if widget is in the dock), making it a floating widget.
+        """
+
 
 class BECStatusBox(RPCBase):
     """An autonomous widget to display the status of BEC services."""
@@ -539,6 +575,25 @@ class BECStatusBox(RPCBase):
     def remove(self):
         """
         Cleanup the BECConnector
+        """
+
+    @rpc_call
+    def attach(self):
+        """
+        None
+        """
+
+    @rpc_call
+    def detach(self):
+        """
+        Detach the widget from its parent dock widget (if widget is in the dock), making it a floating widget.
+        """
+
+    @rpc_timeout(None)
+    @rpc_call
+    def screenshot(self, file_name: "str | None" = None):
+        """
+        Take a screenshot of the dock area and save it to a file.
         """
 
 
@@ -1002,6 +1057,18 @@ class DarkModeButton(RPCBase):
         Cleanup the BECConnector
         """
 
+    @rpc_call
+    def attach(self):
+        """
+        None
+        """
+
+    @rpc_call
+    def detach(self):
+        """
+        Detach the widget from its parent dock widget (if widget is in the dock), making it a floating widget.
+        """
+
 
 class DeviceBrowser(RPCBase):
     """DeviceBrowser is a widget that displays all available devices in the current BEC session."""
@@ -1010,6 +1077,18 @@ class DeviceBrowser(RPCBase):
     def remove(self):
         """
         Cleanup the BECConnector
+        """
+
+    @rpc_call
+    def attach(self):
+        """
+        None
+        """
+
+    @rpc_call
+    def detach(self):
+        """
+        Detach the widget from its parent dock widget (if widget is in the dock), making it a floating widget.
         """
 
 
@@ -1043,6 +1122,18 @@ class DeviceInputBase(RPCBase):
     def remove(self):
         """
         Cleanup the BECConnector
+        """
+
+    @rpc_call
+    def attach(self):
+        """
+        None
+        """
+
+    @rpc_call
+    def detach(self):
+        """
+        Detach the widget from its parent dock widget (if widget is in the dock), making it a floating widget.
         """
 
 
@@ -1431,6 +1522,18 @@ class Heatmap(RPCBase):
     def minimal_crosshair_precision(self) -> "int":
         """
         Minimum decimal places for crosshair when dynamic precision is enabled.
+        """
+
+    @rpc_call
+    def attach(self):
+        """
+        None
+        """
+
+    @rpc_call
+    def detach(self):
+        """
+        Detach the widget from its parent dock widget (if widget is in the dock), making it a floating widget.
         """
 
     @rpc_timeout(None)
@@ -1976,6 +2079,18 @@ class Image(RPCBase):
     def minimal_crosshair_precision(self) -> "int":
         """
         Minimum decimal places for crosshair when dynamic precision is enabled.
+        """
+
+    @rpc_call
+    def attach(self):
+        """
+        None
+        """
+
+    @rpc_call
+    def detach(self):
+        """
+        Detach the widget from its parent dock widget (if widget is in the dock), making it a floating widget.
         """
 
     @rpc_timeout(None)
@@ -2590,6 +2705,25 @@ class MonacoWidget(RPCBase):
             str: The LSP header.
         """
 
+    @rpc_call
+    def attach(self):
+        """
+        None
+        """
+
+    @rpc_call
+    def detach(self):
+        """
+        Detach the widget from its parent dock widget (if widget is in the dock), making it a floating widget.
+        """
+
+    @rpc_timeout(None)
+    @rpc_call
+    def screenshot(self, file_name: "str | None" = None):
+        """
+        Take a screenshot of the dock area and save it to a file.
+        """
+
 
 class MotorMap(RPCBase):
     """Motor map widget for plotting motor positions in 2D including a trace of the last points."""
@@ -2863,6 +2997,18 @@ class MotorMap(RPCBase):
     def legend_label_size(self) -> "int":
         """
         The font size of the legend font.
+        """
+
+    @rpc_call
+    def attach(self):
+        """
+        None
+        """
+
+    @rpc_call
+    def detach(self):
+        """
+        Detach the widget from its parent dock widget (if widget is in the dock), making it a floating widget.
         """
 
     @rpc_timeout(None)
@@ -3277,6 +3423,18 @@ class MultiWaveform(RPCBase):
         Minimum decimal places for crosshair when dynamic precision is enabled.
         """
 
+    @rpc_call
+    def attach(self):
+        """
+        None
+        """
+
+    @rpc_call
+    def detach(self):
+        """
+        Detach the widget from its parent dock widget (if widget is in the dock), making it a floating widget.
+        """
+
     @rpc_timeout(None)
     @rpc_call
     def screenshot(self, file_name: "str | None" = None):
@@ -3498,6 +3656,18 @@ class PositionerBox(RPCBase):
             positioner (Positioner | str) : Positioner to set, accepts str or the device
         """
 
+    @rpc_call
+    def attach(self):
+        """
+        None
+        """
+
+    @rpc_call
+    def detach(self):
+        """
+        Detach the widget from its parent dock widget (if widget is in the dock), making it a floating widget.
+        """
+
     @rpc_timeout(None)
     @rpc_call
     def screenshot(self, file_name: "str | None" = None):
@@ -3527,6 +3697,18 @@ class PositionerBox2D(RPCBase):
             positioner (Positioner | str) : Positioner to set, accepts str or the device
         """
 
+    @rpc_call
+    def attach(self):
+        """
+        None
+        """
+
+    @rpc_call
+    def detach(self):
+        """
+        Detach the widget from its parent dock widget (if widget is in the dock), making it a floating widget.
+        """
+
     @rpc_timeout(None)
     @rpc_call
     def screenshot(self, file_name: "str | None" = None):
@@ -3547,6 +3729,18 @@ class PositionerControlLine(RPCBase):
             positioner (Positioner | str) : Positioner to set, accepts str or the device
         """
 
+    @rpc_call
+    def attach(self):
+        """
+        None
+        """
+
+    @rpc_call
+    def detach(self):
+        """
+        Detach the widget from its parent dock widget (if widget is in the dock), making it a floating widget.
+        """
+
     @rpc_timeout(None)
     @rpc_call
     def screenshot(self, file_name: "str | None" = None):
@@ -3564,6 +3758,25 @@ class PositionerGroup(RPCBase):
         Redraw grid with positioners from device_names string
 
         Device names must be separated by space
+        """
+
+    @rpc_call
+    def attach(self):
+        """
+        None
+        """
+
+    @rpc_call
+    def detach(self):
+        """
+        Detach the widget from its parent dock widget (if widget is in the dock), making it a floating widget.
+        """
+
+    @rpc_timeout(None)
+    @rpc_call
+    def screenshot(self, file_name: "str | None" = None):
+        """
+        Take a screenshot of the dock area and save it to a file.
         """
 
 
@@ -3705,6 +3918,18 @@ class ResetButton(RPCBase):
         Cleanup the BECConnector
         """
 
+    @rpc_call
+    def attach(self):
+        """
+        None
+        """
+
+    @rpc_call
+    def detach(self):
+        """
+        Detach the widget from its parent dock widget (if widget is in the dock), making it a floating widget.
+        """
+
 
 class ResumeButton(RPCBase):
     """A button that continue scan queue."""
@@ -3713,6 +3938,18 @@ class ResumeButton(RPCBase):
     def remove(self):
         """
         Cleanup the BECConnector
+        """
+
+    @rpc_call
+    def attach(self):
+        """
+        None
+        """
+
+    @rpc_call
+    def detach(self):
+        """
+        Detach the widget from its parent dock widget (if widget is in the dock), making it a floating widget.
         """
 
 
@@ -3996,6 +4233,25 @@ class RingProgressBar(RPCBase):
             bool: True if scan segment updates are enabled.
         """
 
+    @rpc_call
+    def attach(self):
+        """
+        None
+        """
+
+    @rpc_call
+    def detach(self):
+        """
+        Detach the widget from its parent dock widget (if widget is in the dock), making it a floating widget.
+        """
+
+    @rpc_timeout(None)
+    @rpc_call
+    def screenshot(self, file_name: "str | None" = None):
+        """
+        Take a screenshot of the dock area and save it to a file.
+        """
+
 
 class SBBMonitor(RPCBase):
     """A widget to display the SBB monitor website."""
@@ -4007,9 +4263,15 @@ class ScanControl(RPCBase):
     """Widget to submit new scans to the queue."""
 
     @rpc_call
-    def remove(self):
+    def attach(self):
         """
-        Cleanup the BECConnector
+        None
+        """
+
+    @rpc_call
+    def detach(self):
+        """
+        Detach the widget from its parent dock widget (if widget is in the dock), making it a floating widget.
         """
 
     @rpc_timeout(None)
@@ -4027,6 +4289,18 @@ class ScanProgressBar(RPCBase):
     def remove(self):
         """
         Cleanup the BECConnector
+        """
+
+    @rpc_call
+    def attach(self):
+        """
+        None
+        """
+
+    @rpc_call
+    def detach(self):
+        """
+        Detach the widget from its parent dock widget (if widget is in the dock), making it a floating widget.
         """
 
 
@@ -4325,6 +4599,18 @@ class ScatterWaveform(RPCBase):
     def minimal_crosshair_precision(self) -> "int":
         """
         Minimum decimal places for crosshair when dynamic precision is enabled.
+        """
+
+    @rpc_call
+    def attach(self):
+        """
+        None
+        """
+
+    @rpc_call
+    def detach(self):
+        """
+        Detach the widget from its parent dock widget (if widget is in the dock), making it a floating widget.
         """
 
     @rpc_timeout(None)
@@ -4629,6 +4915,18 @@ class StopButton(RPCBase):
         Cleanup the BECConnector
         """
 
+    @rpc_call
+    def attach(self):
+        """
+        None
+        """
+
+    @rpc_call
+    def detach(self):
+        """
+        Detach the widget from its parent dock widget (if widget is in the dock), making it a floating widget.
+        """
+
 
 class TextBox(RPCBase):
     """A widget that displays text in plain and HTML format"""
@@ -4660,6 +4958,25 @@ class VSCodeEditor(RPCBase):
 
 class Waveform(RPCBase):
     """Widget for plotting waveforms."""
+
+    @rpc_call
+    def attach(self):
+        """
+        None
+        """
+
+    @rpc_call
+    def detach(self):
+        """
+        Detach the widget from its parent dock widget (if widget is in the dock), making it a floating widget.
+        """
+
+    @rpc_timeout(None)
+    @rpc_call
+    def screenshot(self, file_name: "str | None" = None):
+        """
+        Take a screenshot of the dock area and save it to a file.
+        """
 
     @property
     @rpc_call
@@ -4965,13 +5282,6 @@ class Waveform(RPCBase):
         Minimum decimal places for crosshair when dynamic precision is enabled.
         """
 
-    @rpc_timeout(None)
-    @rpc_call
-    def screenshot(self, file_name: "str | None" = None):
-        """
-        Take a screenshot of the dock area and save it to a file.
-        """
-
     @property
     @rpc_call
     def curves(self) -> "list[Curve]":
@@ -5213,6 +5523,18 @@ class WebConsole(RPCBase):
         Cleanup the BECConnector
         """
 
+    @rpc_call
+    def attach(self):
+        """
+        None
+        """
+
+    @rpc_call
+    def detach(self):
+        """
+        Detach the widget from its parent dock widget (if widget is in the dock), making it a floating widget.
+        """
+
 
 class WebsiteWidget(RPCBase):
     """A simple widget to display a website"""
@@ -5251,4 +5573,23 @@ class WebsiteWidget(RPCBase):
     def forward(self):
         """
         Go forward in the history
+        """
+
+    @rpc_call
+    def attach(self):
+        """
+        None
+        """
+
+    @rpc_call
+    def detach(self):
+        """
+        Detach the widget from its parent dock widget (if widget is in the dock), making it a floating widget.
+        """
+
+    @rpc_timeout(None)
+    @rpc_call
+    def screenshot(self, file_name: "str | None" = None):
+        """
+        Take a screenshot of the dock area and save it to a file.
         """

--- a/bec_widgets/cli/client.py
+++ b/bec_widgets/cli/client.py
@@ -128,20 +128,21 @@ class AdvancedDockArea(RPCBase):
         floatable: "bool" = True,
         movable: "bool" = True,
         start_floating: "bool" = False,
+        where: "Literal['left', 'right', 'top', 'bottom'] | None" = None,
     ) -> "BECWidget":
         """
-        Creates a new widget or reuses an existing one and schedules its dock creation.
+        Create a new widget (or reuse an instance) and add it as a dock.
 
         Args:
-            widget (BECWidget | str): The widget instance or a string specifying the
-                type of widget to create.
-            closable (bool): Whether the dock should be closable. Defaults to True.
-            floatable (bool): Whether the dock should be floatable. Defaults to True.
-            movable (bool): Whether the dock should be movable. Defaults to True.
-            start_floating (bool): Whether to start the dock in a floating state. Defaults to False.
-
+            widget: Widget instance or a string widget type (factory-created).
+            closable: Whether the dock is closable.
+            floatable: Whether the dock is floatable.
+            movable: Whether the dock is movable.
+            start_floating: Start the dock in a floating state.
+            where: Preferred area to add the dock: "left" | "right" | "top" | "bottom".
+                   If None, uses the instance default passed at construction time.
         Returns:
-            widget: The widget instance.
+            The widget instance.
         """
 
     @rpc_call
@@ -182,6 +183,20 @@ class AdvancedDockArea(RPCBase):
     def delete_all(self):
         """
         Delete all docks and widgets.
+        """
+
+    @property
+    @rpc_call
+    def mode(self) -> "str":
+        """
+        None
+        """
+
+    @mode.setter
+    @rpc_call
+    def mode(self) -> "str":
+        """
+        None
         """
 
 

--- a/bec_widgets/cli/client.py
+++ b/bec_widgets/cli/client.py
@@ -119,6 +119,72 @@ class AbortButton(RPCBase):
         """
 
 
+class AdvancedDockArea(RPCBase):
+    @rpc_call
+    def new(
+        self,
+        widget: "BECWidget | str",
+        closable: "bool" = True,
+        floatable: "bool" = True,
+        movable: "bool" = True,
+        start_floating: "bool" = False,
+    ) -> "BECWidget":
+        """
+        Creates a new widget or reuses an existing one and schedules its dock creation.
+
+        Args:
+            widget (BECWidget | str): The widget instance or a string specifying the
+                type of widget to create.
+            closable (bool): Whether the dock should be closable. Defaults to True.
+            floatable (bool): Whether the dock should be floatable. Defaults to True.
+            movable (bool): Whether the dock should be movable. Defaults to True.
+            start_floating (bool): Whether to start the dock in a floating state. Defaults to False.
+
+        Returns:
+            widget: The widget instance.
+        """
+
+    @rpc_call
+    def widget_map(self) -> "dict[str, QWidget]":
+        """
+        Return a dictionary mapping widget names to their corresponding BECWidget instances.
+
+        Returns:
+            dict: A dictionary mapping widget names to BECWidget instances.
+        """
+
+    @rpc_call
+    def widget_list(self) -> "list[QWidget]":
+        """
+        Return a list of all BECWidget instances in the dock area.
+
+        Returns:
+            list: A list of all BECWidget instances in the dock area.
+        """
+
+    @property
+    @rpc_call
+    def lock_workspace(self) -> "bool":
+        """
+        Get or set the lock state of the workspace.
+
+        Returns:
+            bool: True if the workspace is locked, False otherwise.
+        """
+
+    @rpc_call
+    def attach_all(self):
+        """
+        Return all floating docks to the dock area, preserving tab groups within each floating container.
+        """
+
+    @rpc_call
+    def delete_all(self):
+        """
+        Delete all docks and widgets.
+        """
+
+
 class AutoUpdates(RPCBase):
     @property
     @rpc_call

--- a/bec_widgets/examples/jupyter_console/jupyter_console_window.py
+++ b/bec_widgets/examples/jupyter_console/jupyter_console_window.py
@@ -16,6 +16,7 @@ from qtpy.QtWidgets import (
 
 from bec_widgets.utils import BECDispatcher
 from bec_widgets.utils.widget_io import WidgetHierarchy as wh
+from bec_widgets.widgets.containers.advanced_dock_area.advanced_dock_area import AdvancedDockArea
 from bec_widgets.widgets.containers.dock import BECDockArea
 from bec_widgets.widgets.containers.layout_manager.layout_manager import LayoutManagerWidget
 from bec_widgets.widgets.editors.jupyter_console.jupyter_console import BECJupyterConsole
@@ -44,6 +45,7 @@ class JupyterConsoleWindow(QWidget):  # pragma: no cover:
                     "wh": wh,
                     "dock": self.dock,
                     "im": self.im,
+                    "ads": self.ads,
                     # "mi": self.mi,
                     # "mm": self.mm,
                     # "lm": self.lm,
@@ -120,14 +122,12 @@ class JupyterConsoleWindow(QWidget):  # pragma: no cover:
         tab_widget.addTab(sixth_tab, "Image Next Gen")
         tab_widget.setCurrentIndex(1)
         #
-        # seventh_tab = QWidget()
-        # seventh_tab_layout = QVBoxLayout(seventh_tab)
-        # self.scatter = ScatterWaveform()
-        # self.scatter_mi = self.scatter.main_curve
-        # self.scatter.plot("samx", "samy", "bpm4i")
-        # seventh_tab_layout.addWidget(self.scatter)
-        # tab_widget.addTab(seventh_tab, "Scatter Waveform")
-        # tab_widget.setCurrentIndex(6)
+        seventh_tab = QWidget()
+        seventh_tab_layout = QVBoxLayout(seventh_tab)
+        self.ads = AdvancedDockArea(gui_id="ads")
+        seventh_tab_layout.addWidget(self.ads)
+        tab_widget.addTab(seventh_tab, "ADS")
+        tab_widget.setCurrentIndex(2)
         #
         # eighth_tab = QWidget()
         # eighth_tab_layout = QVBoxLayout(eighth_tab)

--- a/bec_widgets/utils/bec_connector.py
+++ b/bec_widgets/utils/bec_connector.py
@@ -77,8 +77,8 @@ class BECConnector:
 
     USER_ACCESS = ["_config_dict", "_get_all_rpc", "_rpc_id"]
     EXIT_HANDLERS = {}
-    remove_signal = Signal()
-    name_established_signal = Signal(str)
+    widget_removed = Signal()
+    name_established = Signal(str)
 
     def __init__(
         self,
@@ -207,7 +207,7 @@ class BECConnector:
         # 2) Register the object for RPC
         self.rpc_register.add_rpc(self)
         try:
-            self.name_established_signal.emit(self.object_name)
+            self.name_established.emit(self.object_name)
         except RuntimeError:
             return
 
@@ -456,7 +456,7 @@ class BECConnector:
         # i.e. Curve Item from Waveform
         else:
             self.rpc_register.remove_rpc(self)
-        self.remove_signal.emit()  # Emit the remove signal to notify listeners (eg docks in QtADS)
+        self.widget_removed.emit()  # Emit the remove signal to notify listeners (eg docks in QtADS)
 
     def get_config(self, dict_output: bool = True) -> dict | BaseModel:
         """

--- a/bec_widgets/utils/bec_connector.py
+++ b/bec_widgets/utils/bec_connector.py
@@ -78,6 +78,7 @@ class BECConnector:
     USER_ACCESS = ["_config_dict", "_get_all_rpc", "_rpc_id"]
     EXIT_HANDLERS = {}
     remove_signal = Signal()
+    name_established_signal = Signal(str)
 
     def __init__(
         self,
@@ -205,6 +206,10 @@ class BECConnector:
         self._enforce_unique_sibling_name()
         # 2) Register the object for RPC
         self.rpc_register.add_rpc(self)
+        try:
+            self.name_established_signal.emit(self.object_name)
+        except RuntimeError:
+            return
 
     def _enforce_unique_sibling_name(self):
         """

--- a/bec_widgets/utils/bec_connector.py
+++ b/bec_widgets/utils/bec_connector.py
@@ -77,6 +77,7 @@ class BECConnector:
 
     USER_ACCESS = ["_config_dict", "_get_all_rpc", "_rpc_id"]
     EXIT_HANDLERS = {}
+    remove_signal = Signal()
 
     def __init__(
         self,
@@ -450,6 +451,7 @@ class BECConnector:
         # i.e. Curve Item from Waveform
         else:
             self.rpc_register.remove_rpc(self)
+        self.remove_signal.emit()  # Emit the remove signal to notify listeners (eg docks in QtADS)
 
     def get_config(self, dict_output: bool = True) -> dict | BaseModel:
         """

--- a/bec_widgets/utils/bec_widget.py
+++ b/bec_widgets/utils/bec_widget.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING
 
 import darkdetect
+import PySide6QtAds as QtAds
 import shiboken6
 from bec_lib.logger import bec_logger
 from qtpy.QtCore import QObject
@@ -14,6 +15,7 @@ from bec_widgets.utils.bec_connector import BECConnector, ConnectionConfig
 from bec_widgets.utils.colors import set_theme
 from bec_widgets.utils.error_popups import SafeSlot
 from bec_widgets.utils.rpc_decorator import rpc_timeout
+from bec_widgets.utils.widget_io import WidgetHierarchy
 
 if TYPE_CHECKING:  # pragma: no cover
     from bec_widgets.widgets.containers.dock import BECDock
@@ -27,7 +29,7 @@ class BECWidget(BECConnector):
     # The icon name is the name of the icon in the icon theme, typically a name taken
     # from fonts.google.com/icons. Override this in subclasses to set the icon name.
     ICON_NAME = "widgets"
-    USER_ACCESS = ["remove"]
+    USER_ACCESS = ["remove", "attach", "detach"]
 
     # pylint: disable=too-many-arguments
     def __init__(
@@ -123,6 +125,26 @@ class BECWidget(BECConnector):
             return
         screenshot.save(file_name)
         logger.info(f"Screenshot saved to {file_name}")
+
+    def attach(self):
+        dock = WidgetHierarchy.find_ancestor(self, QtAds.CDockWidget)
+        if dock is None:
+            return
+
+        if not dock.isFloating():
+            return
+        dock.dockManager().addDockWidget(QtAds.DockWidgetArea.RightDockWidgetArea, dock)
+
+    def detach(self):
+        """
+        Detach the widget from its parent dock widget (if widget is in the dock), making it a floating widget.
+        """
+        dock = WidgetHierarchy.find_ancestor(self, QtAds.CDockWidget)
+        if dock is None:
+            return
+        if dock.isFloating():
+            return
+        dock.setFloating()
 
     def cleanup(self):
         """Cleanup the widget."""

--- a/bec_widgets/utils/widget_io.py
+++ b/bec_widgets/utils/widget_io.py
@@ -567,6 +567,34 @@ class WidgetHierarchy:
         connectors.extend(widget.findChildren(BECConnector))
         return connectors
 
+    @staticmethod
+    def find_ancestor(widget, ancestor_class) -> QWidget | None:
+        """
+        Traverse up the parent chain to find the nearest ancestor matching ancestor_class.
+        ancestor_class may be a class or a class-name string.
+        Returns the matching ancestor, or None if none is found.
+        """
+
+        parent = getattr(widget, "parent", None)
+        # First call parent() if widget has that method
+        if callable(parent):
+            parent = parent()
+        # Otherwise assume widget.parent attribute
+        while parent is not None and isinstance(parent, QWidget):
+            try:
+                if isinstance(ancestor_class, str):
+                    if parent.__class__.__name__ == ancestor_class:
+                        return parent
+                else:
+                    if isinstance(parent, ancestor_class):
+                        return parent
+            except Exception:
+                # In case ancestor_class isn't a valid type or parent.inspect fails
+                pass
+            # Move up one level
+            parent = parent.parent() if hasattr(parent, "parent") else None
+        return None
+
 
 # Example usage
 def hierarchy_example():  # pragma: no cover

--- a/bec_widgets/utils/widget_io.py
+++ b/bec_widgets/utils/widget_io.py
@@ -553,6 +553,20 @@ class WidgetHierarchy:
                     WidgetIO.set_value(child, value)
                 WidgetHierarchy.import_config_from_dict(child, widget_config, set_values)
 
+    @staticmethod
+    def get_bec_connectors_from_parent(widget) -> list:
+        """
+        Return all BECConnector instances that are descendants of the given widget,
+        including the widget itself if it is a BECConnector.
+        """
+        from bec_widgets.utils import BECConnector
+
+        connectors = []
+        if isinstance(widget, BECConnector):
+            connectors.append(widget)
+        connectors.extend(widget.findChildren(BECConnector))
+        return connectors
+
 
 # Example usage
 def hierarchy_example():  # pragma: no cover

--- a/bec_widgets/utils/widget_io.py
+++ b/bec_widgets/utils/widget_io.py
@@ -465,13 +465,19 @@ class WidgetHierarchy:
         """
         from bec_widgets.utils import BECConnector
 
+        # Guard against deleted/invalid Qt wrappers
         if not shb.isValid(widget):
             return None
-        parent = widget.parent()
+
+        # Retrieve first parent
+        parent = widget.parent() if hasattr(widget, "parent") else None
+        # Walk up, validating each step
         while parent is not None:
+            if not shb.isValid(parent):
+                return None
             if isinstance(parent, BECConnector):
                 return parent
-            parent = parent.parent()
+            parent = parent.parent() if hasattr(parent, "parent") else None
         return None
 
     @staticmethod
@@ -556,15 +562,17 @@ class WidgetHierarchy:
     @staticmethod
     def get_bec_connectors_from_parent(widget) -> list:
         """
-        Return all BECConnector instances that are descendants of the given widget,
+        Return all BECConnector instances whose closest BECConnector ancestor is the given widget,
         including the widget itself if it is a BECConnector.
         """
         from bec_widgets.utils import BECConnector
 
-        connectors = []
+        connectors: list[BECConnector] = []
         if isinstance(widget, BECConnector):
             connectors.append(widget)
-        connectors.extend(widget.findChildren(BECConnector))
+        for child in widget.findChildren(BECConnector):
+            if WidgetHierarchy._get_becwidget_ancestor(child) is widget:
+                connectors.append(child)
         return connectors
 
     @staticmethod
@@ -574,13 +582,29 @@ class WidgetHierarchy:
         ancestor_class may be a class or a class-name string.
         Returns the matching ancestor, or None if none is found.
         """
+        # Guard against deleted/invalid Qt wrappers
+        if not shb.isValid(widget):
+            return None
 
+        # If searching for BECConnector specifically, reuse the dedicated helper
+        try:
+            from bec_widgets.utils import BECConnector  # local import to avoid cycles
+
+            if ancestor_class is BECConnector or (
+                isinstance(ancestor_class, str) and ancestor_class == "BECConnector"
+            ):
+                return WidgetHierarchy._get_becwidget_ancestor(widget)
+        except Exception:
+            # If import fails, fall back to generic traversal below
+            pass
+
+        # Generic traversal across QObject parent chain
         parent = getattr(widget, "parent", None)
-        # First call parent() if widget has that method
         if callable(parent):
             parent = parent()
-        # Otherwise assume widget.parent attribute
-        while parent is not None and isinstance(parent, QWidget):
+        while parent is not None:
+            if not shb.isValid(parent):
+                return None
             try:
                 if isinstance(ancestor_class, str):
                     if parent.__class__.__name__ == ancestor_class:
@@ -589,9 +613,7 @@ class WidgetHierarchy:
                     if isinstance(parent, ancestor_class):
                         return parent
             except Exception:
-                # In case ancestor_class isn't a valid type or parent.inspect fails
                 pass
-            # Move up one level
             parent = parent.parent() if hasattr(parent, "parent") else None
         return None
 

--- a/bec_widgets/utils/widget_state_manager.py
+++ b/bec_widgets/utils/widget_state_manager.py
@@ -15,6 +15,8 @@ from qtpy.QtWidgets import (
     QWidget,
 )
 
+from bec_widgets.utils.widget_io import WidgetHierarchy
+
 logger = bec_logger.logger
 
 
@@ -59,13 +61,16 @@ class WidgetStateManager:
             settings = QSettings(filename, QSettings.IniFormat)
             self._load_widget_state_qsettings(self.widget, settings)
 
-    def _save_widget_state_qsettings(self, widget: QWidget, settings: QSettings):
+    def _save_widget_state_qsettings(
+        self, widget: QWidget, settings: QSettings, recursive: bool = True
+    ):
         """
         Save the state of the widget to QSettings.
 
         Args:
             widget(QWidget): The widget to save the state for.
             settings(QSettings): The QSettings object to save the state to.
+            recursive(bool): Whether to recursively save the state of child widgets.
         """
         if widget.property("skip_settings") is True:
             return
@@ -88,21 +93,32 @@ class WidgetStateManager:
         settings.endGroup()
 
         # Recursively process children (only if they aren't skipped)
-        for child in widget.children():
+        if not recursive:
+            return
+
+        direct_children = widget.children()
+        bec_connector_children = WidgetHierarchy.get_bec_connectors_from_parent(widget)
+        all_children = list(
+            set(direct_children) | set(bec_connector_children)
+        )  # to avoid duplicates
+        for child in all_children:
             if (
                 child.objectName()
                 and child.property("skip_settings") is not True
                 and not isinstance(child, QLabel)
             ):
-                self._save_widget_state_qsettings(child, settings)
+                self._save_widget_state_qsettings(child, settings, False)
 
-    def _load_widget_state_qsettings(self, widget: QWidget, settings: QSettings):
+    def _load_widget_state_qsettings(
+        self, widget: QWidget, settings: QSettings, recursive: bool = True
+    ):
         """
         Load the state of the widget from QSettings.
 
         Args:
             widget(QWidget): The widget to load the state for.
             settings(QSettings): The QSettings object to load the state from.
+            recursive(bool): Whether to recursively load the state of child widgets.
         """
         if widget.property("skip_settings") is True:
             return
@@ -118,14 +134,21 @@ class WidgetStateManager:
                 widget.setProperty(name, value)
         settings.endGroup()
 
+        if not recursive:
+            return
         # Recursively process children (only if they aren't skipped)
-        for child in widget.children():
+        direct_children = widget.children()
+        bec_connector_children = WidgetHierarchy.get_bec_connectors_from_parent(widget)
+        all_children = list(
+            set(direct_children) | set(bec_connector_children)
+        )  # to avoid duplicates
+        for child in all_children:
             if (
                 child.objectName()
                 and child.property("skip_settings") is not True
                 and not isinstance(child, QLabel)
             ):
-                self._load_widget_state_qsettings(child, settings)
+                self._load_widget_state_qsettings(child, settings, False)
 
     def _get_full_widget_name(self, widget: QWidget):
         """

--- a/bec_widgets/utils/widget_state_manager.py
+++ b/bec_widgets/utils/widget_state_manager.py
@@ -31,35 +31,47 @@ class WidgetStateManager:
     def __init__(self, widget):
         self.widget = widget
 
-    def save_state(self, filename: str = None):
+    def save_state(self, filename: str | None = None, settings: QSettings | None = None):
         """
         Save the state of the widget to an INI file.
 
         Args:
             filename(str): The filename to save the state to.
+            settings(QSettings): Optional QSettings object to save the state to.
         """
-        if not filename:
+        if not filename and not settings:
             filename, _ = QFileDialog.getSaveFileName(
                 self.widget, "Save Settings", "", "INI Files (*.ini)"
             )
         if filename:
             settings = QSettings(filename, QSettings.IniFormat)
             self._save_widget_state_qsettings(self.widget, settings)
+        elif settings:
+            # If settings are provided, save the state to the provided QSettings object
+            self._save_widget_state_qsettings(self.widget, settings)
+        else:
+            logger.warning("No filename or settings provided for saving state.")
 
-    def load_state(self, filename: str = None):
+    def load_state(self, filename: str | None = None, settings: QSettings | None = None):
         """
         Load the state of the widget from an INI file.
 
         Args:
             filename(str): The filename to load the state from.
+            settings(QSettings): Optional QSettings object to load the state from.
         """
-        if not filename:
+        if not filename and not settings:
             filename, _ = QFileDialog.getOpenFileName(
                 self.widget, "Load Settings", "", "INI Files (*.ini)"
             )
         if filename:
             settings = QSettings(filename, QSettings.IniFormat)
             self._load_widget_state_qsettings(self.widget, settings)
+        elif settings:
+            # If settings are provided, load the state from the provided QSettings object
+            self._load_widget_state_qsettings(self.widget, settings)
+        else:
+            logger.warning("No filename or settings provided for saving state.")
 
     def _save_widget_state_qsettings(
         self, widget: QWidget, settings: QSettings, recursive: bool = True

--- a/bec_widgets/widgets/containers/advanced_dock_area/advanced_dock_area.py
+++ b/bec_widgets/widgets/containers/advanced_dock_area/advanced_dock_area.py
@@ -5,7 +5,7 @@ from typing import Literal, cast
 
 import PySide6QtAds as QtAds
 from PySide6QtAds import CDockManager, CDockWidget
-from qtpy.QtCore import QSettings, Signal
+from qtpy.QtCore import Signal
 from qtpy.QtWidgets import (
     QApplication,
     QCheckBox,
@@ -34,6 +34,16 @@ from bec_widgets.utils.toolbars.actions import (
 from bec_widgets.utils.toolbars.bundles import ToolbarBundle
 from bec_widgets.utils.toolbars.toolbar import ModularToolBar
 from bec_widgets.utils.widget_state_manager import WidgetStateManager
+from bec_widgets.widgets.containers.advanced_dock_area.profile_utils import (
+    SETTINGS_KEYS,
+    is_profile_readonly,
+    list_profiles,
+    open_settings,
+    profile_path,
+    read_manifest,
+    set_profile_readonly,
+    write_manifest,
+)
 from bec_widgets.widgets.containers.advanced_dock_area.toolbar_components.workspace_actions import (
     WorkspaceConnection,
     workspace_bundle,
@@ -53,81 +63,6 @@ from bec_widgets.widgets.services.bec_queue.bec_queue import BECQueue
 from bec_widgets.widgets.services.bec_status_box.bec_status_box import BECStatusBox
 from bec_widgets.widgets.utility.logpanel import LogPanel
 from bec_widgets.widgets.utility.visual.dark_mode_button.dark_mode_button import DarkModeButton
-
-MODULE_PATH = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
-_DEFAULT_PROFILES_DIR = os.path.join(os.path.dirname(__file__), "states", "default")
-_USER_PROFILES_DIR = os.path.join(os.path.dirname(__file__), "states", "user")
-
-
-def _profiles_dir() -> str:
-    path = os.environ.get("BECWIDGETS_PROFILE_DIR", _USER_PROFILES_DIR)
-    os.makedirs(path, exist_ok=True)
-    return path
-
-
-def _profile_path(name: str) -> str:
-    return os.path.join(_profiles_dir(), f"{name}.ini")
-
-
-SETTINGS_KEYS = {
-    "geom": "mainWindow/Geometry",
-    "state": "mainWindow/State",
-    "ads_state": "mainWindow/DockingState",
-    "manifest": "manifest/widgets",
-    "readonly": "profile/readonly",
-}
-
-
-def list_profiles() -> list[str]:
-    return sorted(os.path.splitext(f)[0] for f in os.listdir(_profiles_dir()) if f.endswith(".ini"))
-
-
-def is_profile_readonly(name: str) -> bool:
-    """Check if a profile is marked as read-only."""
-    settings = open_settings(name)
-    return settings.value(SETTINGS_KEYS["readonly"], False, type=bool)
-
-
-def set_profile_readonly(name: str, readonly: bool) -> None:
-    """Set the read-only status of a profile."""
-    settings = open_settings(name)
-    settings.setValue(SETTINGS_KEYS["readonly"], readonly)
-    settings.sync()
-
-
-def open_settings(name: str) -> QSettings:
-    return QSettings(_profile_path(name), QSettings.IniFormat)
-
-
-def write_manifest(settings: QSettings, docks: list[CDockWidget]) -> None:
-    settings.beginWriteArray(SETTINGS_KEYS["manifest"], len(docks))
-    for i, dock in enumerate(docks):
-        settings.setArrayIndex(i)
-        w = dock.widget()
-        settings.setValue("object_name", w.objectName())
-        settings.setValue("widget_class", w.__class__.__name__)
-        settings.setValue("closable", getattr(dock, "_default_closable", True))
-        settings.setValue("floatable", getattr(dock, "_default_floatable", True))
-        settings.setValue("movable", getattr(dock, "_default_movable", True))
-    settings.endArray()
-
-
-def read_manifest(settings: QSettings) -> list[dict]:
-    items: list[dict] = []
-    count = settings.beginReadArray(SETTINGS_KEYS["manifest"])
-    for i in range(count):
-        settings.setArrayIndex(i)
-        items.append(
-            {
-                "object_name": settings.value("object_name"),
-                "widget_class": settings.value("widget_class"),
-                "closable": settings.value("closable", type=bool),
-                "floatable": settings.value("floatable", type=bool),
-                "movable": settings.value("movable", type=bool),
-            }
-        )
-    settings.endArray()
-    return items
 
 
 class DockSettingsDialog(QDialog):
@@ -751,7 +686,7 @@ class AdvancedDockArea(BECWidget, QWidget):
             readonly = dialog.is_readonly()
 
             # Check if profile already exists and is read-only
-            if os.path.exists(_profile_path(name)) and is_profile_readonly(name):
+            if os.path.exists(profile_path(name)) and is_profile_readonly(name):
                 suggested_name = f"{name}_custom"
                 reply = QMessageBox.warning(
                     self,
@@ -771,14 +706,14 @@ class AdvancedDockArea(BECWidget, QWidget):
                     readonly = dialog.is_readonly()
 
                     # Check again if the new name is also read-only (recursive protection)
-                    if os.path.exists(_profile_path(name)) and is_profile_readonly(name):
+                    if os.path.exists(profile_path(name)) and is_profile_readonly(name):
                         return self.save_profile()
                 else:
                     return
         else:
             # If name is provided directly, assume not read-only unless already exists
             readonly = False
-            if os.path.exists(_profile_path(name)) and is_profile_readonly(name):
+            if os.path.exists(profile_path(name)) and is_profile_readonly(name):
                 QMessageBox.warning(
                     self,
                     "Read-only Profile",
@@ -889,7 +824,7 @@ class AdvancedDockArea(BECWidget, QWidget):
         if reply != QMessageBox.Yes:
             return
 
-        file_path = _profile_path(name)
+        file_path = profile_path(name)
         try:
             os.remove(file_path)
         except FileNotFoundError:

--- a/bec_widgets/widgets/containers/advanced_dock_area/advanced_dock_area.py
+++ b/bec_widgets/widgets/containers/advanced_dock_area/advanced_dock_area.py
@@ -847,8 +847,6 @@ class AdvancedDockArea(BECMainWindow):
 if __name__ == "__main__":
     import sys
 
-    if sys.platform.startswith("linux"):
-        os.environ["QT_QPA_PLATFORM"] = "xcb"
     app = QApplication(sys.argv)
     dispatcher = BECDispatcher(gui_id="ads")
     main_window = AdvancedDockArea()

--- a/bec_widgets/widgets/containers/advanced_dock_area/advanced_dock_area.py
+++ b/bec_widgets/widgets/containers/advanced_dock_area/advanced_dock_area.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 import os
-from typing import cast
+from typing import cast, Literal
 
 import PySide6QtAds as QtAds
 from PySide6QtAds import CDockManager, CDockWidget
-from qtpy.QtCore import Property, QSettings, QSize, Signal
+from qtpy.QtCore import QSettings, Signal
 from qtpy.QtWidgets import (
     QApplication,
     QCheckBox,
@@ -202,12 +202,28 @@ class SaveProfileDialog(QDialog):
 class AdvancedDockArea(BECWidget, QWidget):
     RPC = True
     PLUGIN = False
-    USER_ACCESS = ["new", "widget_map", "widget_list", "lock_workspace", "attach_all", "delete_all"]
+    USER_ACCESS = [
+        "new",
+        "widget_map",
+        "widget_list",
+        "lock_workspace",
+        "attach_all",
+        "delete_all",
+        "mode",
+        "mode.setter",
+    ]
 
     # Define a signal for mode changes
     mode_changed = Signal(str)
 
-    def __init__(self, parent=None, mode: str = "developer", *args, **kwargs):
+    def __init__(
+        self,
+        parent=None,
+        mode: str = "developer",
+        default_add_direction: Literal["left", "right", "top", "bottom"] = "right",
+        *args,
+        **kwargs,
+    ):
         super().__init__(parent=parent, *args, **kwargs)
 
         # Title (as a top-level QWidget it can have a window title)
@@ -219,10 +235,10 @@ class AdvancedDockArea(BECWidget, QWidget):
         self._root_layout.setSpacing(0)
 
         # Setting the dock manager with flags
-        QtAds.CDockManager.setConfigFlag(QtAds.CDockManager.eConfigFlag.FocusHighlighting, True)
-        QtAds.CDockManager.setConfigFlag(
-            QtAds.CDockManager.eConfigFlag.RetainTabSizeWhenCloseButtonHidden, True
-        )
+        # QtAds.CDockManager.setConfigFlag(QtAds.CDockManager.eConfigFlag.FocusHighlighting, True)
+        # QtAds.CDockManager.setConfigFlag(
+        #     QtAds.CDockManager.eConfigFlag.RetainTabSizeWhenCloseButtonHidden, True
+        # )
         self.dock_manager = CDockManager(self)
 
         # Dock manager helper variables
@@ -230,6 +246,11 @@ class AdvancedDockArea(BECWidget, QWidget):
 
         # Initialize mode property first (before toolbar setup)
         self._mode = "developer"
+        self._default_add_direction = (
+            default_add_direction
+            if default_add_direction in ("left", "right", "top", "bottom")
+            else "right"
+        )
 
         # Toolbar
         self.dark_mode_button = DarkModeButton(parent=self, toolbar=True)
@@ -257,9 +278,6 @@ class AdvancedDockArea(BECWidget, QWidget):
 
         # Apply the requested mode after everything is set up
         self.mode = mode
-
-    def minimumSizeHint(self):
-        return QSize(1200, 800)
 
     def _make_dock(
         self,
@@ -331,6 +349,19 @@ class AdvancedDockArea(BECWidget, QWidget):
         if isValid(dock):
             dock.closeDockWidget()
             dock.deleteDockWidget()
+
+    def _area_from_where(self, where: str | None) -> QtAds.DockWidgetArea:
+        """Return ADS DockWidgetArea from a human-friendly direction string.
+        If *where* is None, fall back to instance default.
+        """
+        d = (where or getattr(self, "_default_add_direction", "right") or "right").lower()
+        mapping = {
+            "left": QtAds.DockWidgetArea.LeftDockWidgetArea,
+            "right": QtAds.DockWidgetArea.RightDockWidgetArea,
+            "top": QtAds.DockWidgetArea.TopDockWidgetArea,
+            "bottom": QtAds.DockWidgetArea.BottomDockWidgetArea,
+        }
+        return mapping.get(d, QtAds.DockWidgetArea.RightDockWidgetArea)
 
     ################################################################################
     # Toolbar Setup
@@ -553,22 +584,25 @@ class AdvancedDockArea(BECWidget, QWidget):
         floatable: bool = True,
         movable: bool = True,
         start_floating: bool = False,
+        where: Literal["left", "right", "top", "bottom"] | None = None,
     ) -> BECWidget:
         """
-        Creates a new widget or reuses an existing one and schedules its dock creation.
+        Create a new widget (or reuse an instance) and add it as a dock.
 
         Args:
-            widget (BECWidget | str): The widget instance or a string specifying the
-                type of widget to create.
-            closable (bool): Whether the dock should be closable. Defaults to True.
-            floatable (bool): Whether the dock should be floatable. Defaults to True.
-            movable (bool): Whether the dock should be movable. Defaults to True.
-            start_floating (bool): Whether to start the dock in a floating state. Defaults to False.
-
+            widget: Widget instance or a string widget type (factory-created).
+            closable: Whether the dock is closable.
+            floatable: Whether the dock is floatable.
+            movable: Whether the dock is movable.
+            start_floating: Start the dock in a floating state.
+            where: Preferred area to add the dock: "left" | "right" | "top" | "bottom".
+                   If None, uses the instance default passed at construction time.
         Returns:
-            widget: The widget instance.
+            The widget instance.
         """
-        # 1) Instantiate or look up the widget (this schedules the BECConnector naming logic)
+        target_area = self._area_from_where(where)
+
+        # 1) Instantiate or look up the widget
         if isinstance(widget, str):
             widget = cast(BECWidget, widget_handler.create_widget(widget_type=widget, parent=self))
             widget.name_established.connect(
@@ -578,8 +612,20 @@ class AdvancedDockArea(BECWidget, QWidget):
                     floatable=floatable,
                     movable=movable,
                     start_floating=start_floating,
+                    area=target_area,
                 )
             )
+            return widget
+
+        # If a widget instance is passed, dock it immediately
+        self._create_dock_with_name(
+            widget=widget,
+            closable=closable,
+            floatable=floatable,
+            movable=movable,
+            start_floating=start_floating,
+            area=target_area,
+        )
         return widget
 
     def _create_dock_with_name(
@@ -589,13 +635,15 @@ class AdvancedDockArea(BECWidget, QWidget):
         floatable: bool = False,
         movable: bool = True,
         start_floating: bool = False,
+        area: QtAds.DockWidgetArea | None = None,
     ):
+        target_area = area or self._area_from_where(None)
         self._make_dock(
             widget,
             closable=closable,
             floatable=floatable,
             movable=movable,
-            area=QtAds.DockWidgetArea.RightDockWidgetArea,
+            area=target_area,
             start_floating=start_floating,
         )
         self.dock_manager.setFocus()
@@ -906,21 +954,6 @@ class AdvancedDockArea(BECWidget, QWidget):
             # Fallback to user mode
             self.toolbar.show_bundles(["spacer_bundle", "workspace", "dock_actions"])
 
-    def switch_to_plot_mode(self):
-        self.mode = "plot"
-
-    def switch_to_device_mode(self):
-        self.mode = "device"
-
-    def switch_to_utils_mode(self):
-        self.mode = "utils"
-
-    def switch_to_developer_mode(self):
-        self.mode = "developer"
-
-    def switch_to_user_mode(self):
-        self.mode = "user"
-
     def cleanup(self):
         """
         Cleanup the dock area.
@@ -938,7 +971,7 @@ if __name__ == "__main__":
     app = QApplication(sys.argv)
     dispatcher = BECDispatcher(gui_id="ads")
     window = BECMainWindowNoRPC()
-    ads = AdvancedDockArea(parent=window, mode="developer")
+    ads = AdvancedDockArea(mode="developer", root_widget=True)
     window.setCentralWidget(ads)
     window.show()
     window.resize(800, 600)

--- a/bec_widgets/widgets/containers/advanced_dock_area/advanced_dock_area.py
+++ b/bec_widgets/widgets/containers/advanced_dock_area/advanced_dock_area.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import os
-from typing import cast, Literal
+from typing import Literal, cast
 
 import PySide6QtAds as QtAds
 from PySide6QtAds import CDockManager, CDockWidget
@@ -234,11 +234,7 @@ class AdvancedDockArea(BECWidget, QWidget):
         self._root_layout.setContentsMargins(0, 0, 0, 0)
         self._root_layout.setSpacing(0)
 
-        # Setting the dock manager with flags
-        # QtAds.CDockManager.setConfigFlag(QtAds.CDockManager.eConfigFlag.FocusHighlighting, True)
-        # QtAds.CDockManager.setConfigFlag(
-        #     QtAds.CDockManager.eConfigFlag.RetainTabSizeWhenCloseButtonHidden, True
-        # )
+        # Init Dock Manager
         self.dock_manager = CDockManager(self)
 
         # Dock manager helper variables

--- a/bec_widgets/widgets/containers/advanced_dock_area/advanced_dock_area.py
+++ b/bec_widgets/widgets/containers/advanced_dock_area/advanced_dock_area.py
@@ -1,0 +1,857 @@
+from __future__ import annotations
+
+import os
+from typing import cast
+
+import PySide6QtAds as QtAds
+from PySide6QtAds import CDockManager, CDockWidget
+from qtpy.QtCore import QSettings, QSize, Qt
+from qtpy.QtGui import QAction
+from qtpy.QtWidgets import (
+    QApplication,
+    QCheckBox,
+    QDialog,
+    QHBoxLayout,
+    QInputDialog,
+    QLabel,
+    QLineEdit,
+    QMessageBox,
+    QPushButton,
+    QSizePolicy,
+    QVBoxLayout,
+    QWidget,
+)
+from shiboken6 import isValid
+
+from bec_widgets import BECWidget, SafeProperty, SafeSlot
+from bec_widgets.cli.rpc.rpc_widget_handler import widget_handler
+from bec_widgets.utils import BECDispatcher
+from bec_widgets.utils.property_editor import PropertyEditor
+from bec_widgets.utils.toolbars.actions import (
+    ExpandableMenuAction,
+    MaterialIconAction,
+    WidgetAction,
+)
+from bec_widgets.utils.toolbars.bundles import ToolbarBundle
+from bec_widgets.utils.toolbars.toolbar import ModularToolBar
+from bec_widgets.utils.widget_state_manager import WidgetStateManager
+from bec_widgets.widgets.containers.advanced_dock_area.toolbar_components.workspace_actions import (
+    WorkspaceConnection,
+    workspace_bundle,
+)
+from bec_widgets.widgets.containers.main_window.main_window import BECMainWindow
+from bec_widgets.widgets.control.device_control.positioner_box import PositionerBox
+from bec_widgets.widgets.control.scan_control import ScanControl
+from bec_widgets.widgets.editors.vscode.vscode import VSCodeEditor
+from bec_widgets.widgets.plots.heatmap.heatmap import Heatmap
+from bec_widgets.widgets.plots.image.image import Image
+from bec_widgets.widgets.plots.motor_map.motor_map import MotorMap
+from bec_widgets.widgets.plots.multi_waveform.multi_waveform import MultiWaveform
+from bec_widgets.widgets.plots.scatter_waveform.scatter_waveform import ScatterWaveform
+from bec_widgets.widgets.plots.waveform.waveform import Waveform
+from bec_widgets.widgets.progress.ring_progress_bar import RingProgressBar
+from bec_widgets.widgets.services.bec_queue.bec_queue import BECQueue
+from bec_widgets.widgets.services.bec_status_box.bec_status_box import BECStatusBox
+from bec_widgets.widgets.utility.logpanel import LogPanel
+from bec_widgets.widgets.utility.visual.dark_mode_button.dark_mode_button import DarkModeButton
+
+MODULE_PATH = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+_DEFAULT_PROFILES_DIR = os.path.join(os.path.dirname(__file__), "states", "default")
+_USER_PROFILES_DIR = os.path.join(os.path.dirname(__file__), "states", "user")
+
+
+def _profiles_dir() -> str:
+    path = os.environ.get("BECWIDGETS_PROFILE_DIR", _USER_PROFILES_DIR)
+    os.makedirs(path, exist_ok=True)
+    return path
+
+
+def _profile_path(name: str) -> str:
+    return os.path.join(_profiles_dir(), f"{name}.ini")
+
+
+SETTINGS_KEYS = {
+    "geom": "mainWindow/Geometry",
+    "state": "mainWindow/State",
+    "ads_state": "mainWindow/DockingState",
+    "manifest": "manifest/widgets",
+    "readonly": "profile/readonly",
+}
+
+
+def list_profiles() -> list[str]:
+    return sorted(os.path.splitext(f)[0] for f in os.listdir(_profiles_dir()) if f.endswith(".ini"))
+
+
+def is_profile_readonly(name: str) -> bool:
+    """Check if a profile is marked as read-only."""
+    settings = open_settings(name)
+    return settings.value(SETTINGS_KEYS["readonly"], False, type=bool)
+
+
+def set_profile_readonly(name: str, readonly: bool) -> None:
+    """Set the read-only status of a profile."""
+    settings = open_settings(name)
+    settings.setValue(SETTINGS_KEYS["readonly"], readonly)
+    settings.sync()
+
+
+def open_settings(name: str) -> QSettings:
+    return QSettings(_profile_path(name), QSettings.IniFormat)
+
+
+def write_manifest(settings: QSettings, docks: list[CDockWidget]) -> None:
+    settings.beginWriteArray(SETTINGS_KEYS["manifest"], len(docks))
+    for i, dock in enumerate(docks):
+        settings.setArrayIndex(i)
+        w = dock.widget()
+        settings.setValue("object_name", w.objectName())
+        settings.setValue("widget_class", w.__class__.__name__)
+        settings.setValue("closable", getattr(dock, "_default_closable", True))
+        settings.setValue("floatable", getattr(dock, "_default_floatable", True))
+        settings.setValue("movable", getattr(dock, "_default_movable", True))
+    settings.endArray()
+
+
+def read_manifest(settings: QSettings) -> list[dict]:
+    items: list[dict] = []
+    count = settings.beginReadArray(SETTINGS_KEYS["manifest"])
+    for i in range(count):
+        settings.setArrayIndex(i)
+        items.append(
+            {
+                "object_name": settings.value("object_name"),
+                "widget_class": settings.value("widget_class"),
+                "closable": settings.value("closable", type=bool),
+                "floatable": settings.value("floatable", type=bool),
+                "movable": settings.value("movable", type=bool),
+            }
+        )
+    settings.endArray()
+    return items
+
+
+class DockSettingsDialog(QDialog):
+
+    def __init__(self, parent: QWidget, target: QWidget):
+        super().__init__(parent)
+        self.setWindowTitle("Dock Settings")
+        self.setModal(True)
+        layout = QVBoxLayout(self)
+
+        # Property editor
+        self.prop_editor = PropertyEditor(target, self, show_only_bec=True)
+        layout.addWidget(self.prop_editor)
+
+
+class SaveProfileDialog(QDialog):
+    """Dialog for saving workspace profiles with read-only option."""
+
+    def __init__(self, parent: QWidget, current_name: str = ""):
+        super().__init__(parent)
+        self.setWindowTitle("Save Workspace Profile")
+        self.setModal(True)
+        self.resize(400, 150)
+        layout = QVBoxLayout(self)
+
+        # Name input
+        name_row = QHBoxLayout()
+        name_row.addWidget(QLabel("Profile Name:"))
+        self.name_edit = QLineEdit(current_name)
+        self.name_edit.setPlaceholderText("Enter profile name...")
+        name_row.addWidget(self.name_edit)
+        layout.addLayout(name_row)
+
+        # Read-only checkbox
+        self.readonly_checkbox = QCheckBox("Mark as read-only (cannot be overwritten or deleted)")
+        layout.addWidget(self.readonly_checkbox)
+
+        # Info label
+        info_label = QLabel("Read-only profiles are protected from modification and deletion.")
+        info_label.setStyleSheet("color: gray; font-size: 10px;")
+        layout.addWidget(info_label)
+
+        # Buttons
+        btn_row = QHBoxLayout()
+        btn_row.addStretch(1)
+        self.save_btn = QPushButton("Save")
+        self.save_btn.setDefault(True)
+        cancel_btn = QPushButton("Cancel")
+        self.save_btn.clicked.connect(self.accept)
+        cancel_btn.clicked.connect(self.reject)
+        btn_row.addWidget(self.save_btn)
+        btn_row.addWidget(cancel_btn)
+        layout.addLayout(btn_row)
+
+        # Enable/disable save button based on name input
+        self.name_edit.textChanged.connect(self._update_save_button)
+        self._update_save_button()
+
+    def _update_save_button(self):
+        """Enable save button only when name is not empty."""
+        self.save_btn.setEnabled(bool(self.name_edit.text().strip()))
+
+    def get_profile_name(self) -> str:
+        """Get the entered profile name."""
+        return self.name_edit.text().strip()
+
+    def is_readonly(self) -> bool:
+        """Check if the profile should be marked as read-only."""
+        return self.readonly_checkbox.isChecked()
+
+
+class AdvancedDockArea(BECMainWindow):
+    RPC = True
+    PLUGIN = False
+    USER_ACCESS = ["new", "widget_map", "widget_list", "lock_workspace", "attach_all", "delete_all"]
+
+    def __init__(self, parent=None, *args, **kwargs):
+        super().__init__(parent=parent, *args, **kwargs)
+
+        # Setting the dock manager with flags
+        QtAds.CDockManager.setConfigFlag(QtAds.CDockManager.eConfigFlag.FocusHighlighting, True)
+        QtAds.CDockManager.setConfigFlag(
+            QtAds.CDockManager.eConfigFlag.RetainTabSizeWhenCloseButtonHidden, True
+        )
+        QtAds.CDockManager.setConfigFlag(
+            QtAds.CDockManager.eConfigFlag.HideSingleCentralWidgetTitleBar, True
+        )
+        self.dock_manager = CDockManager(self)
+
+        # Dock manager helper variables
+        self._locked = False  # Lock state of the workspace
+
+        # Toolbar
+        self.dark_mode_button = DarkModeButton(parent=self, toolbar=True)
+        self._setup_toolbar()
+        self._hook_toolbar()
+
+        # Populate and hook the workspace combo
+        self._refresh_workspace_list()
+
+        # State manager
+        self.state_manager = WidgetStateManager(self)
+
+        # Insert Mode menu
+        self._editable = None
+        self._setup_developer_mode_menu()
+
+        # Notification center re-raise
+        self.notification_centre.raise_()
+        self.statusBar().raise_()
+
+    def minimumSizeHint(self):
+        return QSize(1200, 800)
+
+    def _make_dock(
+        self,
+        widget: QWidget,
+        *,
+        closable: bool,
+        floatable: bool,
+        movable: bool = True,
+        area: QtAds.DockWidgetArea = QtAds.DockWidgetArea.RightDockWidgetArea,
+        start_floating: bool = False,
+    ) -> CDockWidget:
+        dock = CDockWidget(widget.objectName())
+        dock.setWidget(widget)
+        dock.setFeature(CDockWidget.DockWidgetDeleteOnClose, True)
+        dock.setFeature(CDockWidget.CustomCloseHandling, True)
+        dock.setFeature(CDockWidget.DockWidgetClosable, closable)
+        dock.setFeature(CDockWidget.DockWidgetFloatable, floatable)
+        dock.setFeature(CDockWidget.DockWidgetMovable, movable)
+
+        self._install_dock_settings_action(dock, widget)
+
+        def on_dock_close():
+            widget.close()
+            dock.closeDockWidget()
+            dock.deleteDockWidget()
+
+        def on_widget_destroyed():
+            if not isValid(dock):
+                return
+            dock.closeDockWidget()
+            dock.deleteDockWidget()
+
+        dock.closeRequested.connect(on_dock_close)
+        if hasattr(widget, "widget_removed"):
+            widget.widget_removed.connect(on_widget_destroyed)
+
+        dock.setMinimumSizeHintMode(CDockWidget.eMinimumSizeHintMode.MinimumSizeHintFromDockWidget)
+        self.dock_manager.addDockWidget(area, dock)
+        if start_floating:
+            dock.setFloating()
+        return dock
+
+    def _install_dock_settings_action(self, dock: CDockWidget, widget: QWidget) -> None:
+        action = MaterialIconAction(
+            icon_name="settings", tooltip="Dock settings", filled=True, parent=self
+        ).action
+        action.setToolTip("Dock settings")
+        action.setObjectName("dockSettingsAction")
+        action.triggered.connect(lambda: self._open_dock_settings_dialog(dock, widget))
+        dock.setTitleBarActions([action])
+        dock.setting_action = action
+
+    def _open_dock_settings_dialog(self, dock: CDockWidget, widget: QWidget) -> None:
+        dlg = DockSettingsDialog(self, widget)
+        dlg.resize(600, 600)
+        dlg.exec()
+
+    def _apply_dock_lock(self, locked: bool) -> None:
+        if locked:
+            self.dock_manager.lockDockWidgetFeaturesGlobally()
+        else:
+            self.dock_manager.lockDockWidgetFeaturesGlobally(QtAds.CDockWidget.NoDockWidgetFeatures)
+
+    def _delete_dock(self, dock: CDockWidget) -> None:
+        w = dock.widget()
+        if w and isValid(w):
+            w.close()
+            w.deleteLater()
+        if isValid(dock):
+            dock.closeDockWidget()
+            dock.deleteDockWidget()
+
+    ################################################################################
+    # Toolbar Setup
+    ################################################################################
+
+    def _setup_toolbar(self):
+        self.toolbar = ModularToolBar(parent=self)
+
+        PLOT_ACTIONS = {
+            "waveform": (Waveform.ICON_NAME, "Add Waveform", "Waveform"),
+            "scatter_waveform": (
+                ScatterWaveform.ICON_NAME,
+                "Add Scatter Waveform",
+                "ScatterWaveform",
+            ),
+            "multi_waveform": (MultiWaveform.ICON_NAME, "Add Multi Waveform", "MultiWaveform"),
+            "image": (Image.ICON_NAME, "Add Image", "Image"),
+            "motor_map": (MotorMap.ICON_NAME, "Add Motor Map", "MotorMap"),
+            "heatmap": (Heatmap.ICON_NAME, "Add Heatmap", "Heatmap"),
+        }
+        DEVICE_ACTIONS = {
+            "scan_control": (ScanControl.ICON_NAME, "Add Scan Control", "ScanControl"),
+            "positioner_box": (PositionerBox.ICON_NAME, "Add Device Box", "PositionerBox"),
+        }
+        UTIL_ACTIONS = {
+            "queue": (BECQueue.ICON_NAME, "Add Scan Queue", "BECQueue"),
+            "vs_code": (VSCodeEditor.ICON_NAME, "Add VS Code", "VSCodeEditor"),
+            "status": (BECStatusBox.ICON_NAME, "Add BEC Status Box", "BECStatusBox"),
+            "progress_bar": (
+                RingProgressBar.ICON_NAME,
+                "Add Circular ProgressBar",
+                "RingProgressBar",
+            ),
+            "log_panel": (LogPanel.ICON_NAME, "Add LogPanel - Disabled", "LogPanel"),
+            "sbb_monitor": ("train", "Add SBB Monitor", "SBBMonitor"),
+        }
+
+        def _build_menu(key: str, label: str, mapping: dict[str, tuple[str, str, str]]):
+            self.toolbar.components.add_safe(
+                key,
+                ExpandableMenuAction(
+                    label=label,
+                    actions={
+                        k: MaterialIconAction(
+                            icon_name=v[0], tooltip=v[1], filled=True, parent=self
+                        )
+                        for k, v in mapping.items()
+                    },
+                ),
+            )
+            b = ToolbarBundle(key, self.toolbar.components)
+            b.add_action(key)
+            self.toolbar.add_bundle(b)
+
+        _build_menu("menu_plots", "Add Plot ", PLOT_ACTIONS)
+        _build_menu("menu_devices", "Add Device Control ", DEVICE_ACTIONS)
+        _build_menu("menu_utils", "Add Utils ", UTIL_ACTIONS)
+
+        # Workspace
+        spacer_bundle = ToolbarBundle("spacer_bundle", self.toolbar.components)
+        spacer = QWidget(parent=self.toolbar.components.toolbar)
+        spacer.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+        self.toolbar.components.add_safe("spacer", WidgetAction(widget=spacer, adjust_size=False))
+        spacer_bundle.add_action("spacer")
+        self.toolbar.add_bundle(spacer_bundle)
+
+        self.toolbar.add_bundle(workspace_bundle(self.toolbar.components))
+        self.toolbar.connect_bundle(
+            "workspace", WorkspaceConnection(components=self.toolbar.components, target_widget=self)
+        )
+
+        # Dock actions
+        self.toolbar.components.add_safe(
+            "attach_all",
+            MaterialIconAction(
+                icon_name="zoom_in_map", tooltip="Attach all floating docks", parent=self
+            ),
+        )
+        self.toolbar.components.add_safe(
+            "screenshot",
+            MaterialIconAction(icon_name="photo_camera", tooltip="Take Screenshot", parent=self),
+        )
+        self.toolbar.components.add_safe(
+            "dark_mode", WidgetAction(widget=self.dark_mode_button, adjust_size=False, parent=self)
+        )
+        bda = ToolbarBundle("dock_actions", self.toolbar.components)
+        bda.add_action("attach_all")
+        bda.add_action("screenshot")
+        bda.add_action("dark_mode")
+        self.toolbar.add_bundle(bda)
+
+        self.toolbar.show_bundles(
+            [
+                "menu_plots",
+                "menu_devices",
+                "menu_utils",
+                "spacer_bundle",
+                "workspace",
+                "dock_actions",
+            ]
+        )
+        self.addToolBar(Qt.TopToolBarArea, self.toolbar)
+
+        # Store mappings on self for use in _hook_toolbar
+        self._ACTION_MAPPINGS = {
+            "menu_plots": PLOT_ACTIONS,
+            "menu_devices": DEVICE_ACTIONS,
+            "menu_utils": UTIL_ACTIONS,
+        }
+
+    def _hook_toolbar(self):
+
+        def _connect_menu(menu_key: str):
+            menu = self.toolbar.components.get_action(menu_key)
+            mapping = self._ACTION_MAPPINGS[menu_key]
+            for key, (_, _, widget_type) in mapping.items():
+                act = menu.actions[key].action
+                if widget_type == "LogPanel":
+                    act.setEnabled(False)  # keep disabled per issue #644
+                else:
+                    act.triggered.connect(lambda _, t=widget_type: self.new(widget=t))
+
+        _connect_menu("menu_plots")
+        _connect_menu("menu_devices")
+        _connect_menu("menu_utils")
+
+        self.toolbar.components.get_action("attach_all").action.triggered.connect(self.attach_all)
+        self.toolbar.components.get_action("screenshot").action.triggered.connect(self.screenshot)
+
+    def _setup_developer_mode_menu(self):
+        """Add a 'Developer' checkbox to the View menu after theme actions."""
+        mb = self.menuBar()
+
+        # Find the View menu (inherited from BECMainWindow)
+        view_menu = None
+        for action in mb.actions():
+            if action.menu() and action.menu().title() == "View":
+                view_menu = action.menu()
+                break
+
+        if view_menu is None:
+            # If View menu doesn't exist, create it
+            view_menu = mb.addMenu("View")
+
+        # Add separator after existing theme actions
+        view_menu.addSeparator()
+
+        # Add Developer mode checkbox
+        self._developer_mode_action = QAction("Developer", self, checkable=True)
+
+        # Default selection based on current lock state
+        self._editable = not self.lock_workspace
+        self._developer_mode_action.setChecked(self._editable)
+
+        # Wire up action
+        self._developer_mode_action.triggered.connect(self._on_developer_mode_toggled)
+
+        view_menu.addAction(self._developer_mode_action)
+
+    def _on_developer_mode_toggled(self, checked: bool) -> None:
+        """Handle developer mode checkbox toggle."""
+        self._set_editable(checked)
+
+    def _set_editable(self, editable: bool) -> None:
+        self.lock_workspace = not editable
+        self._editable = editable
+
+        # Sync the toolbar lock toggle with current mode
+        lock_action = self.toolbar.components.get_action("lock").action
+        lock_action.setChecked(not editable)
+        lock_action.setVisible(editable)
+
+        attach_all_action = self.toolbar.components.get_action("attach_all").action
+        attach_all_action.setVisible(editable)
+
+        # Show full creation menus only when editable; otherwise keep minimal set
+        if editable:
+            self.toolbar.show_bundles(
+                [
+                    "menu_plots",
+                    "menu_devices",
+                    "menu_utils",
+                    "spacer_bundle",
+                    "workspace",
+                    "dock_actions",
+                ]
+            )
+        else:
+            self.toolbar.show_bundles(["spacer_bundle", "workspace", "dock_actions"])
+
+        # Keep Developer mode UI in sync
+        if hasattr(self, "_developer_mode_action"):
+            self._developer_mode_action.setChecked(editable)
+
+    ################################################################################
+    # Adding widgets
+    ################################################################################
+    @SafeSlot(popup_error=True)
+    def new(
+        self,
+        widget: BECWidget | str,
+        closable: bool = True,
+        floatable: bool = True,
+        movable: bool = True,
+        start_floating: bool = False,
+    ) -> BECWidget:
+        """
+        Creates a new widget or reuses an existing one and schedules its dock creation.
+
+        Args:
+            widget (BECWidget | str): The widget instance or a string specifying the
+                type of widget to create.
+            closable (bool): Whether the dock should be closable. Defaults to True.
+            floatable (bool): Whether the dock should be floatable. Defaults to True.
+            movable (bool): Whether the dock should be movable. Defaults to True.
+            start_floating (bool): Whether to start the dock in a floating state. Defaults to False.
+
+        Returns:
+            widget: The widget instance.
+        """
+        # 1) Instantiate or look up the widget (this schedules the BECConnector naming logic)
+        if isinstance(widget, str):
+            widget = cast(BECWidget, widget_handler.create_widget(widget_type=widget, parent=self))
+            widget.name_established.connect(
+                lambda: self._create_dock_with_name(
+                    widget=widget,
+                    closable=closable,
+                    floatable=floatable,
+                    movable=movable,
+                    start_floating=start_floating,
+                )
+            )
+        return widget
+
+    def _create_dock_with_name(
+        self,
+        widget: BECWidget,
+        closable: bool = True,
+        floatable: bool = False,
+        movable: bool = True,
+        start_floating: bool = False,
+    ):
+        self._make_dock(
+            widget,
+            closable=closable,
+            floatable=floatable,
+            movable=movable,
+            area=QtAds.DockWidgetArea.RightDockWidgetArea,
+            start_floating=start_floating,
+        )
+        self.dock_manager.setFocus()
+
+    ################################################################################
+    # Dock Management
+    ################################################################################
+
+    def dock_map(self) -> dict[str, CDockWidget]:
+        """
+        Return the dock widgets map as dictionary with names as keys and dock widgets as values.
+
+        Returns:
+            dict: A dictionary mapping widget names to their corresponding dock widgets.
+        """
+        return self.dock_manager.dockWidgetsMap()
+
+    def dock_list(self) -> list[CDockWidget]:
+        """
+        Return the list of dock widgets.
+
+        Returns:
+            list: A list of all dock widgets in the dock area.
+        """
+        return self.dock_manager.dockWidgets()
+
+    def widget_map(self) -> dict[str, QWidget]:
+        """
+        Return a dictionary mapping widget names to their corresponding BECWidget instances.
+
+        Returns:
+            dict: A dictionary mapping widget names to BECWidget instances.
+        """
+        return {dock.objectName(): dock.widget() for dock in self.dock_list()}
+
+    def widget_list(self) -> list[QWidget]:
+        """
+        Return a list of all BECWidget instances in the dock area.
+
+        Returns:
+            list: A list of all BECWidget instances in the dock area.
+        """
+        return [dock.widget() for dock in self.dock_list() if isinstance(dock.widget(), QWidget)]
+
+    @SafeSlot()
+    def attach_all(self):
+        """
+        Return all floating docks to the dock area, preserving tab groups within each floating container.
+        """
+        for container in self.dock_manager.floatingWidgets():
+            docks = container.dockWidgets()
+            if not docks:
+                continue
+            target = docks[0]
+            self.dock_manager.addDockWidget(QtAds.DockWidgetArea.RightDockWidgetArea, target)
+            for d in docks[1:]:
+                self.dock_manager.addDockWidgetTab(
+                    QtAds.DockWidgetArea.RightDockWidgetArea, d, target
+                )
+
+    @SafeSlot()
+    def delete_all(self):
+        """Delete all docks and widgets."""
+        for dock in list(self.dock_manager.dockWidgets()):
+            self._delete_dock(dock)
+
+    ################################################################################
+    # Workspace Management
+    ################################################################################
+    @SafeProperty(bool)
+    def lock_workspace(self) -> bool:
+        """
+        Get or set the lock state of the workspace.
+
+        Returns:
+            bool: True if the workspace is locked, False otherwise.
+        """
+        return self._locked
+
+    @lock_workspace.setter
+    def lock_workspace(self, value: bool):
+        """
+        Set the lock state of the workspace. Docks remain resizable, but are not movable or closable.
+
+        Args:
+            value (bool): True to lock the workspace, False to unlock it.
+        """
+        self._locked = value
+        self._apply_dock_lock(value)
+        self.toolbar.components.get_action("save_workspace").action.setVisible(not value)
+        self.toolbar.components.get_action("delete_workspace").action.setVisible(not value)
+        for dock in self.dock_list():
+            dock.setting_action.setVisible(not value)
+
+    @SafeSlot(str)
+    def save_profile(self, name: str | None = None):
+        """
+        Save the current workspace profile.
+
+        Args:
+            name (str | None): The name of the profile. If None, a dialog will prompt for a name.
+        """
+        if not name:
+            # Use the new SaveProfileDialog instead of QInputDialog
+            dialog = SaveProfileDialog(self)
+            if dialog.exec() != QDialog.Accepted:
+                return
+            name = dialog.get_profile_name()
+            readonly = dialog.is_readonly()
+
+            # Check if profile already exists and is read-only
+            if os.path.exists(_profile_path(name)) and is_profile_readonly(name):
+                suggested_name = f"{name}_custom"
+                reply = QMessageBox.warning(
+                    self,
+                    "Read-only Profile",
+                    f"The profile '{name}' is marked as read-only and cannot be overwritten.\n\n"
+                    f"Would you like to save it with a different name?\n"
+                    f"Suggested name: '{suggested_name}'",
+                    QMessageBox.Yes | QMessageBox.No,
+                    QMessageBox.Yes,
+                )
+                if reply == QMessageBox.Yes:
+                    # Show dialog again with suggested name pre-filled
+                    dialog = SaveProfileDialog(self, suggested_name)
+                    if dialog.exec() != QDialog.Accepted:
+                        return
+                    name = dialog.get_profile_name()
+                    readonly = dialog.is_readonly()
+
+                    # Check again if the new name is also read-only (recursive protection)
+                    if os.path.exists(_profile_path(name)) and is_profile_readonly(name):
+                        return self.save_profile()
+                else:
+                    return
+        else:
+            # If name is provided directly, assume not read-only unless already exists
+            readonly = False
+            if os.path.exists(_profile_path(name)) and is_profile_readonly(name):
+                QMessageBox.warning(
+                    self,
+                    "Read-only Profile",
+                    f"The profile '{name}' is marked as read-only and cannot be overwritten.",
+                    QMessageBox.Ok,
+                )
+                return
+
+        # Display saving placeholder
+        workspace_combo = self.toolbar.components.get_action("workspace_combo").widget
+        workspace_combo.blockSignals(True)
+        workspace_combo.insertItem(0, f"{name}-saving")
+        workspace_combo.setCurrentIndex(0)
+        workspace_combo.blockSignals(False)
+
+        # Save the profile
+        settings = open_settings(name)
+        settings.setValue(SETTINGS_KEYS["geom"], self.saveGeometry())
+        settings.setValue(SETTINGS_KEYS["state"], self.saveState())
+        settings.setValue(SETTINGS_KEYS["ads_state"], self.dock_manager.saveState())
+        self.dock_manager.addPerspective(name)
+        self.dock_manager.savePerspectives(settings)
+        self.state_manager.save_state(settings=settings)
+        write_manifest(settings, self.dock_list())
+
+        # Set read-only status if specified
+        if readonly:
+            set_profile_readonly(name, readonly)
+
+        settings.sync()
+        self._refresh_workspace_list()
+        workspace_combo.setCurrentText(name)
+
+    def load_profile(self, name: str | None = None):
+        """
+        Load a workspace profile.
+
+        Args:
+            name (str | None): The name of the profile. If None, a dialog will prompt for a name.
+        """
+        # FIXME this has to be tweaked
+        if not name:
+            name, ok = QInputDialog.getText(
+                self, "Load Workspace", "Enter the name of the workspace profile to load:"
+            )
+            if not ok or not name:
+                return
+        settings = open_settings(name)
+
+        for item in read_manifest(settings):
+            obj_name = item["object_name"]
+            widget_class = item["widget_class"]
+            if obj_name not in self.widget_map():
+                w = widget_handler.create_widget(widget_type=widget_class, parent=self)
+                w.setObjectName(obj_name)
+                self._make_dock(
+                    w,
+                    closable=item["closable"],
+                    floatable=item["floatable"],
+                    movable=item["movable"],
+                    area=QtAds.DockWidgetArea.RightDockWidgetArea,
+                )
+
+        geom = settings.value(SETTINGS_KEYS["geom"])
+        if geom:
+            self.restoreGeometry(geom)
+        window_state = settings.value(SETTINGS_KEYS["state"])
+        if window_state:
+            self.restoreState(window_state)
+        dock_state = settings.value(SETTINGS_KEYS["ads_state"])
+        if dock_state:
+            self.dock_manager.restoreState(dock_state)
+        self.dock_manager.loadPerspectives(settings)
+        self.state_manager.load_state(settings=settings)
+        self._set_editable(self._editable)
+
+    @SafeSlot()
+    def delete_profile(self):
+        """
+        Delete the currently selected workspace profile file and refresh the combo list.
+        """
+        combo = self.toolbar.components.get_action("workspace_combo").widget
+        name = combo.currentText()
+        if not name:
+            return
+
+        # Check if profile is read-only
+        if is_profile_readonly(name):
+            QMessageBox.warning(
+                self,
+                "Read-only Profile",
+                f"The profile '{name}' is marked as read-only and cannot be deleted.\n\n"
+                f"Read-only profiles are protected from modification and deletion.",
+                QMessageBox.Ok,
+            )
+            return
+
+        # Confirm deletion for regular profiles
+        reply = QMessageBox.question(
+            self,
+            "Delete Profile",
+            f"Are you sure you want to delete the profile '{name}'?\n\n"
+            f"This action cannot be undone.",
+            QMessageBox.Yes | QMessageBox.No,
+            QMessageBox.No,
+        )
+        if reply != QMessageBox.Yes:
+            return
+
+        file_path = _profile_path(name)
+        try:
+            os.remove(file_path)
+        except FileNotFoundError:
+            return
+        self._refresh_workspace_list()
+
+    def _refresh_workspace_list(self):
+        """
+        Populate the workspace combo box with all saved profile names (without .ini).
+        """
+        combo = self.toolbar.components.get_action("workspace_combo").widget
+        if hasattr(combo, "refresh_profiles"):
+            combo.refresh_profiles()
+        else:
+            # Fallback for regular QComboBox
+            combo.blockSignals(True)
+            combo.clear()
+            combo.addItems(list_profiles())
+            combo.blockSignals(False)
+
+    ################################################################################
+    # Styling
+    ################################################################################
+
+    def cleanup(self):
+        """
+        Cleanup the dock area.
+        """
+        self.delete_all()
+        self.dark_mode_button.close()
+        self.dark_mode_button.deleteLater()
+        super().cleanup()
+
+
+if __name__ == "__main__":
+    import sys
+
+    if sys.platform.startswith("linux"):
+        os.environ["QT_QPA_PLATFORM"] = "xcb"
+    app = QApplication(sys.argv)
+    dispatcher = BECDispatcher(gui_id="ads")
+    main_window = AdvancedDockArea()
+    main_window.show()
+    main_window.resize(800, 600)
+    sys.exit(app.exec())

--- a/bec_widgets/widgets/containers/advanced_dock_area/advanced_dock_area.py
+++ b/bec_widgets/widgets/containers/advanced_dock_area/advanced_dock_area.py
@@ -5,8 +5,7 @@ from typing import cast
 
 import PySide6QtAds as QtAds
 from PySide6QtAds import CDockManager, CDockWidget
-from qtpy.QtCore import QSettings, QSize, Qt
-from qtpy.QtGui import QAction
+from qtpy.QtCore import Property, QSettings, QSize, Signal
 from qtpy.QtWidgets import (
     QApplication,
     QCheckBox,
@@ -39,7 +38,7 @@ from bec_widgets.widgets.containers.advanced_dock_area.toolbar_components.worksp
     WorkspaceConnection,
     workspace_bundle,
 )
-from bec_widgets.widgets.containers.main_window.main_window import BECMainWindow
+from bec_widgets.widgets.containers.main_window.main_window import BECMainWindowNoRPC
 from bec_widgets.widgets.control.device_control.positioner_box import PositionerBox
 from bec_widgets.widgets.control.scan_control import ScanControl
 from bec_widgets.widgets.editors.vscode.vscode import VSCodeEditor
@@ -200,31 +199,46 @@ class SaveProfileDialog(QDialog):
         return self.readonly_checkbox.isChecked()
 
 
-class AdvancedDockArea(BECMainWindow):
+class AdvancedDockArea(BECWidget, QWidget):
     RPC = True
     PLUGIN = False
     USER_ACCESS = ["new", "widget_map", "widget_list", "lock_workspace", "attach_all", "delete_all"]
 
-    def __init__(self, parent=None, *args, **kwargs):
+    # Define a signal for mode changes
+    mode_changed = Signal(str)
+
+    def __init__(self, parent=None, mode: str = "developer", *args, **kwargs):
         super().__init__(parent=parent, *args, **kwargs)
+
+        # Title (as a top-level QWidget it can have a window title)
+        self.setWindowTitle("Advanced Dock Area")
+
+        # Top-level layout hosting a toolbar and the dock manager
+        self._root_layout = QVBoxLayout(self)
+        self._root_layout.setContentsMargins(0, 0, 0, 0)
+        self._root_layout.setSpacing(0)
 
         # Setting the dock manager with flags
         QtAds.CDockManager.setConfigFlag(QtAds.CDockManager.eConfigFlag.FocusHighlighting, True)
         QtAds.CDockManager.setConfigFlag(
             QtAds.CDockManager.eConfigFlag.RetainTabSizeWhenCloseButtonHidden, True
         )
-        QtAds.CDockManager.setConfigFlag(
-            QtAds.CDockManager.eConfigFlag.HideSingleCentralWidgetTitleBar, True
-        )
         self.dock_manager = CDockManager(self)
 
         # Dock manager helper variables
         self._locked = False  # Lock state of the workspace
 
+        # Initialize mode property first (before toolbar setup)
+        self._mode = "developer"
+
         # Toolbar
         self.dark_mode_button = DarkModeButton(parent=self, toolbar=True)
         self._setup_toolbar()
         self._hook_toolbar()
+
+        # Place toolbar and dock manager into layout
+        self._root_layout.addWidget(self.toolbar)
+        self._root_layout.addWidget(self.dock_manager, 1)
 
         # Populate and hook the workspace combo
         self._refresh_workspace_list()
@@ -232,13 +246,17 @@ class AdvancedDockArea(BECMainWindow):
         # State manager
         self.state_manager = WidgetStateManager(self)
 
-        # Insert Mode menu
+        # Developer mode state
         self._editable = None
-        self._setup_developer_mode_menu()
+        # Initialize default editable state based on current lock
+        self._set_editable(True)  # default to editable; will sync toolbar toggle below
 
-        # Notification center re-raise
-        self.notification_centre.raise_()
-        self.statusBar().raise_()
+        # Sync Developer toggle icon state after initial setup
+        dev_action = self.toolbar.components.get_action("developer_mode").action
+        dev_action.setChecked(self._editable)
+
+        # Apply the requested mode after everything is set up
+        self.mode = mode
 
     def minimumSizeHint(self):
         return QSize(1200, 800)
@@ -350,6 +368,7 @@ class AdvancedDockArea(BECMainWindow):
             "sbb_monitor": ("train", "Add SBB Monitor", "SBBMonitor"),
         }
 
+        # Create expandable menu actions (original behavior)
         def _build_menu(key: str, label: str, mapping: dict[str, tuple[str, str, str]]):
             self.toolbar.components.add_safe(
                 key,
@@ -370,6 +389,27 @@ class AdvancedDockArea(BECMainWindow):
         _build_menu("menu_plots", "Add Plot ", PLOT_ACTIONS)
         _build_menu("menu_devices", "Add Device Control ", DEVICE_ACTIONS)
         _build_menu("menu_utils", "Add Utils ", UTIL_ACTIONS)
+
+        # Create flat toolbar bundles for each widget type
+        def _build_flat_bundles(category: str, mapping: dict[str, tuple[str, str, str]]):
+            bundle = ToolbarBundle(f"flat_{category}", self.toolbar.components)
+
+            for action_id, (icon_name, tooltip, widget_type) in mapping.items():
+                # Create individual action for each widget type
+                flat_action_id = f"flat_{action_id}"
+                self.toolbar.components.add_safe(
+                    flat_action_id,
+                    MaterialIconAction(
+                        icon_name=icon_name, tooltip=tooltip, filled=True, parent=self
+                    ),
+                )
+                bundle.add_action(flat_action_id)
+
+            self.toolbar.add_bundle(bundle)
+
+        _build_flat_bundles("plots", PLOT_ACTIONS)
+        _build_flat_bundles("devices", DEVICE_ACTIONS)
+        _build_flat_bundles("utils", UTIL_ACTIONS)
 
         # Workspace
         spacer_bundle = ToolbarBundle("spacer_bundle", self.toolbar.components)
@@ -398,12 +438,21 @@ class AdvancedDockArea(BECMainWindow):
         self.toolbar.components.add_safe(
             "dark_mode", WidgetAction(widget=self.dark_mode_button, adjust_size=False, parent=self)
         )
+        # Developer mode toggle (moved from menu into toolbar)
+        self.toolbar.components.add_safe(
+            "developer_mode",
+            MaterialIconAction(
+                icon_name="code", tooltip="Developer Mode", checkable=True, parent=self
+            ),
+        )
         bda = ToolbarBundle("dock_actions", self.toolbar.components)
         bda.add_action("attach_all")
         bda.add_action("screenshot")
         bda.add_action("dark_mode")
+        bda.add_action("developer_mode")
         self.toolbar.add_bundle(bda)
 
+        # Default bundle configuration (show menus by default)
         self.toolbar.show_bundles(
             [
                 "menu_plots",
@@ -414,7 +463,6 @@ class AdvancedDockArea(BECMainWindow):
                 "dock_actions",
             ]
         )
-        self.addToolBar(Qt.TopToolBarArea, self.toolbar)
 
         # Store mappings on self for use in _hook_toolbar
         self._ACTION_MAPPINGS = {
@@ -439,42 +487,26 @@ class AdvancedDockArea(BECMainWindow):
         _connect_menu("menu_devices")
         _connect_menu("menu_utils")
 
+        # Connect flat toolbar actions
+        def _connect_flat_actions(category: str, mapping: dict[str, tuple[str, str, str]]):
+            for action_id, (_, _, widget_type) in mapping.items():
+                flat_action_id = f"flat_{action_id}"
+                flat_action = self.toolbar.components.get_action(flat_action_id).action
+                if widget_type == "LogPanel":
+                    flat_action.setEnabled(False)  # keep disabled per issue #644
+                else:
+                    flat_action.triggered.connect(lambda _, t=widget_type: self.new(widget=t))
+
+        _connect_flat_actions("plots", self._ACTION_MAPPINGS["menu_plots"])
+        _connect_flat_actions("devices", self._ACTION_MAPPINGS["menu_devices"])
+        _connect_flat_actions("utils", self._ACTION_MAPPINGS["menu_utils"])
+
         self.toolbar.components.get_action("attach_all").action.triggered.connect(self.attach_all)
         self.toolbar.components.get_action("screenshot").action.triggered.connect(self.screenshot)
-
-    def _setup_developer_mode_menu(self):
-        """Add a 'Developer' checkbox to the View menu after theme actions."""
-        mb = self.menuBar()
-
-        # Find the View menu (inherited from BECMainWindow)
-        view_menu = None
-        for action in mb.actions():
-            if action.menu() and action.menu().title() == "View":
-                view_menu = action.menu()
-                break
-
-        if view_menu is None:
-            # If View menu doesn't exist, create it
-            view_menu = mb.addMenu("View")
-
-        # Add separator after existing theme actions
-        view_menu.addSeparator()
-
-        # Add Developer mode checkbox
-        self._developer_mode_action = QAction("Developer", self, checkable=True)
-
-        # Default selection based on current lock state
-        self._editable = not self.lock_workspace
-        self._developer_mode_action.setChecked(self._editable)
-
-        # Wire up action
-        self._developer_mode_action.triggered.connect(self._on_developer_mode_toggled)
-
-        view_menu.addAction(self._developer_mode_action)
-
-    def _on_developer_mode_toggled(self, checked: bool) -> None:
-        """Handle developer mode checkbox toggle."""
-        self._set_editable(checked)
+        # Developer mode toggle
+        self.toolbar.components.get_action("developer_mode").action.toggled.connect(
+            self._on_developer_mode_toggled
+        )
 
     def _set_editable(self, editable: bool) -> None:
         self.lock_workspace = not editable
@@ -504,8 +536,11 @@ class AdvancedDockArea(BECMainWindow):
             self.toolbar.show_bundles(["spacer_bundle", "workspace", "dock_actions"])
 
         # Keep Developer mode UI in sync
-        if hasattr(self, "_developer_mode_action"):
-            self._developer_mode_action.setChecked(editable)
+        self.toolbar.components.get_action("developer_mode").action.setChecked(editable)
+
+    def _on_developer_mode_toggled(self, checked: bool) -> None:
+        """Handle developer mode checkbox toggle."""
+        self._set_editable(checked)
 
     ################################################################################
     # Adding widgets
@@ -718,7 +753,9 @@ class AdvancedDockArea(BECMainWindow):
         # Save the profile
         settings = open_settings(name)
         settings.setValue(SETTINGS_KEYS["geom"], self.saveGeometry())
-        settings.setValue(SETTINGS_KEYS["state"], self.saveState())
+        settings.setValue(
+            SETTINGS_KEYS["state"], b""
+        )  # No QMainWindow state; placeholder for backward compat
         settings.setValue(SETTINGS_KEYS["ads_state"], self.dock_manager.saveState())
         self.dock_manager.addPerspective(name)
         self.dock_manager.savePerspectives(settings)
@@ -766,9 +803,8 @@ class AdvancedDockArea(BECMainWindow):
         geom = settings.value(SETTINGS_KEYS["geom"])
         if geom:
             self.restoreGeometry(geom)
-        window_state = settings.value(SETTINGS_KEYS["state"])
-        if window_state:
-            self.restoreState(window_state)
+        # No window state for QWidget-based host; keep for backwards compat read
+        # window_state = settings.value(SETTINGS_KEYS["state"])  # ignored
         dock_state = settings.value(SETTINGS_KEYS["ads_state"])
         if dock_state:
             self.dock_manager.restoreState(dock_state)
@@ -831,8 +867,59 @@ class AdvancedDockArea(BECMainWindow):
             combo.blockSignals(False)
 
     ################################################################################
-    # Styling
+    # Mode Switching
     ################################################################################
+
+    @SafeProperty(str)
+    def mode(self) -> str:
+        return self._mode
+
+    @mode.setter
+    def mode(self, new_mode: str):
+        if new_mode not in ["plot", "device", "utils", "developer", "user"]:
+            raise ValueError(f"Invalid mode: {new_mode}")
+        self._mode = new_mode
+        self.mode_changed.emit(new_mode)
+
+        # Update toolbar visibility based on mode
+        if new_mode == "user":
+            # User mode: show only essential tools
+            self.toolbar.show_bundles(["spacer_bundle", "workspace", "dock_actions"])
+        elif new_mode == "developer":
+            # Developer mode: show all tools (use menu bundles)
+            self.toolbar.show_bundles(
+                [
+                    "menu_plots",
+                    "menu_devices",
+                    "menu_utils",
+                    "spacer_bundle",
+                    "workspace",
+                    "dock_actions",
+                ]
+            )
+        elif new_mode in ["plot", "device", "utils"]:
+            # Specific modes: show flat toolbar for that category
+            bundle_name = f"flat_{new_mode}s" if new_mode != "utils" else "flat_utils"
+            self.toolbar.show_bundles([bundle_name])
+            # self.toolbar.show_bundles([bundle_name, "spacer_bundle", "workspace", "dock_actions"])
+        else:
+            # Fallback to user mode
+            self.toolbar.show_bundles(["spacer_bundle", "workspace", "dock_actions"])
+
+    def switch_to_plot_mode(self):
+        self.mode = "plot"
+
+    def switch_to_device_mode(self):
+        self.mode = "device"
+
+    def switch_to_utils_mode(self):
+        self.mode = "utils"
+
+    def switch_to_developer_mode(self):
+        self.mode = "developer"
+
+    def switch_to_user_mode(self):
+        self.mode = "user"
 
     def cleanup(self):
         """
@@ -841,6 +928,7 @@ class AdvancedDockArea(BECMainWindow):
         self.delete_all()
         self.dark_mode_button.close()
         self.dark_mode_button.deleteLater()
+        self.toolbar.cleanup()
         super().cleanup()
 
 
@@ -849,7 +937,9 @@ if __name__ == "__main__":
 
     app = QApplication(sys.argv)
     dispatcher = BECDispatcher(gui_id="ads")
-    main_window = AdvancedDockArea()
-    main_window.show()
-    main_window.resize(800, 600)
+    window = BECMainWindowNoRPC()
+    ads = AdvancedDockArea(parent=window, mode="developer")
+    window.setCentralWidget(ads)
+    window.show()
+    window.resize(800, 600)
     sys.exit(app.exec())

--- a/bec_widgets/widgets/containers/advanced_dock_area/profile_utils.py
+++ b/bec_widgets/widgets/containers/advanced_dock_area/profile_utils.py
@@ -1,0 +1,79 @@
+import os
+
+from PySide6QtAds import CDockWidget
+from qtpy.QtCore import QSettings
+
+MODULE_PATH = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+_DEFAULT_PROFILES_DIR = os.path.join(os.path.dirname(__file__), "states", "default")
+_USER_PROFILES_DIR = os.path.join(os.path.dirname(__file__), "states", "user")
+
+
+def profiles_dir() -> str:
+    path = os.environ.get("BECWIDGETS_PROFILE_DIR", _USER_PROFILES_DIR)
+    os.makedirs(path, exist_ok=True)
+    return path
+
+
+def profile_path(name: str) -> str:
+    return os.path.join(profiles_dir(), f"{name}.ini")
+
+
+SETTINGS_KEYS = {
+    "geom": "mainWindow/Geometry",
+    "state": "mainWindow/State",
+    "ads_state": "mainWindow/DockingState",
+    "manifest": "manifest/widgets",
+    "readonly": "profile/readonly",
+}
+
+
+def list_profiles() -> list[str]:
+    return sorted(os.path.splitext(f)[0] for f in os.listdir(profiles_dir()) if f.endswith(".ini"))
+
+
+def is_profile_readonly(name: str) -> bool:
+    """Check if a profile is marked as read-only."""
+    settings = open_settings(name)
+    return settings.value(SETTINGS_KEYS["readonly"], False, type=bool)
+
+
+def set_profile_readonly(name: str, readonly: bool) -> None:
+    """Set the read-only status of a profile."""
+    settings = open_settings(name)
+    settings.setValue(SETTINGS_KEYS["readonly"], readonly)
+    settings.sync()
+
+
+def open_settings(name: str) -> QSettings:
+    return QSettings(profile_path(name), QSettings.IniFormat)
+
+
+def write_manifest(settings: QSettings, docks: list[CDockWidget]) -> None:
+    settings.beginWriteArray(SETTINGS_KEYS["manifest"], len(docks))
+    for i, dock in enumerate(docks):
+        settings.setArrayIndex(i)
+        w = dock.widget()
+        settings.setValue("object_name", w.objectName())
+        settings.setValue("widget_class", w.__class__.__name__)
+        settings.setValue("closable", getattr(dock, "_default_closable", True))
+        settings.setValue("floatable", getattr(dock, "_default_floatable", True))
+        settings.setValue("movable", getattr(dock, "_default_movable", True))
+    settings.endArray()
+
+
+def read_manifest(settings: QSettings) -> list[dict]:
+    items: list[dict] = []
+    count = settings.beginReadArray(SETTINGS_KEYS["manifest"])
+    for i in range(count):
+        settings.setArrayIndex(i)
+        items.append(
+            {
+                "object_name": settings.value("object_name"),
+                "widget_class": settings.value("widget_class"),
+                "closable": settings.value("closable", type=bool),
+                "floatable": settings.value("floatable", type=bool),
+                "movable": settings.value("movable", type=bool),
+            }
+        )
+    settings.endArray()
+    return items

--- a/bec_widgets/widgets/containers/advanced_dock_area/toolbar_components/workspace_actions.py
+++ b/bec_widgets/widgets/containers/advanced_dock_area/toolbar_components/workspace_actions.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+from bec_qthemes import material_icon
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import QComboBox, QSizePolicy, QWidget
+
+from bec_widgets import SafeSlot
+from bec_widgets.utils.toolbars.actions import MaterialIconAction, WidgetAction
+from bec_widgets.utils.toolbars.bundles import ToolbarBundle, ToolbarComponents
+
+
+class ProfileComboBox(QComboBox):
+    """Custom combobox that displays icons for read-only profiles."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+
+    def refresh_profiles(self):
+        """Refresh the profile list with appropriate icons."""
+        from ..advanced_dock_area import is_profile_readonly, list_profiles
+
+        current_text = self.currentText()
+        self.blockSignals(True)
+        self.clear()
+
+        lock_icon = material_icon("edit_off", size=(16, 16), convert_to_pixmap=False)
+
+        for profile in list_profiles():
+            if is_profile_readonly(profile):
+                self.addItem(lock_icon, f"{profile}")
+                # Set tooltip for read-only profiles
+                self.setItemData(self.count() - 1, "Read-only profile", Qt.ToolTipRole)
+            else:
+                self.addItem(profile)
+
+        # Restore selection if possible
+        index = self.findText(current_text)
+        if index >= 0:
+            self.setCurrentIndex(index)
+
+        self.blockSignals(False)
+
+
+def workspace_bundle(components: ToolbarComponents) -> ToolbarBundle:
+    """
+    Creates a workspace toolbar bundle for AdvancedDockArea.
+
+    Args:
+        components (ToolbarComponents): The components to be added to the bundle.
+
+    Returns:
+        ToolbarBundle: The workspace toolbar bundle.
+    """
+    # Lock icon action
+    components.add_safe(
+        "lock",
+        MaterialIconAction(
+            icon_name="lock_open_right",
+            tooltip="Lock Workspace",
+            checkable=True,
+            parent=components.toolbar,
+        ),
+    )
+
+    # Workspace combo
+    combo = ProfileComboBox(parent=components.toolbar)
+    components.add_safe("workspace_combo", WidgetAction(widget=combo, adjust_size=False))
+
+    # Save the current workspace icon
+    components.add_safe(
+        "save_workspace",
+        MaterialIconAction(
+            icon_name="save",
+            tooltip="Save Current Workspace",
+            checkable=False,
+            parent=components.toolbar,
+        ),
+    )
+    # Delete workspace icon
+    components.add_safe(
+        "refresh_workspace",
+        MaterialIconAction(
+            icon_name="refresh",
+            tooltip="Refresh Current Workspace",
+            checkable=False,
+            parent=components.toolbar,
+        ),
+    )
+    # Delete workspace icon
+    components.add_safe(
+        "delete_workspace",
+        MaterialIconAction(
+            icon_name="delete",
+            tooltip="Delete Current Workspace",
+            checkable=False,
+            parent=components.toolbar,
+        ),
+    )
+
+    bundle = ToolbarBundle("workspace", components)
+    bundle.add_action("lock")
+    bundle.add_action("workspace_combo")
+    bundle.add_action("save_workspace")
+    bundle.add_action("refresh_workspace")
+    bundle.add_action("delete_workspace")
+    return bundle
+
+
+class WorkspaceConnection:
+    """
+    Connection class for workspace actions in AdvancedDockArea.
+    """
+
+    def __init__(self, components: ToolbarComponents, target_widget=None):
+        self.bundle_name = "workspace"
+        self.components = components
+        self.target_widget = target_widget
+        if not hasattr(self.target_widget, "lock_workspace"):
+            raise AttributeError("Target widget must implement 'lock_workspace'.")
+        super().__init__()
+        self._connected = False
+
+    def connect(self):
+        self._connected = True
+        # Connect the action to the target widget's method
+        self.components.get_action("lock").action.toggled.connect(self._lock_workspace)
+        self.components.get_action("save_workspace").action.triggered.connect(
+            self.target_widget.save_profile
+        )
+        self.components.get_action("workspace_combo").widget.currentTextChanged.connect(
+            self.target_widget.load_profile
+        )
+        self.components.get_action("refresh_workspace").action.triggered.connect(
+            self._refresh_workspace
+        )
+        self.components.get_action("delete_workspace").action.triggered.connect(
+            self.target_widget.delete_profile
+        )
+
+    def disconnect(self):
+        if not self._connected:
+            return
+        # Disconnect the action from the target widget's method
+        self.components.get_action("lock").action.toggled.disconnect(self._lock_workspace)
+        self.components.get_action("save_workspace").action.triggered.disconnect(
+            self.target_widget.save_profile
+        )
+        self.components.get_action("workspace_combo").widget.currentTextChanged.disconnect(
+            self.target_widget.load_profile
+        )
+        self.components.get_action("refresh_workspace").action.triggered.disconnect(
+            self._refresh_workspace
+        )
+        self.components.get_action("delete_workspace").action.triggered.disconnect(
+            self.target_widget.delete_profile
+        )
+
+    @SafeSlot(bool)
+    def _lock_workspace(self, value: bool):
+        """
+        Switches the workspace lock state and change the icon accordingly.
+        """
+        setattr(self.target_widget, "lock_workspace", value)
+        self.components.get_action("lock").action.setChecked(value)
+        icon = material_icon(
+            "lock" if value else "lock_open_right", size=(20, 20), convert_to_pixmap=False
+        )
+        self.components.get_action("lock").action.setIcon(icon)
+
+    @SafeSlot()
+    def _refresh_workspace(self):
+        """
+        Refreshes the current workspace.
+        """
+        combo = self.components.get_action("workspace_combo").widget
+        current_workspace = combo.currentText()
+        self.target_widget.load_profile(current_workspace)

--- a/bec_widgets/widgets/containers/advanced_dock_area/toolbar_components/workspace_actions.py
+++ b/bec_widgets/widgets/containers/advanced_dock_area/toolbar_components/workspace_actions.py
@@ -7,6 +7,11 @@ from qtpy.QtWidgets import QComboBox, QSizePolicy, QWidget
 from bec_widgets import SafeSlot
 from bec_widgets.utils.toolbars.actions import MaterialIconAction, WidgetAction
 from bec_widgets.utils.toolbars.bundles import ToolbarBundle, ToolbarComponents
+from bec_widgets.utils.toolbars.connections import BundleConnection
+from bec_widgets.widgets.containers.advanced_dock_area.profile_utils import (
+    is_profile_readonly,
+    list_profiles,
+)
 
 
 class ProfileComboBox(QComboBox):
@@ -18,7 +23,6 @@ class ProfileComboBox(QComboBox):
 
     def refresh_profiles(self):
         """Refresh the profile list with appropriate icons."""
-        from ..advanced_dock_area import is_profile_readonly, list_profiles
 
         current_text = self.currentText()
         self.blockSignals(True)
@@ -107,18 +111,18 @@ def workspace_bundle(components: ToolbarComponents) -> ToolbarBundle:
     return bundle
 
 
-class WorkspaceConnection:
+class WorkspaceConnection(BundleConnection):
     """
     Connection class for workspace actions in AdvancedDockArea.
     """
 
     def __init__(self, components: ToolbarComponents, target_widget=None):
+        super().__init__(parent=components.toolbar)
         self.bundle_name = "workspace"
         self.components = components
         self.target_widget = target_widget
         if not hasattr(self.target_widget, "lock_workspace"):
             raise AttributeError("Target widget must implement 'lock_workspace'.")
-        super().__init__()
         self._connected = False
 
     def connect(self):
@@ -155,6 +159,7 @@ class WorkspaceConnection:
         self.components.get_action("delete_workspace").action.triggered.disconnect(
             self.target_widget.delete_profile
         )
+        self._connected = False
 
     @SafeSlot(bool)
     def _lock_workspace(self, value: bool):

--- a/bec_widgets/widgets/containers/main_window/main_window.py
+++ b/bec_widgets/widgets/containers/main_window/main_window.py
@@ -357,7 +357,7 @@ class BECMainWindow(BECWidget, QMainWindow):
 
         ########################################
         # Theme menu
-        theme_menu = menu_bar.addMenu("Theme")
+        theme_menu = menu_bar.addMenu("View")
 
         theme_group = QActionGroup(self)
         light_theme_action = QAction("Light Theme", self, checkable=True)

--- a/bec_widgets/widgets/control/device_control/positioner_box/positioner_box/positioner_box.py
+++ b/bec_widgets/widgets/control/device_control/positioner_box/positioner_box/positioner_box.py
@@ -33,7 +33,7 @@ class PositionerBox(PositionerBoxBase):
     PLUGIN = True
     RPC = True
 
-    USER_ACCESS = ["set_positioner", "screenshot"]
+    USER_ACCESS = ["set_positioner", "attach", "detach", "screenshot"]
     device_changed = Signal(str, str)
     # Signal emitted to inform listeners about a position update
     position_update = Signal(float)

--- a/bec_widgets/widgets/control/device_control/positioner_box/positioner_box_2d/positioner_box_2d.py
+++ b/bec_widgets/widgets/control/device_control/positioner_box/positioner_box_2d/positioner_box_2d.py
@@ -34,7 +34,7 @@ class PositionerBox2D(PositionerBoxBase):
 
     PLUGIN = True
     RPC = True
-    USER_ACCESS = ["set_positioner_hor", "set_positioner_ver", "screenshot"]
+    USER_ACCESS = ["set_positioner_hor", "set_positioner_ver", "attach", "detach", "screenshot"]
 
     device_changed_hor = Signal(str, str)
     device_changed_ver = Signal(str, str)

--- a/bec_widgets/widgets/control/device_control/positioner_group/positioner_group.py
+++ b/bec_widgets/widgets/control/device_control/positioner_group/positioner_group.py
@@ -62,7 +62,7 @@ class PositionerGroup(BECWidget, QWidget):
 
     PLUGIN = True
     ICON_NAME = "grid_view"
-    USER_ACCESS = ["set_positioners"]
+    USER_ACCESS = ["set_positioners", "attach", "detach", "screenshot"]
 
     # Signal emitted to inform listeners about a position update of the first positioner
     position_update = Signal(float)

--- a/bec_widgets/widgets/control/scan_control/scan_control.py
+++ b/bec_widgets/widgets/control/scan_control/scan_control.py
@@ -45,7 +45,7 @@ class ScanControl(BECWidget, QWidget):
     Widget to submit new scans to the queue.
     """
 
-    USER_ACCESS = ["remove", "screenshot"]
+    USER_ACCESS = ["attach", "detach", "screenshot"]
     PLUGIN = True
     ICON_NAME = "tune"
     ARG_BOX_POSITION: int = 2

--- a/bec_widgets/widgets/editors/monaco/monaco_widget.py
+++ b/bec_widgets/widgets/editors/monaco/monaco_widget.py
@@ -32,6 +32,9 @@ class MonacoWidget(BECWidget, QWidget):
         "set_vim_mode_enabled",
         "set_lsp_header",
         "get_lsp_header",
+        "attach",
+        "detach",
+        "screenshot",
     ]
 
     def __init__(self, parent=None, config=None, client=None, gui_id=None, **kwargs):

--- a/bec_widgets/widgets/editors/website/website.py
+++ b/bec_widgets/widgets/editors/website/website.py
@@ -21,7 +21,16 @@ class WebsiteWidget(BECWidget, QWidget):
 
     PLUGIN = True
     ICON_NAME = "travel_explore"
-    USER_ACCESS = ["set_url", "get_url", "reload", "back", "forward"]
+    USER_ACCESS = [
+        "set_url",
+        "get_url",
+        "reload",
+        "back",
+        "forward",
+        "attach",
+        "detach",
+        "screenshot",
+    ]
 
     def __init__(
         self, parent=None, url: str = None, config=None, client=None, gui_id=None, **kwargs

--- a/bec_widgets/widgets/plots/heatmap/heatmap.py
+++ b/bec_widgets/widgets/plots/heatmap/heatmap.py
@@ -115,6 +115,8 @@ class Heatmap(ImageBase):
         "auto_range_y.setter",
         "minimal_crosshair_precision",
         "minimal_crosshair_precision.setter",
+        "attach",
+        "detach",
         "screenshot",
         # ImageView Specific Settings
         "color_map",

--- a/bec_widgets/widgets/plots/image/image.py
+++ b/bec_widgets/widgets/plots/image/image.py
@@ -91,6 +91,8 @@ class Image(ImageBase):
         "auto_range_y.setter",
         "minimal_crosshair_precision",
         "minimal_crosshair_precision.setter",
+        "attach",
+        "detach",
         "screenshot",
         # ImageView Specific Settings
         "color_map",

--- a/bec_widgets/widgets/plots/motor_map/motor_map.py
+++ b/bec_widgets/widgets/plots/motor_map/motor_map.py
@@ -128,6 +128,8 @@ class MotorMap(PlotBase):
         "y_log.setter",
         "legend_label_size",
         "legend_label_size.setter",
+        "attach",
+        "detach",
         "screenshot",
         # motor_map specific
         "color",

--- a/bec_widgets/widgets/plots/multi_waveform/multi_waveform.py
+++ b/bec_widgets/widgets/plots/multi_waveform/multi_waveform.py
@@ -96,6 +96,8 @@ class MultiWaveform(PlotBase):
         "legend_label_size.setter",
         "minimal_crosshair_precision",
         "minimal_crosshair_precision.setter",
+        "attach",
+        "detach",
         "screenshot",
         # MultiWaveform Specific RPC Access
         "highlighted_index",

--- a/bec_widgets/widgets/plots/scatter_waveform/scatter_waveform.py
+++ b/bec_widgets/widgets/plots/scatter_waveform/scatter_waveform.py
@@ -84,6 +84,8 @@ class ScatterWaveform(PlotBase):
         "legend_label_size.setter",
         "minimal_crosshair_precision",
         "minimal_crosshair_precision.setter",
+        "attach",
+        "detach",
         "screenshot",
         # Scatter Waveform Specific RPC Access
         "main_curve",

--- a/bec_widgets/widgets/plots/waveform/waveform.py
+++ b/bec_widgets/widgets/plots/waveform/waveform.py
@@ -63,6 +63,10 @@ class Waveform(PlotBase):
     RPC = True
     ICON_NAME = "show_chart"
     USER_ACCESS = [
+        # BECWidget Base Class
+        "attach",
+        "detach",
+        "screenshot",
         # General PlotBase Settings
         "_config_dict",
         "enable_toolbar",
@@ -105,7 +109,6 @@ class Waveform(PlotBase):
         "legend_label_size.setter",
         "minimal_crosshair_precision",
         "minimal_crosshair_precision.setter",
-        "screenshot",
         # Waveform Specific RPC Access
         "curves",
         "x_mode",

--- a/bec_widgets/widgets/progress/ring_progress_bar/ring_progress_bar.py
+++ b/bec_widgets/widgets/progress/ring_progress_bar/ring_progress_bar.py
@@ -96,6 +96,9 @@ class RingProgressBar(BECWidget, QWidget):
         "set_diameter",
         "reset_diameter",
         "enable_auto_updates",
+        "attach",
+        "detach",
+        "screenshot",
     ]
 
     def __init__(

--- a/bec_widgets/widgets/services/bec_status_box/bec_status_box.py
+++ b/bec_widgets/widgets/services/bec_status_box/bec_status_box.py
@@ -76,7 +76,7 @@ class BECStatusBox(BECWidget, CompactPopupWidget):
 
     PLUGIN = True
     CORE_SERVICES = ["DeviceServer", "ScanServer", "SciHub", "ScanBundler", "FileWriterManager"]
-    USER_ACCESS = ["get_server_state", "remove"]
+    USER_ACCESS = ["get_server_state", "remove", "attach", "detach", "screenshot"]
 
     service_update = Signal(BECServiceInfoContainer)
     bec_core_state = Signal(str)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "qtconsole~=5.5, >=5.5.1",  # needed for jupyter console
     "qtpy~=2.4",
     "qtmonaco~=0.5",
+    "PySide6-QtAds==4.4.0",
 ]
 
 

--- a/tests/unit_tests/test_advanced_dock_area.py
+++ b/tests/unit_tests/test_advanced_dock_area.py
@@ -13,11 +13,12 @@ from bec_widgets.widgets.containers.advanced_dock_area.advanced_dock_area import
     AdvancedDockArea,
     DockSettingsDialog,
     SaveProfileDialog,
-    _profile_path,
-    _profiles_dir,
+)
+from bec_widgets.widgets.containers.advanced_dock_area.profile_utils import (
     is_profile_readonly,
     list_profiles,
     open_settings,
+    profile_path,
     read_manifest,
     set_profile_readonly,
     write_manifest,
@@ -457,15 +458,9 @@ class TestSaveProfileDialog:
 class TestProfileManagement:
     """Test profile management functionality."""
 
-    def test_profiles_dir_creation(self, temp_profile_dir):
-        """Test that profiles directory is created."""
-        profiles_dir = _profiles_dir()
-        assert os.path.exists(profiles_dir)
-        assert profiles_dir == temp_profile_dir
-
     def test_profile_path(self, temp_profile_dir):
         """Test profile path generation."""
-        path = _profile_path("test_profile")
+        path = profile_path("test_profile")
         expected = os.path.join(temp_profile_dir, "test_profile.ini")
         assert path == expected
 
@@ -538,21 +533,6 @@ class TestProfileManagement:
 
 class TestWorkspaceProfileOperations:
     """Test workspace profile save/load/delete operations."""
-
-    def test_save_profile_with_name(self, advanced_dock_area, temp_profile_dir, qtbot):
-        """Test saving profile with provided name."""
-        profile_name = "test_save_profile"
-
-        # Create some docks
-        advanced_dock_area.new("DarkModeButton")
-        qtbot.wait(200)
-
-        # Save profile
-        advanced_dock_area.save_profile(profile_name)
-
-        # Check that profile file was created
-        profile_path = _profile_path(profile_name)
-        assert os.path.exists(profile_path)
 
     def test_save_profile_readonly_conflict(self, advanced_dock_area, temp_profile_dir):
         """Test saving profile when read-only profile exists."""
@@ -632,7 +612,7 @@ class TestWorkspaceProfileOperations:
 
                 mock_warning.assert_called_once()
                 # Profile should still exist
-                assert os.path.exists(_profile_path(profile_name))
+                assert os.path.exists(profile_path(profile_name))
 
     def test_delete_profile_success(self, advanced_dock_area, temp_profile_dir):
         """Test successful profile deletion."""
@@ -659,7 +639,7 @@ class TestWorkspaceProfileOperations:
                     mock_question.assert_called_once()
                     mock_refresh.assert_called_once()
                     # Profile should be deleted
-                    assert not os.path.exists(_profile_path(profile_name))
+                    assert not os.path.exists(profile_path(profile_name))
 
     def test_refresh_workspace_list(self, advanced_dock_area, temp_profile_dir):
         """Test refreshing workspace list."""

--- a/tests/unit_tests/test_advanced_dock_area.py
+++ b/tests/unit_tests/test_advanced_dock_area.py
@@ -55,11 +55,6 @@ class TestAdvancedDockAreaInit:
         assert hasattr(advanced_dock_area, "dark_mode_button")
         assert hasattr(advanced_dock_area, "state_manager")
 
-    def test_minimum_size_hint(self, advanced_dock_area):
-        size_hint = advanced_dock_area.minimumSizeHint()
-        assert size_hint.width() == 1200
-        assert size_hint.height() == 800
-
     def test_rpc_and_plugin_flags(self):
         assert AdvancedDockArea.RPC is True
         assert AdvancedDockArea.PLUGIN is False
@@ -97,7 +92,7 @@ class TestDockManagement:
         assert widget is not None
         assert hasattr(widget, "name_established")
 
-    def test_new_widget_instance(self, advanced_dock_area):
+    def test_new_widget_instance(self, advanced_dock_area, qtbot):
         """Test creating dock with existing widget instance."""
         from bec_widgets.widgets.plots.waveform.waveform import Waveform
 
@@ -113,8 +108,9 @@ class TestDockManagement:
         # Should return the same instance
         assert result == widget_instance
 
-        # No new dock created since we passed an instance, not a string
-        assert len(advanced_dock_area.dock_list()) == initial_count
+        qtbot.wait(200)
+
+        assert len(advanced_dock_area.dock_list()) == initial_count + 1
 
     def test_dock_map(self, advanced_dock_area, qtbot):
         """Test dock_map returns correct mapping."""
@@ -783,31 +779,6 @@ class TestModeSwitching:
 
         # Check signal was emitted with correct argument
         assert blocker.args == ["plot"]
-
-    def test_switch_to_plot_mode(self, advanced_dock_area):
-        """Test switch_to_plot_mode method."""
-        advanced_dock_area.switch_to_plot_mode()
-        assert advanced_dock_area.mode == "plot"
-
-    def test_switch_to_device_mode(self, advanced_dock_area):
-        """Test switch_to_device_mode method."""
-        advanced_dock_area.switch_to_device_mode()
-        assert advanced_dock_area.mode == "device"
-
-    def test_switch_to_utils_mode(self, advanced_dock_area):
-        """Test switch_to_utils_mode method."""
-        advanced_dock_area.switch_to_utils_mode()
-        assert advanced_dock_area.mode == "utils"
-
-    def test_switch_to_developer_mode(self, advanced_dock_area):
-        """Test switch_to_developer_mode method."""
-        advanced_dock_area.switch_to_developer_mode()
-        assert advanced_dock_area.mode == "developer"
-
-    def test_switch_to_user_mode(self, advanced_dock_area):
-        """Test switch_to_user_mode method."""
-        advanced_dock_area.switch_to_user_mode()
-        assert advanced_dock_area.mode == "user"
 
 
 class TestToolbarModeBundles:

--- a/tests/unit_tests/test_advanced_dock_area.py
+++ b/tests/unit_tests/test_advanced_dock_area.py
@@ -1,0 +1,806 @@
+# pylint: disable=missing-function-docstring, missing-module-docstring, unused-import
+
+import os
+import tempfile
+from unittest import mock
+from unittest.mock import MagicMock, patch
+
+import pytest
+from qtpy.QtCore import QSettings, Qt
+from qtpy.QtGui import QAction
+from qtpy.QtWidgets import QDialog, QMessageBox
+
+from bec_widgets.widgets.containers.advanced_dock_area.advanced_dock_area import (
+    AdvancedDockArea,
+    DockSettingsDialog,
+    SaveProfileDialog,
+    _profile_path,
+    _profiles_dir,
+    is_profile_readonly,
+    list_profiles,
+    open_settings,
+    read_manifest,
+    set_profile_readonly,
+    write_manifest,
+)
+
+from .client_mocks import mocked_client
+
+
+@pytest.fixture
+def advanced_dock_area(qtbot, mocked_client):
+    """Create an AdvancedDockArea instance for testing."""
+    widget = AdvancedDockArea(client=mocked_client)
+    qtbot.addWidget(widget)
+    qtbot.waitExposed(widget)
+    yield widget
+
+
+@pytest.fixture
+def temp_profile_dir():
+    """Create a temporary directory for profile testing."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        with patch.dict(os.environ, {"BECWIDGETS_PROFILE_DIR": temp_dir}):
+            yield temp_dir
+
+
+class TestAdvancedDockAreaInit:
+    """Test initialization and basic properties."""
+
+    def test_init(self, advanced_dock_area):
+        assert advanced_dock_area is not None
+        assert isinstance(advanced_dock_area, AdvancedDockArea)
+        assert hasattr(advanced_dock_area, "dock_manager")
+        assert hasattr(advanced_dock_area, "toolbar")
+        assert hasattr(advanced_dock_area, "dark_mode_button")
+        assert hasattr(advanced_dock_area, "state_manager")
+
+    def test_minimum_size_hint(self, advanced_dock_area):
+        size_hint = advanced_dock_area.minimumSizeHint()
+        assert size_hint.width() == 1200
+        assert size_hint.height() == 800
+
+    def test_rpc_and_plugin_flags(self):
+        assert AdvancedDockArea.RPC is True
+        assert AdvancedDockArea.PLUGIN is False
+
+    def test_user_access_list(self):
+        expected_methods = [
+            "new",
+            "widget_map",
+            "widget_list",
+            "lock_workspace",
+            "attach_all",
+            "delete_all",
+        ]
+        for method in expected_methods:
+            assert method in AdvancedDockArea.USER_ACCESS
+
+
+class TestDockManagement:
+    """Test dock creation, management, and manipulation."""
+
+    def test_new_widget_string(self, advanced_dock_area, qtbot):
+        """Test creating a new widget from string."""
+        initial_count = len(advanced_dock_area.dock_list())
+
+        # Create a widget by string name
+        widget = advanced_dock_area.new("Waveform")
+
+        # Wait for the dock to be created (since it's async)
+        qtbot.wait(200)
+
+        # Check that dock was actually created
+        assert len(advanced_dock_area.dock_list()) == initial_count + 1
+
+        # Check widget was returned
+        assert widget is not None
+        assert hasattr(widget, "name_established")
+
+    def test_new_widget_instance(self, advanced_dock_area):
+        """Test creating dock with existing widget instance."""
+        from bec_widgets.widgets.plots.waveform.waveform import Waveform
+
+        initial_count = len(advanced_dock_area.dock_list())
+
+        # Create widget instance
+        widget_instance = Waveform(parent=advanced_dock_area, client=advanced_dock_area.client)
+        widget_instance.setObjectName("test_widget")
+
+        # Add it to dock area
+        result = advanced_dock_area.new(widget_instance)
+
+        # Should return the same instance
+        assert result == widget_instance
+
+        # No new dock created since we passed an instance, not a string
+        assert len(advanced_dock_area.dock_list()) == initial_count
+
+    def test_dock_map(self, advanced_dock_area, qtbot):
+        """Test dock_map returns correct mapping."""
+        # Initially empty
+        dock_map = advanced_dock_area.dock_map()
+        assert isinstance(dock_map, dict)
+        initial_count = len(dock_map)
+
+        # Create a widget
+        advanced_dock_area.new("Waveform")
+        qtbot.wait(200)
+
+        # Check dock map updated
+        new_dock_map = advanced_dock_area.dock_map()
+        assert len(new_dock_map) == initial_count + 1
+
+    def test_dock_list(self, advanced_dock_area, qtbot):
+        """Test dock_list returns list of docks."""
+        dock_list = advanced_dock_area.dock_list()
+        assert isinstance(dock_list, list)
+        initial_count = len(dock_list)
+
+        # Create a widget
+        advanced_dock_area.new("Waveform")
+        qtbot.wait(200)
+
+        # Check dock list updated
+        new_dock_list = advanced_dock_area.dock_list()
+        assert len(new_dock_list) == initial_count + 1
+
+    def test_widget_map(self, advanced_dock_area, qtbot):
+        """Test widget_map returns widget mapping."""
+        widget_map = advanced_dock_area.widget_map()
+        assert isinstance(widget_map, dict)
+        initial_count = len(widget_map)
+
+        # Create a widget
+        advanced_dock_area.new("DarkModeButton")
+        qtbot.wait(200)
+
+        # Check widget map updated
+        new_widget_map = advanced_dock_area.widget_map()
+        assert len(new_widget_map) == initial_count + 1
+
+    def test_widget_list(self, advanced_dock_area, qtbot):
+        """Test widget_list returns list of widgets."""
+        widget_list = advanced_dock_area.widget_list()
+        assert isinstance(widget_list, list)
+        initial_count = len(widget_list)
+
+        # Create a widget
+        advanced_dock_area.new("DarkModeButton")
+        qtbot.wait(200)
+
+        # Check widget list updated
+        new_widget_list = advanced_dock_area.widget_list()
+        assert len(new_widget_list) == initial_count + 1
+
+    def test_attach_all(self, advanced_dock_area, qtbot):
+        """Test attach_all functionality."""
+        # Create multiple widgets
+        advanced_dock_area.new("DarkModeButton", start_floating=True)
+        advanced_dock_area.new("DarkModeButton", start_floating=True)
+
+        # Wait for docks to be created
+        qtbot.wait(200)
+
+        # Should have floating widgets
+        initial_floating = len(advanced_dock_area.dock_manager.floatingWidgets())
+
+        # Attach all floating docks
+        advanced_dock_area.attach_all()
+
+        # Wait a bit for the operation to complete
+        qtbot.wait(200)
+
+        # Should have fewer floating widgets (or none if all were attached)
+        final_floating = len(advanced_dock_area.dock_manager.floatingWidgets())
+        assert final_floating <= initial_floating
+
+    def test_delete_all(self, advanced_dock_area, qtbot):
+        """Test delete_all functionality."""
+        # Create multiple widgets
+        advanced_dock_area.new("DarkModeButton")
+        advanced_dock_area.new("DarkModeButton")
+
+        # Wait for docks to be created
+        qtbot.wait(200)
+
+        initial_count = len(advanced_dock_area.dock_list())
+        assert initial_count >= 2
+
+        # Delete all
+        advanced_dock_area.delete_all()
+
+        # Wait for deletion to complete
+        qtbot.wait(200)
+
+        # Should have no docks
+        assert len(advanced_dock_area.dock_list()) == 0
+
+
+class TestWorkspaceLocking:
+    """Test workspace locking functionality."""
+
+    def test_lock_workspace_property_getter(self, advanced_dock_area):
+        """Test lock_workspace property getter."""
+        # Initially unlocked
+        assert advanced_dock_area.lock_workspace is False
+
+        # Set locked state directly
+        advanced_dock_area._locked = True
+        assert advanced_dock_area.lock_workspace is True
+
+    def test_lock_workspace_property_setter(self, advanced_dock_area, qtbot):
+        """Test lock_workspace property setter."""
+        # Create a dock first
+        advanced_dock_area.new("DarkModeButton")
+        qtbot.wait(200)
+
+        # Initially unlocked
+        assert advanced_dock_area.lock_workspace is False
+
+        # Lock workspace
+        advanced_dock_area.lock_workspace = True
+        assert advanced_dock_area._locked is True
+        assert advanced_dock_area.lock_workspace is True
+
+        # Unlock workspace
+        advanced_dock_area.lock_workspace = False
+        assert advanced_dock_area._locked is False
+        assert advanced_dock_area.lock_workspace is False
+
+
+class TestDeveloperMode:
+    """Test developer mode functionality."""
+
+    def test_setup_developer_mode_menu(self, advanced_dock_area):
+        """Test developer mode menu setup."""
+        # The menu should be set up during initialization
+        assert hasattr(advanced_dock_area, "_developer_mode_action")
+        assert isinstance(advanced_dock_area._developer_mode_action, QAction)
+        assert advanced_dock_area._developer_mode_action.isCheckable()
+
+    def test_developer_mode_toggle(self, advanced_dock_area):
+        """Test developer mode toggle functionality."""
+        # Check initial state
+        initial_editable = advanced_dock_area._editable
+
+        # Toggle developer mode
+        advanced_dock_area._on_developer_mode_toggled(True)
+        assert advanced_dock_area._editable is True
+        assert advanced_dock_area.lock_workspace is False
+
+        advanced_dock_area._on_developer_mode_toggled(False)
+        assert advanced_dock_area._editable is False
+        assert advanced_dock_area.lock_workspace is True
+
+    def test_set_editable(self, advanced_dock_area):
+        """Test _set_editable functionality."""
+        # Test setting editable to True
+        advanced_dock_area._set_editable(True)
+        assert advanced_dock_area.lock_workspace is False
+        assert advanced_dock_area._editable is True
+
+        # Test setting editable to False
+        advanced_dock_area._set_editable(False)
+        assert advanced_dock_area.lock_workspace is True
+        assert advanced_dock_area._editable is False
+
+
+class TestToolbarFunctionality:
+    """Test toolbar setup and functionality."""
+
+    def test_toolbar_setup(self, advanced_dock_area):
+        """Test toolbar is properly set up."""
+        assert hasattr(advanced_dock_area, "toolbar")
+        assert hasattr(advanced_dock_area, "_ACTION_MAPPINGS")
+
+        # Check that action mappings are properly set
+        assert "menu_plots" in advanced_dock_area._ACTION_MAPPINGS
+        assert "menu_devices" in advanced_dock_area._ACTION_MAPPINGS
+        assert "menu_utils" in advanced_dock_area._ACTION_MAPPINGS
+
+    def test_toolbar_plot_actions(self, advanced_dock_area):
+        """Test plot toolbar actions trigger widget creation."""
+        plot_actions = [
+            "waveform",
+            "scatter_waveform",
+            "multi_waveform",
+            "image",
+            "motor_map",
+            "heatmap",
+        ]
+
+        for action_name in plot_actions:
+            with patch.object(advanced_dock_area, "new") as mock_new:
+                menu_plots = advanced_dock_area.toolbar.components.get_action("menu_plots")
+                action = menu_plots.actions[action_name].action
+
+                # Get the expected widget type from the action mappings
+                widget_type = advanced_dock_area._ACTION_MAPPINGS["menu_plots"][action_name][2]
+
+                action.trigger()
+                mock_new.assert_called_once_with(widget=widget_type)
+
+    def test_toolbar_device_actions(self, advanced_dock_area):
+        """Test device toolbar actions trigger widget creation."""
+        device_actions = ["scan_control", "positioner_box"]
+
+        for action_name in device_actions:
+            with patch.object(advanced_dock_area, "new") as mock_new:
+                menu_devices = advanced_dock_area.toolbar.components.get_action("menu_devices")
+                action = menu_devices.actions[action_name].action
+
+                # Get the expected widget type from the action mappings
+                widget_type = advanced_dock_area._ACTION_MAPPINGS["menu_devices"][action_name][2]
+
+                action.trigger()
+                mock_new.assert_called_once_with(widget=widget_type)
+
+    def test_toolbar_utils_actions(self, advanced_dock_area):
+        """Test utils toolbar actions trigger widget creation."""
+        utils_actions = ["queue", "vs_code", "status", "progress_bar", "sbb_monitor"]
+
+        for action_name in utils_actions:
+            with patch.object(advanced_dock_area, "new") as mock_new:
+                menu_utils = advanced_dock_area.toolbar.components.get_action("menu_utils")
+                action = menu_utils.actions[action_name].action
+
+                # Skip log_panel as it's disabled
+                if action_name == "log_panel":
+                    assert not action.isEnabled()
+                    continue
+
+                # Get the expected widget type from the action mappings
+                widget_type = advanced_dock_area._ACTION_MAPPINGS["menu_utils"][action_name][2]
+
+                action.trigger()
+                mock_new.assert_called_once_with(widget=widget_type)
+
+    def test_attach_all_action(self, advanced_dock_area, qtbot):
+        """Test attach_all toolbar action."""
+        # Create floating docks
+        advanced_dock_area.new("DarkModeButton", start_floating=True)
+        advanced_dock_area.new("DarkModeButton", start_floating=True)
+
+        qtbot.wait(200)
+
+        initial_floating = len(advanced_dock_area.dock_manager.floatingWidgets())
+
+        # Trigger attach all action
+        action = advanced_dock_area.toolbar.components.get_action("attach_all").action
+        action.trigger()
+
+        # Wait a bit for the operation
+        qtbot.wait(200)
+
+        # Should have fewer or same floating widgets
+        final_floating = len(advanced_dock_area.dock_manager.floatingWidgets())
+        assert final_floating <= initial_floating
+
+    def test_screenshot_action(self, advanced_dock_area, tmpdir):
+        """Test screenshot toolbar action."""
+        # Create a test screenshot file path in tmpdir
+        screenshot_path = tmpdir.join("test_screenshot.png")
+
+        # Mock the QFileDialog.getSaveFileName to return a test filename
+        with mock.patch("bec_widgets.utils.bec_widget.QFileDialog.getSaveFileName") as mock_dialog:
+            mock_dialog.return_value = (str(screenshot_path), "PNG Files (*.png)")
+
+            # Mock the screenshot.save method
+            with mock.patch.object(advanced_dock_area, "grab") as mock_grab:
+                mock_screenshot = mock.MagicMock()
+                mock_grab.return_value = mock_screenshot
+
+                # Trigger the screenshot action
+                action = advanced_dock_area.toolbar.components.get_action("screenshot").action
+                action.trigger()
+
+                # Verify the dialog was called
+                mock_dialog.assert_called_once()
+
+                # Verify grab was called
+                mock_grab.assert_called_once()
+
+                # Verify save was called with the filename
+                mock_screenshot.save.assert_called_once_with(str(screenshot_path))
+
+
+class TestDockSettingsDialog:
+    """Test dock settings dialog functionality."""
+
+    def test_dock_settings_dialog_init(self, advanced_dock_area):
+        """Test DockSettingsDialog initialization."""
+        from bec_widgets.widgets.utility.visual.dark_mode_button.dark_mode_button import (
+            DarkModeButton,
+        )
+
+        # Create a real widget
+        mock_widget = DarkModeButton(parent=advanced_dock_area)
+        dialog = DockSettingsDialog(advanced_dock_area, mock_widget)
+
+        assert dialog.windowTitle() == "Dock Settings"
+        assert dialog.isModal()
+        assert hasattr(dialog, "prop_editor")
+
+    def test_open_dock_settings_dialog(self, advanced_dock_area, qtbot):
+        """Test opening dock settings dialog."""
+        from bec_widgets.widgets.utility.visual.dark_mode_button.dark_mode_button import (
+            DarkModeButton,
+        )
+
+        # Create real widget and dock
+        widget = DarkModeButton(parent=advanced_dock_area)
+        widget.setObjectName("test_widget")
+
+        # Create a real dock
+        dock = advanced_dock_area._make_dock(widget, closable=True, floatable=True, movable=True)
+
+        # Mock dialog exec to avoid blocking
+        with patch.object(DockSettingsDialog, "exec") as mock_exec:
+            mock_exec.return_value = QDialog.Accepted
+
+            # Call the method
+            advanced_dock_area._open_dock_settings_dialog(dock, widget)
+
+            # Verify dialog was created and exec called
+            mock_exec.assert_called_once()
+
+
+class TestSaveProfileDialog:
+    """Test save profile dialog functionality."""
+
+    def test_save_profile_dialog_init(self, qtbot):
+        """Test SaveProfileDialog initialization."""
+        dialog = SaveProfileDialog(None, "test_profile")
+        qtbot.addWidget(dialog)
+
+        assert dialog.windowTitle() == "Save Workspace Profile"
+        assert dialog.isModal()
+        assert dialog.name_edit.text() == "test_profile"
+        assert hasattr(dialog, "readonly_checkbox")
+
+    def test_save_profile_dialog_get_values(self, qtbot):
+        """Test getting values from SaveProfileDialog."""
+        dialog = SaveProfileDialog(None)
+        qtbot.addWidget(dialog)
+
+        dialog.name_edit.setText("my_profile")
+        dialog.readonly_checkbox.setChecked(True)
+
+        assert dialog.get_profile_name() == "my_profile"
+        assert dialog.is_readonly() is True
+
+    def test_save_button_enabled_state(self, qtbot):
+        """Test save button is enabled/disabled based on name input."""
+        dialog = SaveProfileDialog(None)
+        qtbot.addWidget(dialog)
+
+        # Initially should be disabled (empty name)
+        assert not dialog.save_btn.isEnabled()
+
+        # Should be enabled when name is entered
+        dialog.name_edit.setText("test")
+        assert dialog.save_btn.isEnabled()
+
+        # Should be disabled when name is cleared
+        dialog.name_edit.setText("")
+        assert not dialog.save_btn.isEnabled()
+
+
+class TestProfileManagement:
+    """Test profile management functionality."""
+
+    def test_profiles_dir_creation(self, temp_profile_dir):
+        """Test that profiles directory is created."""
+        profiles_dir = _profiles_dir()
+        assert os.path.exists(profiles_dir)
+        assert profiles_dir == temp_profile_dir
+
+    def test_profile_path(self, temp_profile_dir):
+        """Test profile path generation."""
+        path = _profile_path("test_profile")
+        expected = os.path.join(temp_profile_dir, "test_profile.ini")
+        assert path == expected
+
+    def test_open_settings(self, temp_profile_dir):
+        """Test opening settings for a profile."""
+        settings = open_settings("test_profile")
+        assert isinstance(settings, QSettings)
+
+    def test_list_profiles_empty(self, temp_profile_dir):
+        """Test listing profiles when directory is empty."""
+        profiles = list_profiles()
+        assert profiles == []
+
+    def test_list_profiles_with_files(self, temp_profile_dir):
+        """Test listing profiles with existing files."""
+        # Create some test profile files
+        profile_names = ["profile1", "profile2", "profile3"]
+        for name in profile_names:
+            settings = open_settings(name)
+            settings.setValue("test", "value")
+            settings.sync()
+
+        profiles = list_profiles()
+        assert sorted(profiles) == sorted(profile_names)
+
+    def test_readonly_profile_operations(self, temp_profile_dir):
+        """Test read-only profile functionality."""
+        profile_name = "readonly_profile"
+
+        # Initially should not be read-only
+        assert not is_profile_readonly(profile_name)
+
+        # Set as read-only
+        set_profile_readonly(profile_name, True)
+        assert is_profile_readonly(profile_name)
+
+        # Unset read-only
+        set_profile_readonly(profile_name, False)
+        assert not is_profile_readonly(profile_name)
+
+    def test_write_and_read_manifest(self, temp_profile_dir, advanced_dock_area, qtbot):
+        """Test writing and reading dock manifest."""
+        settings = open_settings("test_manifest")
+
+        # Create real docks
+        advanced_dock_area.new("DarkModeButton")
+        advanced_dock_area.new("DarkModeButton")
+        advanced_dock_area.new("DarkModeButton")
+
+        # Wait for docks to be created
+        qtbot.wait(1000)
+
+        docks = advanced_dock_area.dock_list()
+
+        # Write manifest
+        write_manifest(settings, docks)
+        settings.sync()
+
+        # Read manifest
+        items = read_manifest(settings)
+
+        assert len(items) >= 3
+        for item in items:
+            assert "object_name" in item
+            assert "widget_class" in item
+            assert "closable" in item
+            assert "floatable" in item
+            assert "movable" in item
+
+
+class TestWorkspaceProfileOperations:
+    """Test workspace profile save/load/delete operations."""
+
+    def test_save_profile_with_name(self, advanced_dock_area, temp_profile_dir, qtbot):
+        """Test saving profile with provided name."""
+        profile_name = "test_save_profile"
+
+        # Create some docks
+        advanced_dock_area.new("DarkModeButton")
+        qtbot.wait(200)
+
+        # Save profile
+        advanced_dock_area.save_profile(profile_name)
+
+        # Check that profile file was created
+        profile_path = _profile_path(profile_name)
+        assert os.path.exists(profile_path)
+
+    def test_save_profile_readonly_conflict(self, advanced_dock_area, temp_profile_dir):
+        """Test saving profile when read-only profile exists."""
+        profile_name = "readonly_profile"
+
+        # Create a read-only profile
+        set_profile_readonly(profile_name, True)
+        settings = open_settings(profile_name)
+        settings.setValue("test", "value")
+        settings.sync()
+
+        with patch(
+            "bec_widgets.widgets.containers.advanced_dock_area.advanced_dock_area.SaveProfileDialog"
+        ) as mock_dialog_class:
+            mock_dialog = MagicMock()
+            mock_dialog.exec.return_value = QDialog.Accepted
+            mock_dialog.get_profile_name.return_value = profile_name
+            mock_dialog.is_readonly.return_value = False
+            mock_dialog_class.return_value = mock_dialog
+
+            with patch(
+                "bec_widgets.widgets.containers.advanced_dock_area.advanced_dock_area.QMessageBox.warning"
+            ) as mock_warning:
+                mock_warning.return_value = QMessageBox.No
+
+                advanced_dock_area.save_profile()
+
+                mock_warning.assert_called_once()
+
+    def test_load_profile_with_manifest(self, advanced_dock_area, temp_profile_dir, qtbot):
+        """Test loading profile with widget manifest."""
+        profile_name = "test_load_profile"
+
+        # Create a profile with manifest
+        settings = open_settings(profile_name)
+        settings.beginWriteArray("manifest/widgets", 1)
+        settings.setArrayIndex(0)
+        settings.setValue("object_name", "test_widget")
+        settings.setValue("widget_class", "DarkModeButton")
+        settings.setValue("closable", True)
+        settings.setValue("floatable", True)
+        settings.setValue("movable", True)
+        settings.endArray()
+        settings.sync()
+
+        initial_count = len(advanced_dock_area.widget_map())
+
+        # Load profile
+        advanced_dock_area.load_profile(profile_name)
+
+        # Wait for widget to be created
+        qtbot.wait(1000)
+
+        # Check widget was created
+        widget_map = advanced_dock_area.widget_map()
+        assert "test_widget" in widget_map
+
+    def test_delete_profile_readonly(self, advanced_dock_area, temp_profile_dir):
+        """Test deleting read-only profile shows warning."""
+        profile_name = "readonly_profile"
+
+        # Create read-only profile
+        set_profile_readonly(profile_name, True)
+        settings = open_settings(profile_name)
+        settings.setValue("test", "value")
+        settings.sync()
+
+        with patch.object(advanced_dock_area.toolbar.components, "get_action") as mock_get_action:
+            mock_combo = MagicMock()
+            mock_combo.currentText.return_value = profile_name
+            mock_get_action.return_value.widget = mock_combo
+
+            with patch(
+                "bec_widgets.widgets.containers.advanced_dock_area.advanced_dock_area.QMessageBox.warning"
+            ) as mock_warning:
+                advanced_dock_area.delete_profile()
+
+                mock_warning.assert_called_once()
+                # Profile should still exist
+                assert os.path.exists(_profile_path(profile_name))
+
+    def test_delete_profile_success(self, advanced_dock_area, temp_profile_dir):
+        """Test successful profile deletion."""
+        profile_name = "deletable_profile"
+
+        # Create regular profile
+        settings = open_settings(profile_name)
+        settings.setValue("test", "value")
+        settings.sync()
+
+        with patch.object(advanced_dock_area.toolbar.components, "get_action") as mock_get_action:
+            mock_combo = MagicMock()
+            mock_combo.currentText.return_value = profile_name
+            mock_get_action.return_value.widget = mock_combo
+
+            with patch(
+                "bec_widgets.widgets.containers.advanced_dock_area.advanced_dock_area.QMessageBox.question"
+            ) as mock_question:
+                mock_question.return_value = QMessageBox.Yes
+
+                with patch.object(advanced_dock_area, "_refresh_workspace_list") as mock_refresh:
+                    advanced_dock_area.delete_profile()
+
+                    mock_question.assert_called_once()
+                    mock_refresh.assert_called_once()
+                    # Profile should be deleted
+                    assert not os.path.exists(_profile_path(profile_name))
+
+    def test_refresh_workspace_list(self, advanced_dock_area, temp_profile_dir):
+        """Test refreshing workspace list."""
+        # Create some profiles
+        for name in ["profile1", "profile2"]:
+            settings = open_settings(name)
+            settings.setValue("test", "value")
+            settings.sync()
+
+        with patch.object(advanced_dock_area.toolbar.components, "get_action") as mock_get_action:
+            mock_combo = MagicMock()
+            mock_combo.refresh_profiles = MagicMock()
+            mock_get_action.return_value.widget = mock_combo
+
+            advanced_dock_area._refresh_workspace_list()
+
+            mock_combo.refresh_profiles.assert_called_once()
+
+
+class TestCleanupAndMisc:
+    """Test cleanup and miscellaneous functionality."""
+
+    def test_cleanup(self, advanced_dock_area):
+        """Test cleanup functionality."""
+        with patch.object(advanced_dock_area.dark_mode_button, "close") as mock_close:
+            with patch.object(advanced_dock_area.dark_mode_button, "deleteLater") as mock_delete:
+                with patch(
+                    "bec_widgets.widgets.containers.main_window.main_window.BECMainWindow.cleanup"
+                ) as mock_super_cleanup:
+                    advanced_dock_area.cleanup()
+
+                    mock_close.assert_called_once()
+                    mock_delete.assert_called_once()
+                    mock_super_cleanup.assert_called_once()
+
+    def test_delete_dock(self, advanced_dock_area, qtbot):
+        """Test _delete_dock functionality."""
+        from bec_widgets.widgets.utility.visual.dark_mode_button.dark_mode_button import (
+            DarkModeButton,
+        )
+
+        # Create a real widget and dock
+        widget = DarkModeButton(parent=advanced_dock_area)
+        widget.setObjectName("test_widget")
+
+        dock = advanced_dock_area._make_dock(widget, closable=True, floatable=True, movable=True)
+
+        initial_count = len(advanced_dock_area.dock_list())
+
+        # Delete the dock
+        advanced_dock_area._delete_dock(dock)
+
+        # Wait for deletion to complete
+        qtbot.wait(200)
+
+        # Verify dock was removed
+        assert len(advanced_dock_area.dock_list()) == initial_count - 1
+
+    def test_apply_dock_lock(self, advanced_dock_area, qtbot):
+        """Test _apply_dock_lock functionality."""
+        # Create a dock first
+        advanced_dock_area.new("DarkModeButton")
+        qtbot.wait(200)
+
+        # Test locking
+        advanced_dock_area._apply_dock_lock(True)
+        # No assertion needed - just verify it doesn't crash
+
+        # Test unlocking
+        advanced_dock_area._apply_dock_lock(False)
+        # No assertion needed - just verify it doesn't crash
+
+    def test_make_dock(self, advanced_dock_area):
+        """Test _make_dock functionality."""
+        from bec_widgets.widgets.utility.visual.dark_mode_button.dark_mode_button import (
+            DarkModeButton,
+        )
+
+        # Create a real widget
+        widget = DarkModeButton(parent=advanced_dock_area)
+        widget.setObjectName("test_widget")
+
+        initial_count = len(advanced_dock_area.dock_list())
+
+        # Create dock
+        dock = advanced_dock_area._make_dock(widget, closable=True, floatable=True, movable=True)
+
+        # Verify dock was created
+        assert dock is not None
+        assert len(advanced_dock_area.dock_list()) == initial_count + 1
+        assert dock.widget() == widget
+
+    def test_install_dock_settings_action(self, advanced_dock_area):
+        """Test _install_dock_settings_action functionality."""
+        from bec_widgets.widgets.utility.visual.dark_mode_button.dark_mode_button import (
+            DarkModeButton,
+        )
+
+        # Create real widget and dock
+        widget = DarkModeButton(parent=advanced_dock_area)
+        widget.setObjectName("test_widget")
+
+        dock = advanced_dock_area._make_dock(widget, closable=True, floatable=True, movable=True)
+
+        # Verify dock has settings action
+        assert hasattr(dock, "setting_action")
+        assert dock.setting_action is not None
+
+        # Verify title bar actions were set
+        title_bar_actions = dock.titleBarActions()
+        assert len(title_bar_actions) >= 1

--- a/tests/unit_tests/test_advanced_dock_area.py
+++ b/tests/unit_tests/test_advanced_dock_area.py
@@ -6,8 +6,7 @@ from unittest import mock
 from unittest.mock import MagicMock, patch
 
 import pytest
-from qtpy.QtCore import QSettings, Qt
-from qtpy.QtGui import QAction
+from qtpy.QtCore import QSettings
 from qtpy.QtWidgets import QDialog, QMessageBox
 
 from bec_widgets.widgets.containers.advanced_dock_area.advanced_dock_area import (
@@ -50,6 +49,7 @@ class TestAdvancedDockAreaInit:
     def test_init(self, advanced_dock_area):
         assert advanced_dock_area is not None
         assert isinstance(advanced_dock_area, AdvancedDockArea)
+        assert advanced_dock_area.mode == "developer"
         assert hasattr(advanced_dock_area, "dock_manager")
         assert hasattr(advanced_dock_area, "toolbar")
         assert hasattr(advanced_dock_area, "dark_mode_button")
@@ -173,28 +173,6 @@ class TestDockManagement:
         new_widget_list = advanced_dock_area.widget_list()
         assert len(new_widget_list) == initial_count + 1
 
-    def test_attach_all(self, advanced_dock_area, qtbot):
-        """Test attach_all functionality."""
-        # Create multiple widgets
-        advanced_dock_area.new("DarkModeButton", start_floating=True)
-        advanced_dock_area.new("DarkModeButton", start_floating=True)
-
-        # Wait for docks to be created
-        qtbot.wait(200)
-
-        # Should have floating widgets
-        initial_floating = len(advanced_dock_area.dock_manager.floatingWidgets())
-
-        # Attach all floating docks
-        advanced_dock_area.attach_all()
-
-        # Wait a bit for the operation to complete
-        qtbot.wait(200)
-
-        # Should have fewer floating widgets (or none if all were attached)
-        final_floating = len(advanced_dock_area.dock_manager.floatingWidgets())
-        assert final_floating <= initial_floating
-
     def test_delete_all(self, advanced_dock_area, qtbot):
         """Test delete_all functionality."""
         # Create multiple widgets
@@ -251,13 +229,6 @@ class TestWorkspaceLocking:
 
 class TestDeveloperMode:
     """Test developer mode functionality."""
-
-    def test_setup_developer_mode_menu(self, advanced_dock_area):
-        """Test developer mode menu setup."""
-        # The menu should be set up during initialization
-        assert hasattr(advanced_dock_area, "_developer_mode_action")
-        assert isinstance(advanced_dock_area._developer_mode_action, QAction)
-        assert advanced_dock_area._developer_mode_action.isCheckable()
 
     def test_developer_mode_toggle(self, advanced_dock_area):
         """Test developer mode toggle functionality."""
@@ -715,19 +686,6 @@ class TestWorkspaceProfileOperations:
 class TestCleanupAndMisc:
     """Test cleanup and miscellaneous functionality."""
 
-    def test_cleanup(self, advanced_dock_area):
-        """Test cleanup functionality."""
-        with patch.object(advanced_dock_area.dark_mode_button, "close") as mock_close:
-            with patch.object(advanced_dock_area.dark_mode_button, "deleteLater") as mock_delete:
-                with patch(
-                    "bec_widgets.widgets.containers.main_window.main_window.BECMainWindow.cleanup"
-                ) as mock_super_cleanup:
-                    advanced_dock_area.cleanup()
-
-                    mock_close.assert_called_once()
-                    mock_delete.assert_called_once()
-                    mock_super_cleanup.assert_called_once()
-
     def test_delete_dock(self, advanced_dock_area, qtbot):
         """Test _delete_dock functionality."""
         from bec_widgets.widgets.utility.visual.dark_mode_button.dark_mode_button import (
@@ -804,3 +762,332 @@ class TestCleanupAndMisc:
         # Verify title bar actions were set
         title_bar_actions = dock.titleBarActions()
         assert len(title_bar_actions) >= 1
+
+
+class TestModeSwitching:
+    """Test mode switching functionality."""
+
+    def test_mode_property_setter_valid_modes(self, advanced_dock_area):
+        """Test setting valid modes."""
+        valid_modes = ["plot", "device", "utils", "developer", "user"]
+
+        for mode in valid_modes:
+            advanced_dock_area.mode = mode
+            assert advanced_dock_area.mode == mode
+
+    def test_mode_changed_signal_emission(self, advanced_dock_area, qtbot):
+        """Test that mode_changed signal is emitted when mode changes."""
+        # Set up signal spy
+        with qtbot.waitSignal(advanced_dock_area.mode_changed, timeout=1000) as blocker:
+            advanced_dock_area.mode = "plot"
+
+        # Check signal was emitted with correct argument
+        assert blocker.args == ["plot"]
+
+    def test_switch_to_plot_mode(self, advanced_dock_area):
+        """Test switch_to_plot_mode method."""
+        advanced_dock_area.switch_to_plot_mode()
+        assert advanced_dock_area.mode == "plot"
+
+    def test_switch_to_device_mode(self, advanced_dock_area):
+        """Test switch_to_device_mode method."""
+        advanced_dock_area.switch_to_device_mode()
+        assert advanced_dock_area.mode == "device"
+
+    def test_switch_to_utils_mode(self, advanced_dock_area):
+        """Test switch_to_utils_mode method."""
+        advanced_dock_area.switch_to_utils_mode()
+        assert advanced_dock_area.mode == "utils"
+
+    def test_switch_to_developer_mode(self, advanced_dock_area):
+        """Test switch_to_developer_mode method."""
+        advanced_dock_area.switch_to_developer_mode()
+        assert advanced_dock_area.mode == "developer"
+
+    def test_switch_to_user_mode(self, advanced_dock_area):
+        """Test switch_to_user_mode method."""
+        advanced_dock_area.switch_to_user_mode()
+        assert advanced_dock_area.mode == "user"
+
+
+class TestToolbarModeBundles:
+    """Test toolbar bundle creation and visibility for different modes."""
+
+    def test_flat_bundles_created(self, advanced_dock_area):
+        """Test that flat bundles are created during toolbar setup."""
+        # Check that flat bundles exist
+        assert "flat_plots" in advanced_dock_area.toolbar.bundles
+        assert "flat_devices" in advanced_dock_area.toolbar.bundles
+        assert "flat_utils" in advanced_dock_area.toolbar.bundles
+
+    def test_plot_mode_toolbar_visibility(self, advanced_dock_area):
+        """Test toolbar bundle visibility in plot mode."""
+        advanced_dock_area.mode = "plot"
+
+        # Should show only flat_plots bundle (and essential bundles in real implementation)
+        shown_bundles = advanced_dock_area.toolbar.shown_bundles
+        assert "flat_plots" in shown_bundles
+
+        # Should not show other flat bundles
+        assert "flat_devices" not in shown_bundles
+        assert "flat_utils" not in shown_bundles
+
+        # Should not show menu bundles
+        assert "menu_plots" not in shown_bundles
+        assert "menu_devices" not in shown_bundles
+        assert "menu_utils" not in shown_bundles
+
+    def test_device_mode_toolbar_visibility(self, advanced_dock_area):
+        """Test toolbar bundle visibility in device mode."""
+        advanced_dock_area.mode = "device"
+
+        shown_bundles = advanced_dock_area.toolbar.shown_bundles
+        assert "flat_devices" in shown_bundles
+
+        # Should not show other flat bundles
+        assert "flat_plots" not in shown_bundles
+        assert "flat_utils" not in shown_bundles
+
+    def test_utils_mode_toolbar_visibility(self, advanced_dock_area):
+        """Test toolbar bundle visibility in utils mode."""
+        advanced_dock_area.mode = "utils"
+
+        shown_bundles = advanced_dock_area.toolbar.shown_bundles
+        assert "flat_utils" in shown_bundles
+
+        # Should not show other flat bundles
+        assert "flat_plots" not in shown_bundles
+        assert "flat_devices" not in shown_bundles
+
+    def test_developer_mode_toolbar_visibility(self, advanced_dock_area):
+        """Test toolbar bundle visibility in developer mode."""
+        advanced_dock_area.mode = "developer"
+
+        shown_bundles = advanced_dock_area.toolbar.shown_bundles
+
+        # Should show menu bundles
+        assert "menu_plots" in shown_bundles
+        assert "menu_devices" in shown_bundles
+        assert "menu_utils" in shown_bundles
+
+        # Should show essential bundles
+        assert "spacer_bundle" in shown_bundles
+        assert "workspace" in shown_bundles
+        assert "dock_actions" in shown_bundles
+
+    def test_user_mode_toolbar_visibility(self, advanced_dock_area):
+        """Test toolbar bundle visibility in user mode."""
+        advanced_dock_area.mode = "user"
+
+        shown_bundles = advanced_dock_area.toolbar.shown_bundles
+
+        # Should show only essential bundles
+        assert "spacer_bundle" in shown_bundles
+        assert "workspace" in shown_bundles
+        assert "dock_actions" in shown_bundles
+
+        # Should not show any widget creation bundles
+        assert "menu_plots" not in shown_bundles
+        assert "menu_devices" not in shown_bundles
+        assert "menu_utils" not in shown_bundles
+        assert "flat_plots" not in shown_bundles
+        assert "flat_devices" not in shown_bundles
+        assert "flat_utils" not in shown_bundles
+
+
+class TestFlatToolbarActions:
+    """Test flat toolbar actions functionality."""
+
+    def test_flat_plot_actions_created(self, advanced_dock_area):
+        """Test that flat plot actions are created."""
+        plot_actions = [
+            "flat_waveform",
+            "flat_scatter_waveform",
+            "flat_multi_waveform",
+            "flat_image",
+            "flat_motor_map",
+            "flat_heatmap",
+        ]
+
+        for action_name in plot_actions:
+            assert advanced_dock_area.toolbar.components.exists(action_name)
+
+    def test_flat_device_actions_created(self, advanced_dock_area):
+        """Test that flat device actions are created."""
+        device_actions = ["flat_scan_control", "flat_positioner_box"]
+
+        for action_name in device_actions:
+            assert advanced_dock_area.toolbar.components.exists(action_name)
+
+    def test_flat_utils_actions_created(self, advanced_dock_area):
+        """Test that flat utils actions are created."""
+        utils_actions = [
+            "flat_queue",
+            "flat_vs_code",
+            "flat_status",
+            "flat_progress_bar",
+            "flat_log_panel",
+            "flat_sbb_monitor",
+        ]
+
+        for action_name in utils_actions:
+            assert advanced_dock_area.toolbar.components.exists(action_name)
+
+    def test_flat_plot_actions_trigger_widget_creation(self, advanced_dock_area):
+        """Test flat plot actions trigger widget creation."""
+        plot_action_mapping = {
+            "flat_waveform": "Waveform",
+            "flat_scatter_waveform": "ScatterWaveform",
+            "flat_multi_waveform": "MultiWaveform",
+            "flat_image": "Image",
+            "flat_motor_map": "MotorMap",
+            "flat_heatmap": "Heatmap",
+        }
+
+        for action_name, widget_type in plot_action_mapping.items():
+            with patch.object(advanced_dock_area, "new") as mock_new:
+                action = advanced_dock_area.toolbar.components.get_action(action_name).action
+                action.trigger()
+                mock_new.assert_called_once_with(widget=widget_type)
+
+    def test_flat_device_actions_trigger_widget_creation(self, advanced_dock_area):
+        """Test flat device actions trigger widget creation."""
+        device_action_mapping = {
+            "flat_scan_control": "ScanControl",
+            "flat_positioner_box": "PositionerBox",
+        }
+
+        for action_name, widget_type in device_action_mapping.items():
+            with patch.object(advanced_dock_area, "new") as mock_new:
+                action = advanced_dock_area.toolbar.components.get_action(action_name).action
+                action.trigger()
+                mock_new.assert_called_once_with(widget=widget_type)
+
+    def test_flat_utils_actions_trigger_widget_creation(self, advanced_dock_area):
+        """Test flat utils actions trigger widget creation."""
+        utils_action_mapping = {
+            "flat_queue": "BECQueue",
+            "flat_vs_code": "VSCodeEditor",
+            "flat_status": "BECStatusBox",
+            "flat_progress_bar": "RingProgressBar",
+            "flat_sbb_monitor": "SBBMonitor",
+        }
+
+        for action_name, widget_type in utils_action_mapping.items():
+            with patch.object(advanced_dock_area, "new") as mock_new:
+                action = advanced_dock_area.toolbar.components.get_action(action_name).action
+
+                # Skip log_panel as it's disabled
+                if action_name == "flat_log_panel":
+                    assert not action.isEnabled()
+                    continue
+
+                action.trigger()
+                mock_new.assert_called_once_with(widget=widget_type)
+
+    def test_flat_log_panel_action_disabled(self, advanced_dock_area):
+        """Test that flat log panel action is disabled."""
+        action = advanced_dock_area.toolbar.components.get_action("flat_log_panel").action
+        assert not action.isEnabled()
+
+
+class TestModeTransitions:
+    """Test mode transitions and state consistency."""
+
+    def test_mode_transition_sequence(self, advanced_dock_area, qtbot):
+        """Test sequence of mode transitions."""
+        modes = ["plot", "device", "utils", "developer", "user"]
+
+        for mode in modes:
+            with qtbot.waitSignal(advanced_dock_area.mode_changed, timeout=1000) as blocker:
+                advanced_dock_area.mode = mode
+
+            assert advanced_dock_area.mode == mode
+            assert blocker.args == [mode]
+
+    def test_mode_consistency_after_multiple_changes(self, advanced_dock_area):
+        """Test mode consistency after multiple rapid changes."""
+        # Rapidly change modes
+        advanced_dock_area.mode = "plot"
+        advanced_dock_area.mode = "device"
+        advanced_dock_area.mode = "utils"
+        advanced_dock_area.mode = "developer"
+        advanced_dock_area.mode = "user"
+
+        # Final state should be consistent
+        assert advanced_dock_area.mode == "user"
+
+        # Toolbar should show correct bundles for user mode
+        shown_bundles = advanced_dock_area.toolbar.shown_bundles
+        assert "spacer_bundle" in shown_bundles
+        assert "workspace" in shown_bundles
+        assert "dock_actions" in shown_bundles
+
+    def test_toolbar_refresh_on_mode_change(self, advanced_dock_area):
+        """Test that toolbar is properly refreshed when mode changes."""
+        initial_bundles = set(advanced_dock_area.toolbar.shown_bundles)
+
+        # Change to a different mode
+        advanced_dock_area.mode = "plot"
+        plot_bundles = set(advanced_dock_area.toolbar.shown_bundles)
+
+        # Bundles should be different
+        assert initial_bundles != plot_bundles
+        assert "flat_plots" in plot_bundles
+
+    def test_mode_switching_preserves_existing_docks(self, advanced_dock_area, qtbot):
+        """Test that mode switching doesn't affect existing docked widgets."""
+        # Create some widgets
+        advanced_dock_area.new("DarkModeButton")
+        advanced_dock_area.new("DarkModeButton")
+        qtbot.wait(200)
+
+        initial_dock_count = len(advanced_dock_area.dock_list())
+        initial_widget_count = len(advanced_dock_area.widget_list())
+
+        # Switch modes
+        advanced_dock_area.mode = "plot"
+        advanced_dock_area.mode = "device"
+        advanced_dock_area.mode = "user"
+
+        # Dock and widget counts should remain the same
+        assert len(advanced_dock_area.dock_list()) == initial_dock_count
+        assert len(advanced_dock_area.widget_list()) == initial_widget_count
+
+
+class TestModeProperty:
+    """Test mode property getter and setter behavior."""
+
+    def test_mode_property_getter(self, advanced_dock_area):
+        """Test mode property getter returns correct value."""
+        # Set internal mode directly and test getter
+        advanced_dock_area._mode = "plot"
+        assert advanced_dock_area.mode == "plot"
+
+        advanced_dock_area._mode = "device"
+        assert advanced_dock_area.mode == "device"
+
+    def test_mode_property_setter_updates_internal_state(self, advanced_dock_area):
+        """Test mode property setter updates internal state."""
+        advanced_dock_area.mode = "plot"
+        assert advanced_dock_area._mode == "plot"
+
+        advanced_dock_area.mode = "utils"
+        assert advanced_dock_area._mode == "utils"
+
+    def test_mode_property_setter_triggers_toolbar_update(self, advanced_dock_area):
+        """Test mode property setter triggers toolbar update."""
+        with patch.object(advanced_dock_area.toolbar, "show_bundles") as mock_show_bundles:
+            advanced_dock_area.mode = "plot"
+            mock_show_bundles.assert_called_once()
+
+    def test_multiple_mode_changes(self, advanced_dock_area, qtbot):
+        """Test multiple rapid mode changes."""
+        modes = ["plot", "device", "utils", "developer", "user"]
+
+        for i, mode in enumerate(modes):
+            with qtbot.waitSignal(advanced_dock_area.mode_changed, timeout=1000) as blocker:
+                advanced_dock_area.mode = mode
+
+            assert advanced_dock_area.mode == mode
+            assert blocker.args == [mode]


### PR DESCRIPTION
## Description
Introduces a new dock area based on Qt-Ads. Additionally, updates the BECConnector to improve signal removal handling.

## Related Issues

[None reported.]

## Type of Change

- Added Qt-Ads dependency
- Implemented new dock area based on Qt-Ads
- Added saving and restoring of profiles for AdvancedDockArea
- Updated BECConnector to remove signals and assign names for syncing widgets with Qt-Ads
- Adjusted WidgetStateManager for QMainWindow applications
- Added `attach`/`detach` methods to BECWidget for handling dock widgets

## How to Test

1. Run unit tests.
2. Run the AdvancedDockArea demo.
3. Connect from the CLI and test RPC functionality.
4. Interact with the GUI in the ADS demo.
5. Test saving and restoring profiles (both read-only and writable).
6. Verify map and widget list retrieval in the CLI.
7. Check widget removal logic.

## Potential Side Effects

- The current design is visually suboptimal due to the `bec_qtheme` stylesheet template, but this will likely change with an upcoming BEC Widget theme overhaul.
- Should be merged after #832 

## Screenshots / GIFs (if applicable)

[Include any relevant screenshots or GIFs to showcase the changes made.]