### PR TITLE
test: remove references to "scan_motors" in tests

### DIFF
--- a/tests/end-2-end/test_scan_control_e2e.py
+++ b/tests/end-2-end/test_scan_control_e2e.py
@@ -59,5 +59,4 @@ def test_run_line_scan_with_parameters_e2e(scan_control, bec_client_lib, qtbot):
     last_scan = queue.scan_storage.storage[-1]
     assert last_scan.status_message.info["scan_name"] == scan_name
     assert last_scan.status_message.info["exp_time"] == kwargs["exp_time"]
-    assert last_scan.status_message.info["scan_motors"] == [args["device"]]
     assert last_scan.status_message.info["num_points"] == kwargs["steps"]

--- a/tests/end-2-end/test_with_plugins_e2e.py
+++ b/tests/end-2-end/test_with_plugins_e2e.py
@@ -84,7 +84,6 @@ def test_scan_metadata_for_custom_scan(
         last_scan = queue.scan_storage.storage[-1]
         assert last_scan.status_message.info["scan_name"] == scan_name
         assert last_scan.status_message.info["exp_time"] == kwargs["exp_time"]
-        assert last_scan.status_message.info["scan_motors"] == [args["device"]]
         assert last_scan.status_message.info["num_points"] == kwargs["steps"]
 
     if valid:

--- a/tests/unit_tests/test_bec_queue.py
+++ b/tests/unit_tests/test_bec_queue.py
@@ -71,7 +71,6 @@ def bec_queue_msg_full():
                             },
                             "report_instructions": [{"scan_progress": 20}],
                             "scan_id": "2d704cc3-c172-404c-866d-608ce09fce40",
-                            "scan_motors": ["samx"],
                             "scan_number": 1289,
                         }
                     ],


### PR DESCRIPTION
## Description

Removing the deprecated references to "scan_motors"
