### PR TITLE
fix(rpc): add expiration to GUI registry state updates

### DIFF
--- a/bec_widgets/utils/rpc_server.py
+++ b/bec_widgets/utils/rpc_server.py
@@ -229,6 +229,7 @@ class RPCServer:
             MessageEndpoints.gui_registry_state(self.gui_id),
             msg_dict={"data": messages.GUIRegistryStateMessage(state=data)},
             max_size=1,
+            expire=60,
         )
 
     def _serialize_bec_connector(self, connector: BECConnector, wait=False) -> dict:


### PR DESCRIPTION
## Description

The registry state update was missing an expiration time, leading to an accumulation of states for outdated GUIs. 

