### PR TITLE
fix(waveform): async_readback can accept 0D data

### DIFF
--- a/bec_widgets/widgets/plots/waveform/waveform.py
+++ b/bec_widgets/widgets/plots/waveform/waveform.py
@@ -1628,6 +1628,9 @@ class Waveform(PlotBase):
                 continue
             # Ensure we have numpy array for data_plot_y
             data_plot_y = np.asarray(data_plot_y)
+            if data_plot_y.ndim == 0:
+                # Convert scalars/0d arrays to 1d so len() and stacking work
+                data_plot_y = data_plot_y.reshape(1)
             # Add
             if instruction == "add":
                 if len(max_shape) > 1:


### PR DESCRIPTION
can be tested with https://github.com/bec-project/ophyd_devices/pull/152 setting waveform to signal `waveform_0d` from simulated `waveform` device.