### PR TITLE
test: fix available scans endpoint operation

### DIFF
--- a/tests/unit_tests/test_monaco_editor.py
+++ b/tests/unit_tests/test_monaco_editor.py
@@ -14,7 +14,9 @@ from .test_scan_control import available_scans_message
 @pytest.fixture
 def monaco_widget(qtbot, mocked_client):
     widget = MonacoWidget(client=mocked_client)
-    mocked_client.connector.set(MessageEndpoints.available_scans(), available_scans_message)
+    mocked_client.connector.set_and_publish(
+        MessageEndpoints.available_scans(), available_scans_message
+    )
     qtbot.addWidget(widget)
     qtbot.waitExposed(widget)
     yield widget
@@ -62,7 +64,9 @@ def test_monaco_widget_get_scan_control_code(monaco_widget: MonacoWidget, qtbot,
     """
     Test that the MonacoWidget can get scan control code from the dialog.
     """
-    mocked_client.connector.set(MessageEndpoints.available_scans(), available_scans_message)
+    mocked_client.connector.set_and_publish(
+        MessageEndpoints.available_scans(), available_scans_message
+    )
 
     scan_control_dialog = ScanControlDialog(client=mocked_client)
     qtbot.addWidget(scan_control_dialog)

--- a/tests/unit_tests/test_scan_control.py
+++ b/tests/unit_tests/test_scan_control.py
@@ -256,7 +256,9 @@ scan_history = ScanHistoryMessage(
 
 @pytest.fixture(scope="function")
 def scan_control(qtbot, mocked_client):  # , mock_dev):
-    mocked_client.connector.set(MessageEndpoints.available_scans(), available_scans_message)
+    mocked_client.connector.set_and_publish(
+        MessageEndpoints.available_scans(), available_scans_message
+    )
     mocked_client.connector.xadd(
         topic=MessageEndpoints.scan_history(), msg_dict={"data": scan_history}
     )


### PR DESCRIPTION
## Description

Minor change to the Monaco widget unit test to use `set_and_publish` instead of `set` for posting available scans. This is required due to the change in BEC, see https://github.com/bec-project/bec/pull/878


