### PR TITLE
fix(becconnector): ophyd thread killer on exit + in conftest

### DIFF
--- a/bec_widgets/utils/bec_connector.py
+++ b/bec_widgets/utils/bec_connector.py
@@ -129,6 +129,17 @@ class BECConnector:
             def terminate(client=self.client, dispatcher=self.bec_dispatcher):
                 logger.info("Disconnecting", repr(dispatcher))
                 dispatcher.disconnect_all()
+
+                try:  # shutdown ophyd threads if any
+                    from ophyd._pyepics_shim import _dispatcher
+
+                    _dispatcher.stop()
+                    logger.info("Ophyd dispatcher shut down successfully.")
+                except Exception as e:
+                    logger.warning(
+                        f"Error shutting down ophyd dispatcher: {e}\n{traceback.format_exc()}"
+                    )
+
                 logger.info("Shutting down BEC Client", repr(client))
                 client.shutdown()
 

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -41,6 +41,10 @@ def qapplication(qtbot, request, testable_qtimer_class):  # pylint: disable=unus
 
     # if the test failed, we don't want to check for open widgets as
     # it simply pollutes the output
+    # stop pyepics dispatcher for leaking tests
+    from ophyd._pyepics_shim import _dispatcher
+
+    _dispatcher.stop()
     if request.node.stash._storage.get("failed"):
         print("Test failed, skipping cleanup checks")
         return


### PR DESCRIPTION
## Description

This should fix the case of leaking pyepics threads in the tests.