### PR TITLE
fix: explicitly pass the cached readout flag

### DIFF
--- a/bec_widgets/tests/utils.py
+++ b/bec_widgets/tests/utils.py
@@ -173,7 +173,7 @@ class FakePositioner(BECPositioner):
     def set_read_value(self, value):
         self.read_value = value
 
-    def read(self):
+    def read(self, cached=False):
         return self.signals
 
     def set_limits(self, limits):

--- a/bec_widgets/widgets/control/device_control/positioner_box/_base/positioner_box_base.py
+++ b/bec_widgets/widgets/control/device_control/positioner_box/_base/positioner_box_base.py
@@ -88,7 +88,7 @@ class PositionerBoxBase(BECWidget, CompactPopupWidget):
         if not self._check_device_is_valid(device):
             return
 
-        data = self.dev[device].read()
+        data = self.dev[device].read(cached=True)
         self._on_device_readback(
             device,
             self._device_ui_components(device),

--- a/bec_widgets/widgets/plots/motor_map/motor_map.py
+++ b/bec_widgets/widgets/plots/motor_map/motor_map.py
@@ -765,7 +765,7 @@ class MotorMap(PlotBase):
             float: Motor initial position.
         """
         entry = self.entry_validator.validate_signal(name, None)
-        init_position = round(float(self.dev[name].read()[entry]["value"]), precision)
+        init_position = round(float(self.dev[name].read(cached=True)[entry]["value"]), precision)
         return init_position
 
     def _sync_motor_map_selection_toolbar(self):

--- a/bec_widgets/widgets/services/device_browser/device_item/device_signal_display.py
+++ b/bec_widgets/widgets/services/device_browser/device_item/device_signal_display.py
@@ -38,8 +38,8 @@ class SignalDisplay(BECWidget, QWidget):
     @SafeSlot()
     def _refresh(self):
         if (dev := self.dev.get(self.device)) is not None:
-            dev.read()
-            dev.read_configuration()
+            dev.read(cached=True)
+            dev.read_configuration(cached=True)
 
     def _add_refresh_button(self):
         button_holder = QWidget()

--- a/bec_widgets/widgets/utility/signal_label/signal_label.py
+++ b/bec_widgets/widgets/utility/signal_label/signal_label.py
@@ -273,7 +273,9 @@ class SignalLabel(BECWidget, QWidget):
         if not isinstance(self._device_obj, Device | Signal):
             self._value, self._units = "__", ""
             return
-        reading = (self._device_obj.read() or {}) | (self._device_obj.read_configuration() or {})
+        reading = (self._device_obj.read(cached=True) or {}) | (
+            self._device_obj.read_configuration(cached=True) or {}
+        )
         value = reading.get(self._signal_key, {}).get("value")
         if value is None:
             self._value, self._units = "__", ""

--- a/tests/unit_tests/test_positioner_box.py
+++ b/tests/unit_tests/test_positioner_box.py
@@ -50,7 +50,7 @@ def positioner_box(qtbot, mocked_client):
 def test_positioner_box(positioner_box):
     """Test init of positioner box"""
     assert positioner_box.device == "samx"
-    data = positioner_box.dev["samx"].read()
+    data = positioner_box.dev["samx"].read(cached=True)
     # Avoid check for Positioner class from BEC in _init_device
 
     setpoint_text = positioner_box.ui.setpoint.text()

--- a/tests/unit_tests/test_positioner_box_2d.py
+++ b/tests/unit_tests/test_positioner_box_2d.py
@@ -29,8 +29,8 @@ def test_positioner_box_2d(positioner_box_2d):
     """Test init of 2D positioner box"""
     assert positioner_box_2d.device_hor == "samx"
     assert positioner_box_2d.device_ver == "samy"
-    data_hor = positioner_box_2d.dev["samx"].read()
-    data_ver = positioner_box_2d.dev["samy"].read()
+    data_hor = positioner_box_2d.dev["samx"].read(cached=True)
+    data_ver = positioner_box_2d.dev["samy"].read(cached=True)
     # Avoid check for Positioner class from BEC in _init_device
 
     setpoint_hor_text = positioner_box_2d.ui.setpoint_hor.text()


### PR DESCRIPTION
## Description

This PR adds the default flag of cached=True to all .read and .read_configuration calls, primarily to make it backward compatible once we change the default. However, it also has the nice side-effect of highlighting when we are using cached readouts. 


