### PR TITLE
fix: move thefuzz dependency to prod

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "qtconsole~=5.5, >=5.5.1",  # needed for jupyter console
     "qtpy~=2.4",
     "qtmonaco~=0.5",
+    "thefuzz~=0.22",
 ]
 
 
@@ -41,7 +42,7 @@ dev = [
     "pytest-cov~=6.1.1",
     "watchdog~=6.0",
     "pre_commit~=4.2",
-    "thefuzz~=0.22",
+
 ]
 
 [project.urls]


### PR DESCRIPTION
This dependency is imported in widgets when running BEC so it should be in the production dependencies