### PR TITLE
ci: cancel previous CI run for PR or branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,10 @@ on:
         required: false
         type: string
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   pull-requests: write
 


### PR DESCRIPTION
Adds a config to the CI workflow file which cancels previous runs if an update is pushed to the same branch or PR