### PR TITLE
Fix/sanitize object name

### DIFF
--- a/bec_widgets/utils/bec_connector.py
+++ b/bec_widgets/utils/bec_connector.py
@@ -272,6 +272,8 @@ class BECConnector:
         Args:
             name (str): The new object name.
         """
+        # sanitize before setting to avoid issues with Qt object names and RPC namespaces
+        name = sanitize_namespace(name)
         super().setObjectName(name)
         self.object_name = name
         if self.rpc_register.object_is_registered(self):

--- a/tests/unit_tests/test_bec_connector.py
+++ b/tests/unit_tests/test_bec_connector.py
@@ -39,6 +39,18 @@ def test_bec_connector_set_gui_id(bec_connector):
     assert bec_connector.config.gui_id == "test_gui_id"
 
 
+def test_bec_connector_sanitize_names(mocked_client):
+    class MyWidget(BECConnector, QWidget):
+        def __init__(self, parent=None, client=None, **kwargs):
+            super().__init__(parent=parent, client=client, **kwargs)
+
+    widget = MyWidget(client=mocked_client)
+    widget.setObjectName("Test Name With Spaces")
+    assert widget.objectName() == "Test_Name_With_Spaces"
+    widget.setObjectName("Test@Name#With$Special%Characters!")
+    assert widget.objectName() == "Test_Name_With_Special_Characters_"
+
+
 def test_bec_connector_change_config(bec_connector):
     bec_connector.on_config_update({"gui_id": "test_gui_id"})
     assert bec_connector.config.gui_id == "test_gui_id"


### PR DESCRIPTION
## Description

QWidget method `setObjectName` is always sanitizing the names to be compatible with python.