### PR TITLE
Fix/device input no queued connection

### DIFF
--- a/bec_widgets/widgets/control/device_input/device_combobox/device_combobox.py
+++ b/bec_widgets/widgets/control/device_input/device_combobox/device_combobox.py
@@ -489,14 +489,17 @@ class DeviceComboBox(BECWidget, QComboBox):
             action: Device update action emitted by BEC.
             content: Device update payload. Currently unused.
         """
+        if self._callback_id is None or getattr(self, "_destroyed", False):
+            return
         if action in ["add", "remove", "reload"]:
             self.device_config_update.emit()
 
     def cleanup(self):
         """Cleanup the widget."""
         if self._callback_id is not None:
-            self.bec_dispatcher.client.callbacks.remove(self._callback_id)
+            callback_id = self._callback_id
             self._callback_id = None
+            self.bec_dispatcher.client.callbacks.remove(callback_id)
         super().cleanup()
 
     def get_current_device(self) -> object:

--- a/bec_widgets/widgets/control/device_input/device_combobox/device_combobox.py
+++ b/bec_widgets/widgets/control/device_input/device_combobox/device_combobox.py
@@ -496,6 +496,7 @@ class DeviceComboBox(BECWidget, QComboBox):
         """Cleanup the widget."""
         if self._callback_id is not None:
             self.bec_dispatcher.client.callbacks.remove(self._callback_id)
+            self._callback_id = None
         super().cleanup()
 
     def get_current_device(self) -> object:

--- a/bec_widgets/widgets/control/device_input/signal_combobox/signal_combobox.py
+++ b/bec_widgets/widgets/control/device_input/signal_combobox/signal_combobox.py
@@ -588,7 +588,9 @@ class SignalComboBox(BECWidget, QComboBox):
 
     def cleanup(self):
         """Cleanup the widget."""
-        self.bec_dispatcher.client.callbacks.remove(self._device_update_register)
+        if self._device_update_register is not None:
+            self.bec_dispatcher.client.callbacks.remove(self._device_update_register)
+            self._device_update_register = None
         super().cleanup()
 
     @staticmethod

--- a/bec_widgets/widgets/control/device_input/signal_combobox/signal_combobox.py
+++ b/bec_widgets/widgets/control/device_input/signal_combobox/signal_combobox.py
@@ -197,16 +197,21 @@ class SignalComboBox(BECWidget, QComboBox):
         self.update_signals_from_filters()
 
     @SafeSlot()
-    @SafeSlot(dict, dict)
-    def update_signals_from_filters(
-        self, content: dict | None = None, metadata: dict | None = None
-    ):
+    @SafeSlot(str, dict)
+    def update_signals_from_filters(self, action: str | None = None, content: dict | None = None):
         """Refresh available signals from the current device and filters.
 
         Args:
+            action: Optional BEC device update action. If provided, only device list changing
+                actions trigger a refresh.
             content: Optional callback payload from BEC device updates. Currently unused.
-            metadata: Optional callback metadata from BEC device updates. Currently unused.
         """
+        if self._device_update_register is None or getattr(self, "_destroyed", False):
+            return
+
+        if action is not None and action not in ["add", "remove", "reload"]:
+            return
+
         self.config.signal_filter = [kind.name for kind in self.signal_filter]
 
         if self._signal_class_filter:

--- a/bec_widgets/widgets/control/device_input/signal_combobox/signal_combobox.py
+++ b/bec_widgets/widgets/control/device_input/signal_combobox/signal_combobox.py
@@ -594,8 +594,9 @@ class SignalComboBox(BECWidget, QComboBox):
     def cleanup(self):
         """Cleanup the widget."""
         if self._device_update_register is not None:
-            self.bec_dispatcher.client.callbacks.remove(self._device_update_register)
+            callback_id = self._device_update_register
             self._device_update_register = None
+            self.bec_dispatcher.client.callbacks.remove(callback_id)
         super().cleanup()
 
     @staticmethod

--- a/tests/unit_tests/test_device_input_widgets.py
+++ b/tests/unit_tests/test_device_input_widgets.py
@@ -139,6 +139,23 @@ def test_device_input_combobox_cleanup_unregisters_callback(qtbot, mocked_client
         assert widget._callback_id is None
 
 
+def test_device_input_combobox_cleanup_clears_callback_before_unregister(qtbot, mocked_client):
+    widget = DeviceComboBox(client=mocked_client)
+    qtbot.addWidget(widget)
+    callback_id = widget._callback_id
+
+    def assert_callback_cleared(removed_callback_id):
+        assert removed_callback_id == callback_id
+        assert widget._callback_id is None
+
+    with mock.patch.object(
+        mocked_client.callbacks, "remove", side_effect=assert_callback_cleared
+    ) as remove_mock:
+        widget.cleanup()
+
+    remove_mock.assert_called_once_with(callback_id)
+
+
 def test_get_device_from_input_combobox_init(device_input_combobox):
     device_input_combobox.setCurrentIndex(0)
     device_text = device_input_combobox.currentText()

--- a/tests/unit_tests/test_device_input_widgets.py
+++ b/tests/unit_tests/test_device_input_widgets.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import pytest
 from bec_lib.device import ReadoutPriority
 
@@ -122,6 +124,19 @@ def test_device_input_combobox_disabled_invalid_has_neutral_border(device_input_
 
     device_input_combobox.setEnabled(True)
     assert "red" in device_input_combobox.styleSheet()
+
+
+def test_device_input_combobox_cleanup_unregisters_callback(qtbot, mocked_client):
+    with mock.patch.object(mocked_client.callbacks, "remove"):
+        widget = DeviceComboBox(client=mocked_client)
+        qtbot.addWidget(widget)
+        callback_id = widget._callback_id
+
+        widget.close()
+        widget.deleteLater()
+
+        mocked_client.callbacks.remove.assert_called_once_with(callback_id)
+        assert widget._callback_id is None
 
 
 def test_get_device_from_input_combobox_init(device_input_combobox):

--- a/tests/unit_tests/test_device_signal_input.py
+++ b/tests/unit_tests/test_device_signal_input.py
@@ -188,10 +188,12 @@ def test_linked_device_combobox_updates_signal_combobox_on_each_text_change(
 def test_device_signal_input_base_cleanup(qtbot, mocked_client):
     with mock.patch.object(mocked_client.callbacks, "remove"):
         widget = SignalComboBox(client=mocked_client)
+        callback_id = widget._device_update_register
         widget.close()
         widget.deleteLater()
 
-        mocked_client.callbacks.remove.assert_called_once_with(widget._device_update_register)
+        mocked_client.callbacks.remove.assert_called_once_with(callback_id)
+        assert widget._device_update_register is None
 
 
 def test_signal_combobox_get_signal_name_with_item_data(qtbot, device_signal_combobox):

--- a/tests/unit_tests/test_device_signal_input.py
+++ b/tests/unit_tests/test_device_signal_input.py
@@ -196,6 +196,15 @@ def test_device_signal_input_base_cleanup(qtbot, mocked_client):
         assert widget._device_update_register is None
 
 
+def test_signal_combobox_device_update_ignores_update_action(qtbot, mocked_client):
+    widget = create_widget(qtbot=qtbot, widget=SignalComboBox, client=mocked_client)
+
+    with mock.patch.object(widget, "_set_signal_groups") as set_signal_groups:
+        widget.update_signals_from_filters("update", {})
+
+    set_signal_groups.assert_not_called()
+
+
 def test_signal_combobox_get_signal_name_with_item_data(qtbot, device_signal_combobox):
     """Test get_signal_name returns obj_name from item data when available."""
     device_signal_combobox.include_normal_signals = True

--- a/tests/unit_tests/test_device_signal_input.py
+++ b/tests/unit_tests/test_device_signal_input.py
@@ -196,6 +196,41 @@ def test_device_signal_input_base_cleanup(qtbot, mocked_client):
         assert widget._device_update_register is None
 
 
+def test_signal_combobox_cleanup_clears_callback_before_unregister(qtbot, mocked_client):
+    widget = create_widget(qtbot=qtbot, widget=SignalComboBox, client=mocked_client)
+    callback_id = widget._device_update_register
+
+    def assert_callback_cleared(removed_callback_id):
+        assert removed_callback_id == callback_id
+        assert widget._device_update_register is None
+
+    with mock.patch.object(
+        mocked_client.callbacks, "remove", side_effect=assert_callback_cleared
+    ) as remove_mock:
+        widget.cleanup()
+
+    remove_mock.assert_called_once_with(callback_id)
+
+
+def test_signal_combobox_cleanup_blocks_in_flight_device_update(qtbot, mocked_client):
+    widget = create_widget(qtbot=qtbot, widget=SignalComboBox, client=mocked_client)
+    callback_id = widget._device_update_register
+
+    def trigger_in_flight_update(_):
+        widget.update_signals_from_filters("reload", {})
+
+    with (
+        mock.patch.object(
+            mocked_client.callbacks, "remove", side_effect=trigger_in_flight_update
+        ) as remove_mock,
+        mock.patch.object(widget, "_set_signal_groups") as set_signal_groups,
+    ):
+        widget.cleanup()
+
+    remove_mock.assert_called_once_with(callback_id)
+    set_signal_groups.assert_not_called()
+
+
 def test_signal_combobox_device_update_ignores_update_action(qtbot, mocked_client):
     widget = create_widget(qtbot=qtbot, widget=SignalComboBox, client=mocked_client)
 


### PR DESCRIPTION
## Description

Fixes severe bug when device input widgets were not correctly unsubscribing to callback from redis connector. Was creating lot of issues with CSAXS XrayEye gui. Was tested with https://gitea.psi.ch/bec/csaxs_bec/pulls/208 at csaxs cons 02 with their flomni workflow.
