### PR TITLE
Fix access to status from metadata

### DIFF
--- a/bec_widgets/widgets/plots/heatmap/heatmap.py
+++ b/bec_widgets/widgets/plots/heatmap/heatmap.py
@@ -611,7 +611,7 @@ class Heatmap(ImageBase):
             scan_msg = self.scan_item.status_message
         elif hasattr(self.scan_item, "metadata"):
             metadata = self.scan_item.metadata["bec"]
-            status = metadata["exit_status"]
+            status = metadata["status"]
             scan_id = metadata["scan_id"]
             scan_name = metadata["scan_name"]
             scan_type = metadata["scan_type"]

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -227,7 +227,7 @@ def create_history_file(file_path, data: dict, metadata: dict) -> messages.ScanH
     msg = messages.ScanHistoryMessage(
         scan_id=metadata["scan_id"],
         scan_name=metadata["scan_name"],
-        exit_status=metadata["exit_status"],
+        exit_status=metadata["status"],
         file_path=file_path,
         scan_number=metadata["scan_number"],
         dataset_number=metadata["dataset_number"],
@@ -274,7 +274,7 @@ def grid_scan_history_msg(tmpdir):
         "scan_id": "test_scan",
         "scan_name": "grid_scan",
         "scan_type": "step",
-        "exit_status": "closed",
+        "status": "closed",
         "scan_number": 1,
         "dataset_number": 1,
         "request_inputs": {
@@ -354,7 +354,7 @@ def scan_history_factory(tmpdir):
             "scan_id": scan_id,
             "scan_name": scan_name,
             "scan_type": scan_type,
-            "exit_status": "closed",
+            "status": "closed",
             "scan_number": scan_number,
             "dataset_number": dataset_number,
             "request_inputs": {


### PR DESCRIPTION
While testing widgets, I found that the access to the scan status was not yet migrated from `exit_status` to `status` for the heatmap widget. this PR fixes this. It also closes #1118 . It does not change the ScanHistoryMessage occurences of 'exit_status'. This can be revisited once the bec.message is adapted.