### PR TITLE
fix(web_links): update documentation links in BECWebLinksMixin

### DIFF
--- a/bec_widgets/widgets/containers/main_window/addons/web_links.py
+++ b/bec_widgets/widgets/containers/main_window/addons/web_links.py
@@ -4,11 +4,7 @@ import webbrowser
 class BECWebLinksMixin:
     @staticmethod
     def open_bec_docs():
-        webbrowser.open("https://beamline-experiment-control.readthedocs.io/en/latest/")
-
-    @staticmethod
-    def open_bec_widgets_docs():
-        webbrowser.open("https://bec.readthedocs.io/projects/bec-widgets/en/latest/")
+        webbrowser.open("https://bec-project.github.io/bec_docs/")
 
     @staticmethod
     def open_bec_bug_report():

--- a/bec_widgets/widgets/containers/main_window/main_window.py
+++ b/bec_widgets/widgets/containers/main_window/main_window.py
@@ -355,17 +355,13 @@ class BECMainWindow(BECWidget, QMainWindow):
 
         bec_docs = QAction("BEC Docs", self)
         bec_docs.setIcon(help_icon)
-        widgets_docs = QAction("BEC Widgets Docs", self)
-        widgets_docs.setIcon(help_icon)
         bug_report = QAction("Bug Report", self)
         bug_report.setIcon(bug_icon)
 
         bec_docs.triggered.connect(BECWebLinksMixin.open_bec_docs)
-        widgets_docs.triggered.connect(BECWebLinksMixin.open_bec_widgets_docs)
         bug_report.triggered.connect(BECWebLinksMixin.open_bec_bug_report)
 
         help_menu.addAction(bec_docs)
-        help_menu.addAction(widgets_docs)
         help_menu.addAction(bug_report)
 
     ################################################################################

--- a/tests/unit_tests/test_main_widnow.py
+++ b/tests/unit_tests/test_main_widnow.py
@@ -247,12 +247,10 @@ def test_bec_weblinks(monkeypatch):
     monkeypatch.setattr(webbrowser, "open", fake_open)
 
     BECWebLinksMixin.open_bec_docs()
-    BECWebLinksMixin.open_bec_widgets_docs()
     BECWebLinksMixin.open_bec_bug_report()
 
     assert opened_urls == [
-        "https://beamline-experiment-control.readthedocs.io/en/latest/",
-        "https://bec.readthedocs.io/projects/bec-widgets/en/latest/",
+        "https://bec-project.github.io/bec_docs/",
         "https://github.com/bec-project/bec_widgets/issues",
     ]
 


### PR DESCRIPTION
## Description

Fixing the outdated link to BEC docs and removing the dedicated BW link. 

