### PR TITLE
fix: "exit_status" changed to "status" to reflect BEC ScanHistoryMessage

### DIFF
--- a/bec_widgets/widgets/plots/heatmap/heatmap.py
+++ b/bec_widgets/widgets/plots/heatmap/heatmap.py
@@ -611,7 +611,7 @@ class Heatmap(ImageBase):
             scan_msg = self.scan_item.status_message
         elif hasattr(self.scan_item, "metadata"):
             metadata = self.scan_item.metadata["bec"]
-            status = metadata["exit_status"]
+            status = metadata["status"]
             scan_id = metadata["scan_id"]
             scan_name = metadata["scan_name"]
             scan_type = metadata["scan_type"]

--- a/bec_widgets/widgets/services/scan_history_browser/components/scan_history_metadata_viewer.py
+++ b/bec_widgets/widgets/services/scan_history_browser/components/scan_history_metadata_viewer.py
@@ -50,7 +50,7 @@ class ScanHistoryMetadataViewer(BECWidget, QtWidgets.QGroupBox):
             "start_time": "Start Time",
             "end_time": "End Time",
             "elapsed_time": "Elapsed Time",
-            "exit_status": "Status",
+            "status": "Status",
             "scan_name": "Scan Name",
             "num_points": "Nr of Points",
         }

--- a/tests/end-2-end/test_scan_control_e2e.py
+++ b/tests/end-2-end/test_scan_control_e2e.py
@@ -59,5 +59,4 @@ def test_run_line_scan_with_parameters_e2e(scan_control, bec_client_lib, qtbot):
     last_scan = queue.scan_storage.storage[-1]
     assert last_scan.status_message.info["scan_name"] == scan_name
     assert last_scan.status_message.info["exp_time"] == kwargs["exp_time"]
-    assert last_scan.status_message.info["scan_motors"] == [args["device"]]
     assert last_scan.status_message.info["num_points"] == kwargs["steps"]

--- a/tests/end-2-end/test_with_plugins_e2e.py
+++ b/tests/end-2-end/test_with_plugins_e2e.py
@@ -84,7 +84,6 @@ def test_scan_metadata_for_custom_scan(
         last_scan = queue.scan_storage.storage[-1]
         assert last_scan.status_message.info["scan_name"] == scan_name
         assert last_scan.status_message.info["exp_time"] == kwargs["exp_time"]
-        assert last_scan.status_message.info["scan_motors"] == [args["device"]]
         assert last_scan.status_message.info["num_points"] == kwargs["steps"]
 
     if valid:

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -222,7 +222,7 @@ def create_history_file(file_path, data: dict, metadata: dict) -> messages.ScanH
     msg = messages.ScanHistoryMessage(
         scan_id=metadata["scan_id"],
         scan_name=metadata["scan_name"],
-        exit_status=metadata["exit_status"],
+        exit_status=metadata["status"],
         file_path=file_path,
         scan_number=metadata["scan_number"],
         dataset_number=metadata["dataset_number"],
@@ -269,7 +269,7 @@ def grid_scan_history_msg(tmpdir):
         "scan_id": "test_scan",
         "scan_name": "grid_scan",
         "scan_type": "step",
-        "exit_status": "closed",
+        "status": "closed",
         "scan_number": 1,
         "dataset_number": 1,
         "request_inputs": {
@@ -349,7 +349,7 @@ def scan_history_factory(tmpdir):
             "scan_id": scan_id,
             "scan_name": scan_name,
             "scan_type": scan_type,
-            "exit_status": "closed",
+            "status": "closed",
             "scan_number": scan_number,
             "dataset_number": dataset_number,
             "request_inputs": {

--- a/tests/unit_tests/test_bec_queue.py
+++ b/tests/unit_tests/test_bec_queue.py
@@ -71,7 +71,6 @@ def bec_queue_msg_full():
                             },
                             "report_instructions": [{"scan_progress": 20}],
                             "scan_id": "2d704cc3-c172-404c-866d-608ce09fce40",
-                            "scan_motors": ["samx"],
                             "scan_number": 1289,
                         }
                     ],


### PR DESCRIPTION
## Description
fix: "exit_status" changed to "status" to reflect BEC ScanHistoryMessage + remove "scan_motors" from tests to compile with https://github.com/bec-project/bec/pull/800
