### PR TITLE
fix(dock_area): widget_map and widget_list by default returns only becconnector based widgets

### DIFF
--- a/bec_widgets/cli/client.py
+++ b/bec_widgets/cli/client.py
@@ -199,15 +199,21 @@ class BECDockArea(RPCBase):
         """
 
     @rpc_call
-    def widget_map(self) -> "dict[str, QWidget]":
+    def widget_map(self, bec_widgets_only: "bool" = True) -> "dict[str, QWidget]":
         """
         Return a dictionary mapping widget names to their corresponding widgets.
+
+        Args:
+            bec_widgets_only(bool): If True, only include widgets that are BECConnector instances.
         """
 
     @rpc_call
-    def widget_list(self) -> "list[QWidget]":
+    def widget_list(self, bec_widgets_only: "bool" = True) -> "list[QWidget]":
         """
-        Return a list of all widgets contained in the dock area.
+        Return a list of widgets contained in the dock area.
+
+        Args:
+            bec_widgets_only(bool): If True, only include widgets that are BECConnector instances.
         """
 
     @property
@@ -1147,15 +1153,21 @@ class DockAreaWidget(RPCBase):
         """
 
     @rpc_call
-    def widget_map(self) -> "dict[str, QWidget]":
+    def widget_map(self, bec_widgets_only: "bool" = True) -> "dict[str, QWidget]":
         """
         Return a dictionary mapping widget names to their corresponding widgets.
+
+        Args:
+            bec_widgets_only(bool): If True, only include widgets that are BECConnector instances.
         """
 
     @rpc_call
-    def widget_list(self) -> "list[QWidget]":
+    def widget_list(self, bec_widgets_only: "bool" = True) -> "list[QWidget]":
         """
-        Return a list of all widgets contained in the dock area.
+        Return a list of widgets contained in the dock area.
+
+        Args:
+            bec_widgets_only(bool): If True, only include widgets that are BECConnector instances.
         """
 
     @rpc_call
@@ -2947,15 +2959,21 @@ class MonacoDock(RPCBase):
         """
 
     @rpc_call
-    def widget_map(self) -> "dict[str, QWidget]":
+    def widget_map(self, bec_widgets_only: "bool" = True) -> "dict[str, QWidget]":
         """
         Return a dictionary mapping widget names to their corresponding widgets.
+
+        Args:
+            bec_widgets_only(bool): If True, only include widgets that are BECConnector instances.
         """
 
     @rpc_call
-    def widget_list(self) -> "list[QWidget]":
+    def widget_list(self, bec_widgets_only: "bool" = True) -> "list[QWidget]":
         """
-        Return a list of all widgets contained in the dock area.
+        Return a list of widgets contained in the dock area.
+
+        Args:
+            bec_widgets_only(bool): If True, only include widgets that are BECConnector instances.
         """
 
     @rpc_call

--- a/bec_widgets/widgets/containers/dock_area/basic_dock_area.py
+++ b/bec_widgets/widgets/containers/dock_area/basic_dock_area.py
@@ -14,6 +14,7 @@ from shiboken6 import isValid
 import bec_widgets.widgets.containers.qt_ads as QtAds
 from bec_widgets import BECWidget, SafeSlot
 from bec_widgets.cli.rpc.rpc_widget_handler import widget_handler
+from bec_widgets.utils.bec_connector import BECConnector
 from bec_widgets.utils.property_editor import PropertyEditor
 from bec_widgets.utils.toolbars.actions import MaterialIconAction
 from bec_widgets.widgets.containers.qt_ads import (
@@ -1358,13 +1359,32 @@ class DockAreaWidget(BECWidget, QWidget):
         """Return the list of dock widgets."""
         return self._iter_all_docks()
 
-    def widget_map(self) -> dict[str, QWidget]:
-        """Return a dictionary mapping widget names to their corresponding widgets."""
-        return {dock.objectName(): dock.widget() for dock in self.dock_list()}
+    def widget_map(self, bec_widgets_only: bool = True) -> dict[str, QWidget]:
+        """
+        Return a dictionary mapping widget names to their corresponding widgets.
 
-    def widget_list(self) -> list[QWidget]:
-        """Return a list of all widgets contained in the dock area."""
-        return [dock.widget() for dock in self.dock_list() if isinstance(dock.widget(), QWidget)]
+        Args:
+            bec_widgets_only(bool): If True, only include widgets that are BECConnector instances.
+        """
+
+        widgets: dict[str, QWidget] = {}
+        for dock in self.dock_list():
+            widget = dock.widget()
+            if not isinstance(widget, QWidget):
+                continue
+            if bec_widgets_only and not isinstance(widget, BECConnector):
+                continue
+            widgets[dock.objectName()] = widget
+        return widgets
+
+    def widget_list(self, bec_widgets_only: bool = True) -> list[QWidget]:
+        """
+        Return a list of widgets contained in the dock area.
+
+        Args:
+            bec_widgets_only(bool): If True, only include widgets that are BECConnector instances.
+        """
+        return list(self.widget_map(bec_widgets_only=bec_widgets_only).values())
 
     @SafeSlot()
     def attach_all(self):

--- a/tests/unit_tests/test_dock_area.py
+++ b/tests/unit_tests/test_dock_area.py
@@ -39,6 +39,7 @@ from bec_widgets.widgets.containers.dock_area.settings.dialogs import (
     RestoreProfileDialog,
 )
 from bec_widgets.widgets.containers.dock_area.settings.workspace_manager import WorkSpaceManager
+from bec_widgets.widgets.plots.waveform.waveform import Waveform
 
 from .client_mocks import mocked_client
 
@@ -218,14 +219,24 @@ class TestBasicDockArea:
     """Focused coverage for the lightweight DockAreaWidget base."""
 
     def test_new_widget_instance_registers_in_maps(self, basic_dock_area):
-        panel = QWidget(parent=basic_dock_area)
-        panel.setObjectName("basic_panel")
+        panel_non_bec = QWidget(parent=basic_dock_area)
+        panel_non_bec.setObjectName("panel_non_bec")
 
-        dock = basic_dock_area.new(panel, return_dock=True)
+        panel_bec = Waveform(parent=basic_dock_area)
+        panel_bec.setObjectName("panel_bec")
 
-        assert dock.objectName() == "basic_panel"
-        assert basic_dock_area.dock_map()["basic_panel"] is dock
-        assert basic_dock_area.widget_map()["basic_panel"] is panel
+        dock_non_bec = basic_dock_area.new(panel_non_bec, return_dock=True)
+        dock_bec = basic_dock_area.new(panel_bec, return_dock=True)
+
+        assert dock_non_bec.objectName() == "panel_non_bec"
+        assert dock_bec.objectName() == "panel_bec"
+        assert len(basic_dock_area.dock_map()) == 2
+        assert basic_dock_area.dock_map()["panel_non_bec"] is dock_non_bec
+        assert basic_dock_area.dock_map()["panel_bec"] is dock_bec
+        assert len(basic_dock_area.widget_map(bec_widgets_only=False)) == 2
+        assert len(basic_dock_area.widget_map()) == 1
+        assert basic_dock_area.widget_map(bec_widgets_only=False)["panel_non_bec"] is panel_non_bec
+        assert basic_dock_area.widget_map(bec_widgets_only=False)["panel_bec"] is panel_bec
 
     def test_new_widget_string_creates_widget(self, basic_dock_area, qtbot):
         basic_dock_area.new("DarkModeButton")


### PR DESCRIPTION
## Description

Previous bug where `gui.bec.widget_list()` and  `gui.bec.widget_map()` was fetching also non bec based widgets causes the cli error.

## Related Issues

- closes #1054

## How to test

- in CLI fetch the widgets with `gui.bec.widget_list()` or `gui.bec.widget_map()`
 
