### PR TITLE
fix: use .show instead of .start

### DIFF
--- a/bec_widgets/cli/client_utils.py
+++ b/bec_widgets/cli/client_utils.py
@@ -358,7 +358,7 @@ class BECGuiClient(RPCBase):
             )
 
         if not self._check_if_server_is_alive():
-            self.start(wait=True)
+            self.show(wait=True)
         if wait:
             with wait_for_server(self):
                 return self._new_impl(

--- a/bec_widgets/cli/client_utils.py
+++ b/bec_widgets/cli/client_utils.py
@@ -550,7 +550,7 @@ class BECGuiClient(RPCBase):
         if self.launcher and len(self._top_level) == 0:
             self.launcher._run_rpc("show")  # pylint: disable=protected-access
         for window in self._top_level.values():
-            window.show()
+            window.raise_window()
 
     def _show_all(self):
         with wait_for_server(self):
@@ -569,7 +569,7 @@ class BECGuiClient(RPCBase):
         if self.launcher and len(self._top_level) == 0:
             self.launcher._run_rpc("raise")  # pylint: disable=protected-access
         for window in self._top_level.values():
-            window._run_rpc("raise")  # type: ignore[attr-defined]
+            window.raise_window()
 
     def _raise_all(self):
         with wait_for_server(self):

--- a/bec_widgets/cli/rpc/rpc_base.py
+++ b/bec_widgets/cli/rpc/rpc_base.py
@@ -207,6 +207,10 @@ class RPCBase:
         # Use explicit call to ensure action name is 'raise' (not 'raise_')
         return self._run_rpc("raise")
 
+    def hide(self):
+        """Hide this widget (or its container)."""
+        return self._run_rpc("hide")
+
     def _run_rpc(
         self,
         method,

--- a/tests/end-2-end/conftest.py
+++ b/tests/end-2-end/conftest.py
@@ -45,7 +45,7 @@ def connected_client_gui_obj(qtbot, gui_id, bec_client_lib):
     """
     gui = BECGuiClient(gui_id=gui_id)
     try:
-        gui.start(wait=True)
+        gui.show(wait=True)
         qtbot.waitUntil(lambda: hasattr(gui, "bec"), timeout=5000)
         gui.bec.delete_all()  # ensure clean state
         qtbot.waitUntil(lambda: len(gui.bec.widget_list()) == 0, timeout=10000)

--- a/tests/end-2-end/test_bec_dock_rpc_e2e.py
+++ b/tests/end-2-end/test_bec_dock_rpc_e2e.py
@@ -143,11 +143,11 @@ def test_rpc_gui_obj(connected_client_gui_obj: BECGuiClient, qtbot):
     qtbot.wait(500)
     gui.kill_server()
     assert not gui._gui_is_alive()
-    gui.start(wait=True)
+    gui.show(wait=True)
     assert gui._gui_is_alive()
-    # calling start multiple times should not change anything
-    gui.start(wait=True)
-    gui.start(wait=True)
+    # calling show multiple times should not change anything
+    gui.show(wait=True)
+    gui.show(wait=True)
 
     def wait_for_gui_started():
         return "bec" in gui.windows

--- a/tests/end-2-end/user_interaction/conftest.py
+++ b/tests/end-2-end/user_interaction/conftest.py
@@ -75,7 +75,7 @@ def connected_client_gui_obj(qtbot_scope_module, gui_id, bec_client_lib):
     """
     gui = BECGuiClient(gui_id=gui_id)
     try:
-        gui.start(wait=True)
+        gui.show(wait=True)
         qtbot_scope_module.waitUntil(lambda: hasattr(gui, "bec"), timeout=5000)
         gui.bec.delete_all()  # ensure clean state
         qtbot_scope_module.waitUntil(lambda: len(gui.bec.widget_list()) == 0, timeout=10000)

--- a/tests/unit_tests/test_client_utils.py
+++ b/tests/unit_tests/test_client_utils.py
@@ -220,7 +220,7 @@ def test_client_utils_new_starts_server_when_not_alive():
         with mock.patch("bec_widgets.cli.client_utils.wait_for_server", _no_wait_for_server):
             with (
                 mock.patch.object(gui, "_check_if_server_is_alive", return_value=False),
-                mock.patch.object(gui, "start") as mock_start,
+                mock.patch.object(gui, "show") as mock_start,
             ):
                 gui.new(wait=False, startup_profile=None)
 


### PR DESCRIPTION
## Description

This PR replaces the already deprecated .start method by .show. We should not use deprecated methods internally ;)

## Definition of Done
- [ ] Documentation is up-to-date.

