### PR TITLE
fix(dock-area): avoid switching profile when saving new profile

### DIFF
--- a/bec_widgets/widgets/containers/dock_area/dock_area.py
+++ b/bec_widgets/widgets/containers/dock_area/dock_area.py
@@ -235,11 +235,8 @@ class BECDockArea(DockAreaWidget):
     def _load_initial_profile(self, name: str) -> None:
         """Load the initial profile."""
         self.load_profile(name)
-        combo = self.toolbar.components.get_action("workspace_combo").widget
-        combo.blockSignals(True)
         if not self._empty_profile_active:
-            combo.setCurrentText(name)
-        combo.blockSignals(False)
+            self._set_workspace_combo_text_silent(name)
 
     def _start_empty_workspace(self) -> None:
         """
@@ -669,6 +666,14 @@ class BECDockArea(DockAreaWidget):
         combo = self.toolbar.components.get_action("workspace_combo").widget
         combo.refresh_profiles(active_profile=name)
 
+    def _set_workspace_combo_text_silent(self, text: str) -> None:
+        combo = self.toolbar.components.get_action("workspace_combo").widget
+        was_blocked = combo.blockSignals(True)
+        try:
+            combo.setCurrentText(text)
+        finally:
+            combo.blockSignals(was_blocked)
+
     def _enter_empty_profile_state(self) -> None:
         """
         Switch to the transient empty workspace state.
@@ -796,7 +801,6 @@ class BECDockArea(DockAreaWidget):
             self._pending_autosave_skip = (current_profile, name)
         else:
             self._pending_autosave_skip = None
-        workspace_combo.setCurrentText(name)
         self._finalize_profile_change(name, namespace)
 
     @SafeSlot()

--- a/bec_widgets/widgets/containers/dock_area/toolbar_components/workspace_actions.py
+++ b/bec_widgets/widgets/containers/dock_area/toolbar_components/workspace_actions.py
@@ -103,7 +103,6 @@ class ProfileComboBox(QComboBox):
             if index >= 0:
                 self.setCurrentIndex(index)
 
-        self.blockSignals(False)
         if active_profile and self.currentText() != active_profile:
             idx = self.findText(active_profile)
             if idx >= 0:
@@ -114,6 +113,7 @@ class ProfileComboBox(QComboBox):
             self.setToolTip("Active profile is not in quick select")
         else:
             self.setToolTip("")
+        self.blockSignals(False)
 
 
 def workspace_bundle(components: ToolbarComponents, enable_tools: bool = True) -> ToolbarBundle:

--- a/bec_widgets/widgets/containers/dock_area/toolbar_components/workspace_actions.py
+++ b/bec_widgets/widgets/containers/dock_area/toolbar_components/workspace_actions.py
@@ -24,19 +24,9 @@ class ProfileComboBox(QComboBox):
     def set_quick_profile_provider(self, provider: Callable[[], list[str]]) -> None:
         self._quick_provider = provider
 
-    def refresh_profiles(
-        self, active_profile: str | None = None, show_empty_profile: bool = False
+    def _refresh_profiles(
+        self, current_text: str, active_profile: str | None = None, show_empty_profile: bool = False
     ) -> None:
-        """
-        Refresh the profile list and ensure the active profile is visible.
-
-        Args:
-            active_profile(str | None): The currently active profile name.
-            show_empty_profile(bool): If True, show an explicit empty unsaved workspace entry.
-        """
-
-        current_text = active_profile or self.currentText()
-        self.blockSignals(True)
         self.clear()
 
         quick_profiles = self._quick_provider()
@@ -113,7 +103,24 @@ class ProfileComboBox(QComboBox):
             self.setToolTip("Active profile is not in quick select")
         else:
             self.setToolTip("")
-        self.blockSignals(False)
+
+    def refresh_profiles(
+        self, active_profile: str | None = None, show_empty_profile: bool = False
+    ) -> None:
+        """
+        Refresh the profile list and ensure the active profile is visible.
+
+        Args:
+            active_profile(str | None): The currently active profile name.
+            show_empty_profile(bool): If True, show an explicit empty unsaved workspace entry.
+        """
+
+        current_text = active_profile or self.currentText()
+        was_blocked = self.blockSignals(True)
+        try:
+            self._refresh_profiles(current_text, active_profile, show_empty_profile)
+        finally:
+            self.blockSignals(was_blocked)
 
 
 def workspace_bundle(components: ToolbarComponents, enable_tools: bool = True) -> ToolbarBundle:
@@ -122,6 +129,7 @@ def workspace_bundle(components: ToolbarComponents, enable_tools: bool = True) -
 
     Args:
         components (ToolbarComponents): The components to be added to the bundle.
+        enable_tools(bool): If True, show the workspace management tools; otherwise, only show the profile combo.
 
     Returns:
         ToolbarBundle: The workspace toolbar bundle.

--- a/tests/unit_tests/test_dock_area.py
+++ b/tests/unit_tests/test_dock_area.py
@@ -1863,9 +1863,14 @@ class TestWorkspaceProfileOperations:
         with patch(
             "bec_widgets.widgets.containers.dock_area.dock_area.SaveProfileDialog", StubDialog
         ):
-            advanced_dock_area.save_profile(show_dialog=True)
+            widgets_before_save = list(advanced_dock_area.widget_list())
+            with patch.object(advanced_dock_area, "load_profile") as mock_load_profile:
+                advanced_dock_area.save_profile(show_dialog=True)
+                qtbot.wait(100)
+                mock_load_profile.assert_not_called()
 
         qtbot.wait(500)
+        assert list(advanced_dock_area.widget_list()) == widgets_before_save
         source_manifest = read_manifest(helper.open_user(source_profile))
         new_manifest = read_manifest(helper.open_user(new_profile))
 


### PR DESCRIPTION
## Description

Fixes the logic mistake when saving new profile would recreate the profile because the text of the profile combobox changed. Clears delay and visual glitches on beamline consoles.


## How to test

- make profile in dock area
- save it with dialog or cli
- there should not be any visible glitch or recreation of the workspace
- dock_area.load_profile should not be called after saving profile

