### PR TITLE
fix(widget_state_manager): add 'updatesEnabled' to PROPERTY_TO_SKIP to avoid empty AdvancedDockArea when restore on init when hidden

### DIFF
--- a/bec_widgets/utils/widget_state_manager.py
+++ b/bec_widgets/utils/widget_state_manager.py
@@ -29,6 +29,8 @@ PROPERTY_TO_SKIP = [
     "locale",
     "styleSheet",
     "updatesEnabled",
+    "objectName",
+    "visible",
 ]
 
 
@@ -118,16 +120,8 @@ class WidgetStateManager:
             prop = meta.property(i)
             name = prop.name()
 
-            # Skip persisting QWidget visibility because container widgets (e.g. tab
-            # stacks, dock managers) manage that state themselves. Restoring a saved
-            # False can permanently hide a widget, while forcing True makes hidden
-            # tabs show on top. Leave the property to the parent widget instead.
-            if name == "visible":
-                continue
-
             if (
-                name == "objectName"
-                or name in PROPERTY_TO_SKIP
+                name in PROPERTY_TO_SKIP
                 or not prop.isReadable()
                 or not prop.isWritable()
                 or not prop.isStored()  # can be extended to fine filter
@@ -184,7 +178,7 @@ class WidgetStateManager:
         for i in range(meta.propertyCount()):
             prop = meta.property(i)
             name = prop.name()
-            if name == "visible":
+            if name in PROPERTY_TO_SKIP:
                 continue
             if settings.contains(name):
                 value = settings.value(name)


### PR DESCRIPTION

## Description

Responsible for the disappearing of ADS widgets when closed when not visible. The property is anyway managed by qt after initialization of the whole UI. More information [here](https://doc.qt.io/qt-6/qwidget.html#updatesEnabled-prop)

