### PR TITLE
ci: fix benchmark upload

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,6 +1,6 @@
 name: BW Benchmarks
 
-on: [workflow_call]
+on: [ workflow_call ]
 
 permissions:
   contents: read
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        attempt: [1, 2, 3]
+        attempt: [ 1, 2, 3 ]
 
     env:
       BENCHMARK_JSON: benchmark-results/current-${{ matrix.attempt }}.json
@@ -84,7 +84,7 @@ jobs:
           path: ${{ env.BENCHMARK_JSON }}
 
   benchmark:
-    needs: [benchmark_attempt]
+    needs: [ benchmark_attempt ]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -191,7 +191,7 @@ jobs:
         run: exit 1
 
   publish:
-    needs: [benchmark]
+    needs: [ benchmark ]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
@@ -208,7 +208,10 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: bw-benchmark-json
-          path: .
+          path: benchmark-results
+
+      - name: Verify aggregate benchmark artifact
+        run: test -s "$BENCHMARK_JSON"
 
       - name: Prepare gh-pages for publishing
         run: |

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -10,7 +10,7 @@ env:
   BENCHMARK_BASELINE_JSON: gh-pages-benchmark-data/benchmarks/latest.json
   BENCHMARK_SUMMARY: benchmark-results/summary.md
   BENCHMARK_COMMAND: "bash .github/scripts/run_benchmarks.sh"
-  BENCHMARK_THRESHOLD_PERCENT: 10
+  BENCHMARK_THRESHOLD_PERCENT: 20
   BENCHMARK_HIGHER_IS_BETTER: false
 
 jobs:


### PR DESCRIPTION
## Description

This PR fixes a bug in the benchmark publishing step and increases the threshold to 20 %. Seems we really need that much on GH, even if we only calculate the median. 
