### PR TITLE
feat: BL plugin menu in BECDockArea

### DIFF
--- a/bec_widgets/utils/bec_plugin_helper.py
+++ b/bec_widgets/utils/bec_plugin_helper.py
@@ -143,6 +143,15 @@ def get_plugin_designer_registry() -> dict[str, tuple[str, str]]:
     return {}
 
 
+@lru_cache
+def get_plugin_widget_icons() -> dict[str, str]:
+    """If there is a plugin repository installed, return the designer widget icon registry."""
+    designer_module = get_plugin_designer_module()
+    if designer_module and hasattr(designer_module, "widget_icons"):
+        return designer_module.widget_icons
+    return {}
+
+
 def get_all_plugin_widgets() -> BECClassContainer:
     """If there is a plugin repository installed, load all widgets from it."""
     if plugin := user_widget_plugin():

--- a/bec_widgets/widgets/containers/dock_area/dock_area.py
+++ b/bec_widgets/widgets/containers/dock_area/dock_area.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+from functools import lru_cache
 from typing import Literal, Mapping, Sequence
 
 import slugify
@@ -20,7 +21,12 @@ from qtpy.QtWidgets import (
 import bec_widgets.widgets.containers.qt_ads as QtAds
 from bec_widgets import BECWidget, SafeProperty, SafeSlot
 from bec_widgets.cli.designer_plugins import widget_icons
+from bec_widgets.utils.bec_plugin_helper import (
+    get_plugin_rpc_widget_registry,
+    get_plugin_widget_icons,
+)
 from bec_widgets.utils.colors import apply_theme
+from bec_widgets.utils.plugin_utils import get_rpc_widget_registry
 from bec_widgets.utils.rpc_decorator import rpc_timeout
 from bec_widgets.utils.rpc_widget_handler import widget_handler
 from bec_widgets.utils.toolbars.actions import (
@@ -72,6 +78,19 @@ _PROFILE_NAMESPACE_UNSET = object()
 
 PROFILE_STATE_KEYS = {key: SETTINGS_KEYS[key] for key in ("geom", "state", "ads_state")}
 StartupProfile = Literal["restore", "skip"] | str | None
+
+
+@lru_cache
+def _plugin_toolbar_actions() -> dict[str, tuple[str, str, str]]:
+    plugin_registry = get_plugin_rpc_widget_registry()
+    internal_registry = get_rpc_widget_registry()
+    plugin_icons = get_plugin_widget_icons()
+
+    return {
+        widget_name: (plugin_icons.get(widget_name, "widgets"), f"Add {widget_name}", widget_name)
+        for widget_name in sorted(plugin_registry)
+        if widget_name not in internal_registry
+    }
 
 
 class BECDockArea(DockAreaWidget):
@@ -390,6 +409,10 @@ class BECDockArea(DockAreaWidget):
         _build_menu("menu_devices", "Add Device Control ", device_actions)
         _build_menu("menu_utils", "Add Utils ", util_actions)
 
+        plugin_actions = _plugin_toolbar_actions()
+        if plugin_actions:
+            _build_menu("menu_plugins", "Add Plugins ", plugin_actions)
+
         # Create flat toolbar bundles for each widget type
         def _build_flat_bundles(category: str, mapping: dict[str, tuple[str, str, str]]):
             bundle = ToolbarBundle(f"flat_{category}", self.toolbar.components)
@@ -460,14 +483,16 @@ class BECDockArea(DockAreaWidget):
         bda.add_action("dark_mode")
         self.toolbar.add_bundle(bda)
 
-        self._apply_toolbar_layout()
-
-        # Store mappings on self for use in _hook_toolbar
+        # Store mappings on self for use in _hook_toolbar and _apply_toolbar_layout
         self._ACTION_MAPPINGS = {
             "menu_plots": plot_actions,
             "menu_devices": device_actions,
             "menu_utils": util_actions,
         }
+        if plugin_actions:
+            self._ACTION_MAPPINGS["menu_plugins"] = plugin_actions
+
+        self._apply_toolbar_layout()
 
     def _hook_toolbar(self):
         def _connect_menu(menu_key: str):
@@ -476,7 +501,8 @@ class BECDockArea(DockAreaWidget):
 
             # first two items not needed for this part
             for key, (_, _, widget_type) in mapping.items():
-                act = menu.actions[key].action
+                toolbar_action = menu.actions[key]
+                act = toolbar_action.action
                 if key == "terminal":
                     act.triggered.connect(
                         lambda _, t=widget_type: self.new(widget=t, closable=True, startup_cmd=None)
@@ -487,12 +513,18 @@ class BECDockArea(DockAreaWidget):
                             widget=t, closable=True, show_settings_action=False
                         )
                     )
+                elif menu_key == "menu_plugins":
+                    act.triggered.connect(
+                        lambda _, t=widget_type, a=toolbar_action: self._new_plugin_widget(t, a)
+                    )
                 else:
                     act.triggered.connect(lambda _, t=widget_type: self.new(widget=t))
 
         _connect_menu("menu_plots")
         _connect_menu("menu_devices")
         _connect_menu("menu_utils")
+        if "menu_plugins" in self._ACTION_MAPPINGS:
+            _connect_menu("menu_plugins")
 
         def _connect_flat_actions(mapping: dict[str, tuple[str, str, str]]):
             for action_id, (_, _, widget_type) in mapping.items():
@@ -506,6 +538,10 @@ class BECDockArea(DockAreaWidget):
 
         self.toolbar.components.get_action("attach_all").action.triggered.connect(self.attach_all)
         self.toolbar.components.get_action("screenshot").action.triggered.connect(self.screenshot)
+
+    def _new_plugin_widget(self, widget_type: str, toolbar_action: MaterialIconAction) -> None:
+        # Created as helper method for simple tests
+        self.new(widget=widget_type, dock_icon=toolbar_action.get_icon())
 
     def _set_editable(self, editable: bool) -> None:
         self.workspace_is_locked = not editable
@@ -1108,14 +1144,10 @@ class BECDockArea(DockAreaWidget):
         if mode_key == "user":
             bundles = ["spacer_bundle", "workspace", "dock_actions"]
         elif mode_key == "creator":
-            bundles = [
-                "menu_plots",
-                "menu_devices",
-                "menu_utils",
-                "spacer_bundle",
-                "workspace",
-                "dock_actions",
-            ]
+            bundles = ["menu_plots", "menu_devices", "menu_utils"]
+            if "menu_plugins" in getattr(self, "_ACTION_MAPPINGS", {}):
+                bundles.append("menu_plugins")
+            bundles += ["spacer_bundle", "workspace", "dock_actions"]
         elif mode_key == "plot":
             bundles = ["flat_plots", "spacer_bundle", "workspace", "dock_actions"]
         elif mode_key == "device":

--- a/tests/unit_tests/test_bec_plugin_helper.py
+++ b/tests/unit_tests/test_bec_plugin_helper.py
@@ -2,7 +2,10 @@ from importlib.machinery import FileFinder, SourceFileLoader
 from types import ModuleType
 from unittest import mock
 
-from bec_widgets.utils.bec_plugin_helper import _all_widgets_from_all_submods
+from bec_widgets.utils.bec_plugin_helper import (
+    _all_widgets_from_all_submods,
+    get_plugin_widget_icons,
+)
 from bec_widgets.utils.bec_widget import BECWidget
 from bec_widgets.utils.plugin_utils import BECClassContainer, BECClassInfo
 
@@ -69,3 +72,29 @@ def test_all_widgets_from_module_no_widgets():
         widgets = _all_widgets_from_all_submods(module).as_dict()
 
     assert widgets == {}
+
+
+def test_get_plugin_widget_icons_from_designer_module():
+    designer_module = mock.MagicMock(spec=ModuleType)
+    designer_module.widget_icons = {"PluginWidget": "star"}
+
+    get_plugin_widget_icons.cache_clear()
+    try:
+        with mock.patch(
+            "bec_widgets.utils.bec_plugin_helper.get_plugin_designer_module",
+            return_value=designer_module,
+        ):
+            assert get_plugin_widget_icons() == {"PluginWidget": "star"}
+    finally:
+        get_plugin_widget_icons.cache_clear()
+
+
+def test_get_plugin_widget_icons_without_designer_module():
+    get_plugin_widget_icons.cache_clear()
+    try:
+        with mock.patch(
+            "bec_widgets.utils.bec_plugin_helper.get_plugin_designer_module", return_value=None
+        ):
+            assert get_plugin_widget_icons() == {}
+    finally:
+        get_plugin_widget_icons.cache_clear()

--- a/tests/unit_tests/test_dock_area.py
+++ b/tests/unit_tests/test_dock_area.py
@@ -11,6 +11,7 @@ from qtpy.QtGui import QPixmap
 from qtpy.QtWidgets import QDialog, QMessageBox, QWidget
 
 import bec_widgets.widgets.containers.dock_area.basic_dock_area as basic_dock_module
+import bec_widgets.widgets.containers.dock_area.dock_area as dock_area_module
 import bec_widgets.widgets.containers.dock_area.profile_utils as profile_utils
 from bec_widgets.widgets.containers.dock_area.basic_dock_area import (
     DockAreaWidget,
@@ -66,6 +67,13 @@ def isolate_profile_storage(tmp_path, monkeypatch):
 def temp_profile_dir():
     """Return the current temporary profile directory."""
     return os.environ["BECWIDGETS_PROFILE_DIR"]
+
+
+@pytest.fixture
+def clear_plugin_toolbar_actions_cache():
+    dock_area_module._plugin_toolbar_actions.cache_clear()
+    yield
+    dock_area_module._plugin_toolbar_actions.cache_clear()
 
 
 @pytest.fixture
@@ -984,6 +992,64 @@ class TestToolbarFunctionality:
 
                 # Verify save was called with the filename
                 mock_screenshot.save.assert_called_once_with(str(screenshot_path))
+
+    def test_plugin_toolbar_actions_empty_when_no_plugins(self, clear_plugin_toolbar_actions_cache):
+        """Test that no plugin toolbar actions are produced when no plugin widgets exist."""
+        with patch(
+            "bec_widgets.widgets.containers.dock_area.dock_area.get_plugin_rpc_widget_registry",
+            return_value={},
+        ):
+            plugin_actions = dock_area_module._plugin_toolbar_actions()
+
+        assert plugin_actions == {}
+
+    def test_plugin_toolbar_actions_include_available_plugins(
+        self, clear_plugin_toolbar_actions_cache
+    ):
+        """Test that plugin toolbar actions are built from RPC widgets and generated icons."""
+        plugin_registry = {
+            "FakePluginWidget": ("fake_plugin.widgets.fake_plugin_widget", "FakePluginWidget")
+        }
+        with (
+            patch(
+                "bec_widgets.widgets.containers.dock_area.dock_area.get_plugin_rpc_widget_registry",
+                return_value=plugin_registry,
+            ),
+            patch(
+                "bec_widgets.widgets.containers.dock_area.dock_area.get_plugin_widget_icons",
+                return_value={"FakePluginWidget": "star"},
+            ),
+        ):
+            plugin_actions = dock_area_module._plugin_toolbar_actions()
+
+        assert plugin_actions == {
+            "FakePluginWidget": ("star", "Add FakePluginWidget", "FakePluginWidget")
+        }
+
+    def test_plugin_toolbar_actions_ignore_builtin_name_collisions(
+        self, clear_plugin_toolbar_actions_cache
+    ):
+        """Test that plugin widgets shadowed by built-ins are not added to the plugin menu."""
+        plugin_registry = {"Waveform": ("fake_plugin.widgets.waveform", "Waveform")}
+        with patch(
+            "bec_widgets.widgets.containers.dock_area.dock_area.get_plugin_rpc_widget_registry",
+            return_value=plugin_registry,
+        ):
+            plugin_actions = dock_area_module._plugin_toolbar_actions()
+
+        assert plugin_actions == {}
+
+    def test_new_plugin_widget_passes_toolbar_icon_to_new(self):
+        """Test that plugin widget creation passes the toolbar icon to dock creation."""
+        dock_area = MagicMock()
+        toolbar_action = MagicMock()
+        dock_icon = object()
+        toolbar_action.get_icon.return_value = dock_icon
+
+        BECDockArea._new_plugin_widget(dock_area, "FakePluginWidget", toolbar_action)
+
+        toolbar_action.get_icon.assert_called_once_with()
+        dock_area.new.assert_called_once_with(widget="FakePluginWidget", dock_icon=dock_icon)
 
 
 class TestDockSettingsDialog:


### PR DESCRIPTION
## Description

Added new menu in BECDockArea which allows adding widgets from the menu during runtime.

## Related Issues

- closes #1142

## Type of Change

- New menu based on the plugin repo

## How to test

- Have some plugin repo installed
- Use `BECDockArea`
- Add plugin widget with the menu
- uninstall plugin repo
- relaunch `BECDockArea` and see no plugin menu


## Screenshot

<img width="1280" height="194" alt="image" src="https://github.com/user-attachments/assets/024411d3-c6fd-4abc-b594-95edbc19702b" />


## Side Effect

The icons are correct ONLY for the widgets which are generated with `PLUGIN=True` since icons are fetched from `designer_plugins.py`.  Probably icon dict should be moved to `client.py` and fetched from there.  Created issue #1149.


