### PR TITLE
ci: fix stale issues job permissions; add workflow dispatch option

### DIFF
--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -2,10 +2,14 @@ name: 'Close stale issues and PRs'
 on:
   schedule:
     - cron: '00 10 * * *'
+  workflow_dispatch:
 
 jobs:
   stale:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/stale@v9
         with:


### PR DESCRIPTION
## Description

Fix stale issue job's permissions. I also added the option to manually trigger the job through workflow dispatch. 
