### PR TITLE
fix(dock_area): remove old AdvancedDockArea references

### DIFF
--- a/bec_widgets/cli/client.py
+++ b/bec_widgets/cli/client.py
@@ -187,7 +187,7 @@ class BECDockArea(RPCBase):
                 or a sequence of button names to hide.
             show_settings_action(bool | None): Control whether a dock settings/property action should
                 be installed. Defaults to ``False`` for the basic dock area; subclasses
-                such as `AdvancedDockArea` override the default to ``True``.
+                such as `BECDockArea` override the default to ``True``.
             promote_central(bool): When True, promote the created dock to be the dock manager's
                 central widget (useful for editor stacks or other root content).
             object_name(str | None): Optional object name to assign to the created widget.
@@ -1141,7 +1141,7 @@ class DockAreaView(RPCBase):
                 or a sequence of button names to hide.
             show_settings_action(bool | None): Control whether a dock settings/property action should
                 be installed. Defaults to ``False`` for the basic dock area; subclasses
-                such as `AdvancedDockArea` override the default to ``True``.
+                such as `BECDockArea` override the default to ``True``.
             promote_central(bool): When True, promote the created dock to be the dock manager's
                 central widget (useful for editor stacks or other root content).
             object_name(str | None): Optional object name to assign to the created widget.
@@ -1386,7 +1386,7 @@ class DockAreaWidget(RPCBase):
                 or a sequence of button names to hide.
             show_settings_action(bool | None): Control whether a dock settings/property action should
                 be installed. Defaults to ``False`` for the basic dock area; subclasses
-                such as `AdvancedDockArea` override the default to ``True``.
+                such as `BECDockArea` override the default to ``True``.
             promote_central(bool): When True, promote the created dock to be the dock manager's
                 central widget (useful for editor stacks or other root content).
             dock_icon(QIcon | None): Optional icon applied to the dock via ``CDockWidget.setIcon``.
@@ -3192,7 +3192,7 @@ class MonacoDock(RPCBase):
                 or a sequence of button names to hide.
             show_settings_action(bool | None): Control whether a dock settings/property action should
                 be installed. Defaults to ``False`` for the basic dock area; subclasses
-                such as `AdvancedDockArea` override the default to ``True``.
+                such as `BECDockArea` override the default to ``True``.
             promote_central(bool): When True, promote the created dock to be the dock manager's
                 central widget (useful for editor stacks or other root content).
             dock_icon(QIcon | None): Optional icon applied to the dock via ``CDockWidget.setIcon``.

--- a/bec_widgets/widgets/containers/dock_area/basic_dock_area.py
+++ b/bec_widgets/widgets/containers/dock_area/basic_dock_area.py
@@ -1315,7 +1315,7 @@ class DockAreaWidget(BECWidget, QWidget):
                 or a sequence of button names to hide.
             show_settings_action(bool | None): Control whether a dock settings/property action should
                 be installed. Defaults to ``False`` for the basic dock area; subclasses
-                such as `AdvancedDockArea` override the default to ``True``.
+                such as `BECDockArea` override the default to ``True``.
             promote_central(bool): When True, promote the created dock to be the dock manager's
                 central widget (useful for editor stacks or other root content).
             dock_icon(QIcon | None): Optional icon applied to the dock via ``CDockWidget.setIcon``.

--- a/bec_widgets/widgets/containers/dock_area/dock_area.py
+++ b/bec_widgets/widgets/containers/dock_area/dock_area.py
@@ -136,10 +136,7 @@ class BECDockArea(DockAreaWidget):
         self._profile_management_enabled = enable_profile_management
         self._startup_profile = self._normalize_startup_profile(startup_profile)
         super().__init__(
-            parent,
-            default_add_direction=default_add_direction,
-            title="Advanced Dock Area",
-            **kwargs,
+            parent, default_add_direction=default_add_direction, title="BEC Dock Area", **kwargs
         )
 
         # Initialize mode property first (before toolbar setup)
@@ -168,7 +165,7 @@ class BECDockArea(DockAreaWidget):
 
         # State manager
         self.state_manager = WidgetStateManager(
-            self, serialize_from_root=True, root_id="AdvancedDockArea"
+            self, serialize_from_root=True, root_id="BECDockArea"
         )
 
         # Developer mode state
@@ -304,7 +301,7 @@ class BECDockArea(DockAreaWidget):
                 or a sequence of button names to hide.
             show_settings_action(bool | None): Control whether a dock settings/property action should
                 be installed. Defaults to ``False`` for the basic dock area; subclasses
-                such as `AdvancedDockArea` override the default to ``True``.
+                such as `BECDockArea` override the default to ``True``.
             promote_central(bool): When True, promote the created dock to be the dock manager's
                 central widget (useful for editor stacks or other root content).
             object_name(str | None): Optional object name to assign to the created widget.

--- a/bec_widgets/widgets/containers/dock_area/profile_utils.py
+++ b/bec_widgets/widgets/containers/dock_area/profile_utils.py
@@ -1,5 +1,5 @@
 """
-Utilities for managing AdvancedDockArea profiles stored in INI files.
+Utilities for managing BECDockArea profiles stored in INI files.
 
 Policy:
 - All created/modified profiles are stored under the BEC settings root: <base_path>/profiles/{default,user}
@@ -36,12 +36,12 @@ ProfileOrigin = Literal["module", "plugin", "settings", "unknown"]
 
 def module_profiles_dir() -> str:
     """
-    Return the built-in AdvancedDockArea profiles directory bundled with the module.
+    Return the built-in BECDockArea profiles directory bundled with the module.
 
     Returns:
         str: Absolute path of the read-only module profiles directory.
     """
-    return os.path.join(MODULE_PATH, "containers", "advanced_dock_area", "profiles")
+    return os.path.join(MODULE_PATH, "containers", "dock_area", "profiles")
 
 
 @lru_cache(maxsize=1)

--- a/bec_widgets/widgets/containers/dock_area/settings/workspace_manager.py
+++ b/bec_widgets/widgets/containers/dock_area/settings/workspace_manager.py
@@ -330,7 +330,7 @@ class WorkSpaceManager(BECWidget, QWidget):
             return
 
         self.target_widget.save_profile_dialog()
-        # AdvancedDockArea will emit profile_changed which will trigger table refresh,
+        # BECDockArea will emit profile_changed which will trigger table refresh,
         # but ensure the UI stays in sync even if the signal is delayed.
         self.render_table()
         current = getattr(self.target_widget, "_current_profile_name", None)

--- a/bec_widgets/widgets/containers/dock_area/toolbar_components/workspace_actions.py
+++ b/bec_widgets/widgets/containers/dock_area/toolbar_components/workspace_actions.py
@@ -118,7 +118,7 @@ class ProfileComboBox(QComboBox):
 
 def workspace_bundle(components: ToolbarComponents, enable_tools: bool = True) -> ToolbarBundle:
     """
-    Creates a workspace toolbar bundle for AdvancedDockArea.
+    Creates a workspace toolbar bundle for BECDockArea.
 
     Args:
         components (ToolbarComponents): The components to be added to the bundle.
@@ -171,7 +171,7 @@ def workspace_bundle(components: ToolbarComponents, enable_tools: bool = True) -
 
 class WorkspaceConnection(BundleConnection):
     """
-    Connection class for workspace actions in AdvancedDockArea.
+    Connection class for workspace actions in BECDockArea.
     """
 
     def __init__(self, components: ToolbarComponents, target_widget=None):


### PR DESCRIPTION
## Description

There were still few artifact and comments which were not refactored properly during AdvancedDockArea to BECDockArea renaming (mostly in strings).

## Additional Comments

You might have to delete your widget_settings folder, I changed the root_widget to be identified by WidgetStateManager as "BECDockArea" not "AdvancedDockArea".