### PR TITLE
rpc restore default profile in dock area

### DIFF
--- a/bec_widgets/cli/client.py
+++ b/bec_widgets/cli/client.py
@@ -358,15 +358,19 @@ class BECDockArea(RPCBase):
 
     @rpc_timeout(None)
     @rpc_call
-    def load_profile(self, name: "str | None" = None):
+    def load_profile(self, name: "str | None" = None, restore_baseline: "bool" = False):
         """
         Load a workspace profile.
 
         Before switching, persist the current profile to the runtime copy.
-        Prefer loading the runtime copy; fall back to the baseline copy.
+        Prefer loading the runtime copy; fall back to the baseline copy. When
+        ``restore_baseline`` is True, first overwrite the runtime copy with the
+        baseline profile and then load it.
 
         Args:
             name (str | None): The name of the profile to load. If None, prompts the user.
+            restore_baseline (bool): If True, restore the runtime copy from the
+                baseline before loading. Defaults to False.
         """
 
     @rpc_timeout(None)
@@ -1378,15 +1382,19 @@ class DockAreaView(RPCBase):
 
     @rpc_timeout(None)
     @rpc_call
-    def load_profile(self, name: "str | None" = None):
+    def load_profile(self, name: "str | None" = None, restore_baseline: "bool" = False):
         """
         Load a workspace profile.
 
         Before switching, persist the current profile to the runtime copy.
-        Prefer loading the runtime copy; fall back to the baseline copy.
+        Prefer loading the runtime copy; fall back to the baseline copy. When
+        ``restore_baseline`` is True, first overwrite the runtime copy with the
+        baseline profile and then load it.
 
         Args:
             name (str | None): The name of the profile to load. If None, prompts the user.
+            restore_baseline (bool): If True, restore the runtime copy from the
+                baseline before loading. Defaults to False.
         """
 
     @rpc_timeout(None)

--- a/bec_widgets/cli/client.py
+++ b/bec_widgets/cli/client.py
@@ -369,6 +369,18 @@ class BECDockArea(RPCBase):
             name (str | None): The name of the profile to load. If None, prompts the user.
         """
 
+    @rpc_timeout(None)
+    @rpc_call
+    def restore_baseline_profile(self, name: "str | None" = None, show_dialog: "bool" = True):
+        """
+        Overwrite the runtime copy of *name* with the baseline.
+        If *name* is None, target the currently active profile.
+
+        Args:
+            name (str | None): The name of the profile to restore. If None, uses the current profile.
+            show_dialog (bool): If True, ask for confirmation before restoring.
+        """
+
     @rpc_call
     def delete_profile(self, name: "str | None" = None, show_dialog: "bool" = False) -> "bool":
         """
@@ -1375,6 +1387,18 @@ class DockAreaView(RPCBase):
 
         Args:
             name (str | None): The name of the profile to load. If None, prompts the user.
+        """
+
+    @rpc_timeout(None)
+    @rpc_call
+    def restore_baseline_profile(self, name: "str | None" = None, show_dialog: "bool" = True):
+        """
+        Overwrite the runtime copy of *name* with the baseline.
+        If *name* is None, target the currently active profile.
+
+        Args:
+            name (str | None): The name of the profile to restore. If None, uses the current profile.
+            show_dialog (bool): If True, ask for confirmation before restoring.
         """
 
     @rpc_call

--- a/bec_widgets/cli/client.py
+++ b/bec_widgets/cli/client.py
@@ -375,7 +375,7 @@ class BECDockArea(RPCBase):
 
     @rpc_timeout(None)
     @rpc_call
-    def restore_baseline_profile(self, name: "str | None" = None, show_dialog: "bool" = True):
+    def restore_baseline_profile(self, name: "str | None" = None, show_dialog: "bool" = False):
         """
         Overwrite the runtime copy of *name* with the baseline.
         If *name* is None, target the currently active profile.
@@ -1399,7 +1399,7 @@ class DockAreaView(RPCBase):
 
     @rpc_timeout(None)
     @rpc_call
-    def restore_baseline_profile(self, name: "str | None" = None, show_dialog: "bool" = True):
+    def restore_baseline_profile(self, name: "str | None" = None, show_dialog: "bool" = False):
         """
         Overwrite the runtime copy of *name* with the baseline.
         If *name* is None, target the currently active profile.

--- a/bec_widgets/widgets/containers/dock_area/dock_area.py
+++ b/bec_widgets/widgets/containers/dock_area/dock_area.py
@@ -907,7 +907,7 @@ class BECDockArea(DockAreaWidget):
     @SafeSlot(str)
     @SafeSlot(str, bool)
     @rpc_timeout(None)
-    def restore_baseline_profile(self, name: str | None = None, show_dialog: bool = True):
+    def restore_baseline_profile(self, name: str | None = None, show_dialog: bool = False):
         """
         Overwrite the runtime copy of *name* with the baseline.
         If *name* is None, target the currently active profile.

--- a/bec_widgets/widgets/containers/dock_area/dock_area.py
+++ b/bec_widgets/widgets/containers/dock_area/dock_area.py
@@ -108,6 +108,7 @@ class BECDockArea(DockAreaWidget):
         "list_profiles",
         "save_profile",
         "load_profile",
+        "restore_baseline_profile",
         "delete_profile",
     ]
 
@@ -896,30 +897,34 @@ class BECDockArea(DockAreaWidget):
 
     @SafeSlot()
     @SafeSlot(str)
-    def restore_runtime_profile_from_baseline(self, name: str | None = None):
+    @SafeSlot(str, bool)
+    @rpc_timeout(None)
+    def restore_baseline_profile(self, name: str | None = None, show_dialog: bool = True):
         """
         Overwrite the runtime copy of *name* with the baseline.
         If *name* is None, target the currently active profile.
 
         Args:
             name (str | None): The name of the profile to restore. If None, uses the current profile.
+            show_dialog (bool): If True, ask for confirmation before restoring.
         """
         target = name or getattr(self, "_current_profile_name", None)
         if not target:
             return
         namespace = self.profile_namespace
 
-        current_pixmap = None
-        if self.isVisible():
-            current_pixmap = QPixmap()
-            ba = bytes(self.screenshot_bytes())
-            current_pixmap.loadFromData(ba)
-        if current_pixmap is None or current_pixmap.isNull():
-            current_pixmap = load_runtime_profile_screenshot(target, namespace=namespace)
-        baseline_pixmap = load_baseline_profile_screenshot(target, namespace=namespace)
+        if show_dialog:
+            current_pixmap = None
+            if self.isVisible():
+                current_pixmap = QPixmap()
+                ba = bytes(self.screenshot_bytes())
+                current_pixmap.loadFromData(ba)
+            if current_pixmap is None or current_pixmap.isNull():
+                current_pixmap = load_runtime_profile_screenshot(target, namespace=namespace)
+            baseline_pixmap = load_baseline_profile_screenshot(target, namespace=namespace)
 
-        if not RestoreProfileDialog.confirm(self, current_pixmap, baseline_pixmap):
-            return
+            if not RestoreProfileDialog.confirm(self, current_pixmap, baseline_pixmap):
+                return
 
         restore_runtime_from_baseline(target, namespace=namespace)
         self.delete_all()

--- a/bec_widgets/widgets/containers/dock_area/dock_area.py
+++ b/bec_widgets/widgets/containers/dock_area/dock_area.py
@@ -820,16 +820,21 @@ class BECDockArea(DockAreaWidget):
 
     @SafeSlot()
     @SafeSlot(str)
+    @SafeSlot(str, bool)
     @rpc_timeout(None)
-    def load_profile(self, name: str | None = None):
+    def load_profile(self, name: str | None = None, restore_baseline: bool = False):
         """
         Load a workspace profile.
 
         Before switching, persist the current profile to the runtime copy.
-        Prefer loading the runtime copy; fall back to the baseline copy.
+        Prefer loading the runtime copy; fall back to the baseline copy. When
+        ``restore_baseline`` is True, first overwrite the runtime copy with the
+        baseline profile and then load it.
 
         Args:
             name (str | None): The name of the profile to load. If None, prompts the user.
+            restore_baseline (bool): If True, restore the runtime copy from the
+                baseline before loading. Defaults to False.
         """
         if name == "":
             return
@@ -850,6 +855,9 @@ class BECDockArea(DockAreaWidget):
             else:
                 us_prev = open_runtime_settings(prev_name, namespace=namespace)
                 self._write_snapshot_to_settings(us_prev, save_preview=True)
+
+        if restore_baseline:
+            restore_runtime_from_baseline(name, namespace=namespace)
 
         settings = None
         if any(os.path.exists(path) for path in runtime_profile_candidates(name, namespace)):

--- a/bec_widgets/widgets/containers/dock_area/toolbar_components/workspace_actions.py
+++ b/bec_widgets/widgets/containers/dock_area/toolbar_components/workspace_actions.py
@@ -235,4 +235,4 @@ class WorkspaceConnection(BundleConnection):
         """
         Refreshes the current workspace.
         """
-        self.target_widget.restore_runtime_profile_from_baseline()
+        self.target_widget.restore_baseline_profile()

--- a/bec_widgets/widgets/containers/dock_area/toolbar_components/workspace_actions.py
+++ b/bec_widgets/widgets/containers/dock_area/toolbar_components/workspace_actions.py
@@ -235,4 +235,4 @@ class WorkspaceConnection(BundleConnection):
         """
         Refreshes the current workspace.
         """
-        self.target_widget.restore_baseline_profile()
+        self.target_widget.restore_baseline_profile(show_dialog=True)

--- a/tests/unit_tests/test_dock_area.py
+++ b/tests/unit_tests/test_dock_area.py
@@ -1421,7 +1421,7 @@ class TestAdvancedDockAreaRestoreAndDialogs:
             patch.object(advanced_dock_area, "delete_all") as mock_delete_all,
             patch.object(advanced_dock_area, "load_profile") as mock_load_profile,
         ):
-            advanced_dock_area.restore_baseline_profile()
+            advanced_dock_area.restore_baseline_profile(show_dialog=True)
 
         assert mock_restore.call_count == 1
         args, kwargs = mock_restore.call_args
@@ -1455,7 +1455,7 @@ class TestAdvancedDockAreaRestoreAndDialogs:
         with patch(
             "bec_widgets.widgets.containers.dock_area.dock_area.restore_runtime_from_baseline"
         ) as mock_restore:
-            advanced_dock_area.restore_baseline_profile()
+            advanced_dock_area.restore_baseline_profile(show_dialog=True)
 
         mock_restore.assert_not_called()
 
@@ -1489,7 +1489,7 @@ class TestAdvancedDockAreaRestoreAndDialogs:
         with patch(
             "bec_widgets.widgets.containers.dock_area.dock_area.RestoreProfileDialog.confirm"
         ) as mock_confirm:
-            advanced_dock_area.restore_baseline_profile()
+            advanced_dock_area.restore_baseline_profile(show_dialog=True)
         mock_confirm.assert_not_called()
 
     def test_refresh_workspace_list_with_refresh_profiles(self, advanced_dock_area):

--- a/tests/unit_tests/test_dock_area.py
+++ b/tests/unit_tests/test_dock_area.py
@@ -1887,6 +1887,43 @@ class TestWorkspaceProfileOperations:
         widget_map = advanced_dock_area.widget_map()
         assert "test_widget" in widget_map
 
+    def test_load_profile_default_does_not_restore_baseline(self, advanced_dock_area):
+        """Regular profile loading should not restore the runtime copy."""
+        profile_name = "load_without_baseline_restore"
+        helper = profile_helper(advanced_dock_area)
+        helper.open_runtime(profile_name).sync()
+
+        with patch(
+            "bec_widgets.widgets.containers.dock_area.dock_area.restore_runtime_from_baseline"
+        ) as mock_restore:
+            advanced_dock_area.load_profile(profile_name)
+
+        mock_restore.assert_not_called()
+        assert advanced_dock_area._current_profile_name == profile_name
+
+    def test_load_profile_restores_baseline_without_dialog(self, advanced_dock_area):
+        """CLI loading can restore the runtime copy from baseline without confirmation."""
+        profile_name = "alignment_scan"
+        helper = profile_helper(advanced_dock_area)
+        helper.open_baseline(profile_name).sync()
+        helper.open_runtime(profile_name).sync()
+
+        with (
+            patch(
+                "bec_widgets.widgets.containers.dock_area.dock_area.RestoreProfileDialog.confirm"
+            ) as mock_confirm,
+            patch(
+                "bec_widgets.widgets.containers.dock_area.dock_area.restore_runtime_from_baseline"
+            ) as mock_restore,
+        ):
+            advanced_dock_area.load_profile(profile_name, restore_baseline=True)
+
+        mock_confirm.assert_not_called()
+        mock_restore.assert_called_once_with(
+            profile_name, namespace=advanced_dock_area.profile_namespace
+        )
+        assert advanced_dock_area._current_profile_name == profile_name
+
     def test_load_profile_materializes_runtime_namespace_fallback(self, advanced_dock_area):
         """Loading a runtime fallback copies it into the active namespace before opening."""
         profile_name = "load_runtime_namespace_fallback"

--- a/tests/unit_tests/test_dock_area.py
+++ b/tests/unit_tests/test_dock_area.py
@@ -1421,7 +1421,7 @@ class TestAdvancedDockAreaRestoreAndDialogs:
             patch.object(advanced_dock_area, "delete_all") as mock_delete_all,
             patch.object(advanced_dock_area, "load_profile") as mock_load_profile,
         ):
-            advanced_dock_area.restore_runtime_profile_from_baseline()
+            advanced_dock_area.restore_baseline_profile()
 
         assert mock_restore.call_count == 1
         args, kwargs = mock_restore.call_args
@@ -1455,16 +1455,41 @@ class TestAdvancedDockAreaRestoreAndDialogs:
         with patch(
             "bec_widgets.widgets.containers.dock_area.dock_area.restore_runtime_from_baseline"
         ) as mock_restore:
-            advanced_dock_area.restore_runtime_profile_from_baseline()
+            advanced_dock_area.restore_baseline_profile()
 
         mock_restore.assert_not_called()
+
+    def test_restore_runtime_profile_from_baseline_without_dialog(self, advanced_dock_area):
+        profile_name = "alignment_scan"
+        helper = profile_helper(advanced_dock_area)
+        helper.open_baseline(profile_name).sync()
+        helper.open_runtime(profile_name).sync()
+
+        with (
+            patch(
+                "bec_widgets.widgets.containers.dock_area.dock_area.RestoreProfileDialog.confirm"
+            ) as mock_confirm,
+            patch(
+                "bec_widgets.widgets.containers.dock_area.dock_area.restore_runtime_from_baseline"
+            ) as mock_restore,
+            patch.object(advanced_dock_area, "delete_all") as mock_delete_all,
+            patch.object(advanced_dock_area, "load_profile") as mock_load_profile,
+        ):
+            advanced_dock_area.restore_baseline_profile(profile_name, show_dialog=False)
+
+        mock_confirm.assert_not_called()
+        mock_restore.assert_called_once_with(
+            profile_name, namespace=advanced_dock_area.profile_namespace
+        )
+        mock_delete_all.assert_called_once()
+        mock_load_profile.assert_called_once_with(profile_name)
 
     def test_restore_runtime_profile_from_baseline_no_target(self, advanced_dock_area, monkeypatch):
         advanced_dock_area._current_profile_name = None
         with patch(
             "bec_widgets.widgets.containers.dock_area.dock_area.RestoreProfileDialog.confirm"
         ) as mock_confirm:
-            advanced_dock_area.restore_runtime_profile_from_baseline()
+            advanced_dock_area.restore_baseline_profile()
         mock_confirm.assert_not_called()
 
     def test_refresh_workspace_list_with_refresh_profiles(self, advanced_dock_area):


### PR DESCRIPTION
## Description

The ability to restore default profile was missing from RPC interface.


## How to test

- Make a profile
- Do some changes
- Try to restore from the CLI with/without dialog confirmation


## Merge Order

~~To avoid merge conflicts please lets merge after #1139 and after #1140~~ → done
