### PR TITLE
Fix/async in waveform

### DIFF
--- a/bec_widgets/tests/utils.py
+++ b/bec_widgets/tests/utils.py
@@ -11,7 +11,13 @@ from bec_lib.devicemanager import DeviceContainer
 class FakeDevice(BECDevice):
     """Fake minimal positioner class for testing."""
 
-    def __init__(self, name, enabled=True, readout_priority=ReadoutPriority.MONITORED):
+    def __init__(
+        self,
+        name,
+        enabled=True,
+        readout_priority=ReadoutPriority.MONITORED,
+        signal_class: str | None = None,
+    ):
         super().__init__(name=name)
         self._enabled = enabled
         self.signals = {self.name: {"value": 1.0}}
@@ -26,13 +32,15 @@ class FakeDevice(BECDevice):
             "readOnly": False,
             "name": self.name,
         }
+        if signal_class is None:
+            signal_class = "AsyncSignal" if readout_priority == ReadoutPriority.ASYNC else "Signal"
         self._info = {
             "signals": {
                 self.name: {
                     "kind_str": "hinted",
                     "component_name": self.name,
                     "obj_name": self.name,
-                    "signal_class": "Signal",
+                    "signal_class": signal_class,
                 }
             }
         }

--- a/bec_widgets/utils/signal_classification.py
+++ b/bec_widgets/utils/signal_classification.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from bec_lib.device import DeviceBase
+
+ASYNC_SIGNAL_CLASSES = frozenset({"AsyncSignal", "AsyncMultiSignal", "DynamicSignal"})
+_NON_CURVE_ROLES = frozenset({"preview", "diagnostic", "file_event", "progress"})
+
+
+class SignalCategory(str, Enum):
+    """Data-delivery category of a signal."""
+
+    SYNC = "sync"
+    ASYNC = "async"
+    UNKNOWN = "unknown"
+
+
+def classify_signal_info(signal_info: dict[str, Any] | None) -> SignalCategory:
+    """
+    Classify a serialized signal-info dict (one entry of
+    ``device._info["signals"]``).
+
+    Args:
+        signal_info: The serialized signal info, or None.
+
+    Returns:
+        SignalCategory: ASYNC for the DynamicSignal family (including
+        subclasses detected via the embedded ``signal_info`` block), SYNC for
+        all other concrete signal classes, UNKNOWN when no decision is
+        possible.
+    """
+    if not isinstance(signal_info, dict) or not signal_info:
+        return SignalCategory.UNKNOWN
+
+    signal_class = signal_info.get("signal_class")
+    if signal_class in ASYNC_SIGNAL_CLASSES:
+        return SignalCategory.ASYNC
+
+    describe = signal_info.get("describe")
+    embedded = describe.get("signal_info") if isinstance(describe, dict) else None
+    if isinstance(embedded, dict):
+        role = embedded.get("role", "main")
+        if role in _NON_CURVE_ROLES:
+            return SignalCategory.UNKNOWN
+        return SignalCategory.ASYNC
+
+    if signal_class:
+        return SignalCategory.SYNC
+
+    return SignalCategory.UNKNOWN
+
+
+def classify_device_signal(device: DeviceBase | None, entry: str) -> SignalCategory:
+    """
+    Classify a signal of a device by its serialized info.
+
+    Args:
+        device: The client device (``bec_lib.device.DeviceBase``) from the device
+            manager, or None (e.g. history data whose device no longer exists).
+        entry: The signal entry name (component name used in curve configs).
+
+    Returns:
+        SignalCategory: The category, UNKNOWN when the device or entry cannot
+        be resolved.
+    """
+    if device is None or not entry:
+        return SignalCategory.UNKNOWN
+    info = getattr(device, "_info", None)
+    if not isinstance(info, dict):
+        return SignalCategory.UNKNOWN
+    signals = info.get("signals")
+    if not isinstance(signals, dict):
+        return SignalCategory.UNKNOWN
+
+    signal_info = signals.get(entry)
+    if signal_info is None:
+        for candidate in signals.values():
+            if isinstance(candidate, dict) and candidate.get("obj_name") == entry:
+                signal_info = candidate
+                break
+    return classify_signal_info(signal_info)

--- a/bec_widgets/widgets/plots/waveform/waveform.py
+++ b/bec_widgets/widgets/plots/waveform/waveform.py
@@ -33,6 +33,7 @@ from bec_widgets.utils.container_utils import WidgetContainerUtils
 from bec_widgets.utils.error_popups import SafeProperty, SafeSlot
 from bec_widgets.utils.settings_dialog import SettingsDialog
 from bec_widgets.utils.side_panel import SidePanel
+from bec_widgets.utils.signal_classification import SignalCategory, classify_device_signal
 from bec_widgets.utils.toolbars.bundles import ToolbarBundle
 from bec_widgets.utils.toolbars.toolbar import MaterialIconAction
 from bec_widgets.widgets.dap.lmfit_dialog.lmfit_dialog import LMFitDialog
@@ -2308,21 +2309,26 @@ class Waveform(PlotBase):
         readout_priority_async = self._ensure_str_list(readout_priority.get("async", []))
         readout_priority_sync = self._ensure_str_list(readout_priority.get("monitored", []))
 
-        # Iterate over all curves
         for curve in self.curves:
             if curve.config.source != "device":
                 continue
             dev_name = curve.config.signal.device
-            if dev_name in readout_priority_async:
+            entry = curve.config.signal.signal
+            category = classify_device_signal(self.dev.get(dev_name), entry)
+            if category == SignalCategory.ASYNC or dev_name in readout_priority_async:
                 self._async_curves.append(curve)
                 if hasattr(self.scan_item, "live_data"):
                     self._setup_async_curve(curve)
                 found_async = True
-            elif dev_name in readout_priority_sync:
+            elif category == SignalCategory.SYNC or dev_name in readout_priority_sync:
                 self._sync_curves.append(curve)
                 found_sync = True
             else:
-                logger.warning("Device {dev_name} not found in readout priority list.")
+                logger.warning(
+                    f"Cannot classify signal {dev_name}.{entry}: no signal info and "
+                    "device not found in readout priority list."
+                )
+                continue
         # Determine the mode of the scan
         if found_async and found_sync:
             mode = "mixed"

--- a/bec_widgets/widgets/plots/waveform/waveform.py
+++ b/bec_widgets/widgets/plots/waveform/waveform.py
@@ -33,7 +33,11 @@ from bec_widgets.utils.container_utils import WidgetContainerUtils
 from bec_widgets.utils.error_popups import SafeProperty, SafeSlot
 from bec_widgets.utils.settings_dialog import SettingsDialog
 from bec_widgets.utils.side_panel import SidePanel
-from bec_widgets.utils.signal_classification import SignalCategory, classify_device_signal
+from bec_widgets.utils.signal_classification import (
+    ASYNC_SIGNAL_CLASSES,
+    SignalCategory,
+    classify_device_signal,
+)
 from bec_widgets.utils.toolbars.bundles import ToolbarBundle
 from bec_widgets.utils.toolbars.toolbar import MaterialIconAction
 from bec_widgets.widgets.dap.lmfit_dialog.lmfit_dialog import LMFitDialog
@@ -1745,9 +1749,7 @@ class Waveform(PlotBase):
             tuple[bool, str]: A tuple where the first element is True if the async signal is found (False otherwise),
                 and the second element is the signal name (either the original signal or the storage_name for AsyncMultiSignal).
         """
-        bec_async_signals = self.client.device_manager.get_bec_signals(
-            ["AsyncSignal", "AsyncMultiSignal"]
-        )
+        bec_async_signals = self.client.device_manager.get_bec_signals(sorted(ASYNC_SIGNAL_CLASSES))
         for signal_name, _, entry_data in bec_async_signals:
             if signal_name == name and entry_data.get("obj_name") == signal:
                 return True, entry_data.get("storage_name")

--- a/bec_widgets/widgets/plots/waveform/waveform.py
+++ b/bec_widgets/widgets/plots/waveform/waveform.py
@@ -1781,10 +1781,15 @@ class Waveform(PlotBase):
             stream_key = (name, stream)  # AsyncMultiSignal sub-signals share `stream`
             new_endpoint = MessageEndpoints.device_async_signal(self.scan_id, name, stream)
             old_endpoint = MessageEndpoints.device_async_signal(self.old_scan_id, name, stream)
+            legacy_endpoint = False
         else:
+            # No BEC async signal (AsyncSignal/AsyncMultiSignal/DynamicSignal) was found
+            # for this curve, so it must be served by the deprecated per-device
+            # device_async_readback endpoint.
             stream_key = (name, None)  # old endpoint is keyed by device only
             new_endpoint = MessageEndpoints.device_async_readback(self.scan_id, name)
             old_endpoint = MessageEndpoints.device_async_readback(self.old_scan_id, name)
+            legacy_endpoint = True
 
         endpoint_str = getattr(new_endpoint, "endpoint", new_endpoint)
 
@@ -1797,6 +1802,16 @@ class Waveform(PlotBase):
                 f"'{endpoint_str}'; reusing it instead of subscribing again."
             )
             return
+
+        # TODO implement deprecation warning when simulations are migrated
+        # if legacy_endpoint:
+        #     logger.warning(
+        #         f"Deprecated async endpoint in use: device '{name}' provides async data via the "
+        #         f"legacy 'device_async_readback' endpoint ('{endpoint_str}'). Migrate the device "
+        #         "to an AsyncSignal/AsyncMultiSignal/DynamicSignal so it publishes on the "
+        #         "'device_async_signal' endpoint; support for 'device_async_readback' in the "
+        #         "waveform widget will be removed in a future release."
+        #     )
 
         self._async_streams_setup[stream_key] = [signal]
         self.bec_dispatcher.disconnect_slot(self.on_async_readback, old_endpoint)

--- a/bec_widgets/widgets/plots/waveform/waveform.py
+++ b/bec_widgets/widgets/plots/waveform/waveform.py
@@ -152,7 +152,6 @@ class Waveform(PlotBase):
         self.old_scan_id = None
         self.scan_id = None
         self.scan_item = None
-        self.readout_priority = None
         self.x_axis_mode = {
             "name": "auto",
             "entry": None,
@@ -1590,19 +1589,19 @@ class Waveform(PlotBase):
             self._update_curve_visibility()
             self._mode = self._categorise_device_curves()
 
-            # First trigger to sync and async data
+            # First trigger to sync and async data. Async curve subscriptions
+            # were already set up by _categorise_device_curves above (it calls
+            # _setup_async_curve per async curve for live scans); repeating it
+            # here cleared each curve's data a second time and re-attempted
+            # the stream registration for every new scan.
             if self._mode == "sync":
                 self.sync_signal_update.emit()
                 logger.info("Scan status: Sync mode")
             elif self._mode == "async":
-                for curve in self._async_curves:
-                    self._setup_async_curve(curve)
                 self.async_signal_update.emit()
                 logger.info("Scan status: Async mode")
             else:
                 self.sync_signal_update.emit()
-                for curve in self._async_curves:
-                    self._setup_async_curve(curve)
                 self.async_signal_update.emit()
                 logger.info("Scan status: Mixed mode")
                 logger.warning("Mixed mode - integrity of x axis cannot be guaranteed.")

--- a/bec_widgets/widgets/plots/waveform/waveform.py
+++ b/bec_widgets/widgets/plots/waveform/waveform.py
@@ -142,6 +142,10 @@ class Waveform(PlotBase):
         # Curve data
         self._sync_curves = []
         self._async_curves = []
+        # Async streams already subscribed in the current scan. Keyed by
+        # (device, stream) (stream is None for the old per-device endpoint); the value
+        # is the list of signal entries that share that single subscription.
+        self._async_streams_setup: dict = {}
         self._history_curves = []
         self._slice_index = None
         self._dap_curves = []
@@ -1753,45 +1757,51 @@ class Waveform(PlotBase):
         """
         Setup async curve.
 
+        Several curves can resolve to the same underlying async stream -- most
+        commonly the sub-signals of one ``AsyncMultiSignal``, which share a
+        ``storage_name`` and are published on a single endpoint. Such curves reuse one
+        subscription instead of subscribing to the same endpoint repeatedly;
+        ``on_async_readback`` then feeds every curve that maps to it.
+
         Args:
             curve(Curve): The curve to set up.
         """
         name = curve.config.signal.device
         signal = curve.config.signal.signal
-        async_signal_found, signal = self._check_async_signal_found(name, signal)
+        async_signal_found, stream = self._check_async_signal_found(name, signal)
 
         try:
             curve.clear_data()
         except KeyError:
             logger.warning(f"Curve {name} not found in plot item.")
-            pass
 
-        # New endpoint for async signals
         if async_signal_found:
-            self.bec_dispatcher.disconnect_slot(
-                self.on_async_readback,
-                MessageEndpoints.device_async_signal(self.old_scan_id, name, signal),
-            )
-            self.bec_dispatcher.connect_slot(
-                self.on_async_readback,
-                MessageEndpoints.device_async_signal(self.scan_id, name, signal),
-                from_start=True,
-                cb_info={"scan_id": self.scan_id},
-            )
-
-        # old endpoint
+            stream_key = (name, stream)  # AsyncMultiSignal sub-signals share `stream`
+            new_endpoint = MessageEndpoints.device_async_signal(self.scan_id, name, stream)
+            old_endpoint = MessageEndpoints.device_async_signal(self.old_scan_id, name, stream)
         else:
-            self.bec_dispatcher.disconnect_slot(
-                self.on_async_readback,
-                MessageEndpoints.device_async_readback(self.old_scan_id, name),
+            stream_key = (name, None)  # old endpoint is keyed by device only
+            new_endpoint = MessageEndpoints.device_async_readback(self.scan_id, name)
+            old_endpoint = MessageEndpoints.device_async_readback(self.old_scan_id, name)
+
+        endpoint_str = getattr(new_endpoint, "endpoint", new_endpoint)
+
+        shared = self._async_streams_setup.get(stream_key)
+        if shared is not None:
+            # Another curve already subscribed to this exact stream this scan.
+            shared.append(signal)
+            logger.info(
+                f"Async signals {shared} share a single subscription on endpoint "
+                f"'{endpoint_str}'; reusing it instead of subscribing again."
             )
-            self.bec_dispatcher.connect_slot(
-                self.on_async_readback,
-                MessageEndpoints.device_async_readback(self.scan_id, name),
-                from_start=True,
-                cb_info={"scan_id": self.scan_id},
-            )
-        logger.info(f"Setup async curve {name}")
+            return
+
+        self._async_streams_setup[stream_key] = [signal]
+        self.bec_dispatcher.disconnect_slot(self.on_async_readback, old_endpoint)
+        self.bec_dispatcher.connect_slot(
+            self.on_async_readback, new_endpoint, from_start=True, cb_info={"scan_id": self.scan_id}
+        )
+        logger.info(f"Setup async curve {name} (signal '{signal}', endpoint '{endpoint_str}')")
 
     @SafeSlot(dict, dict, verify_sender=True)
     def on_async_readback(self, msg, metadata):
@@ -2301,6 +2311,7 @@ class Waveform(PlotBase):
         # Reset sync/async curve lists
         self._async_curves.clear()
         self._sync_curves.clear()
+        self._async_streams_setup = {}
         found_async = False
         found_sync = False
         mode = "sync"

--- a/tests/unit_tests/test_signal_classification.py
+++ b/tests/unit_tests/test_signal_classification.py
@@ -1,0 +1,78 @@
+from types import SimpleNamespace
+
+from bec_widgets.utils.signal_classification import (
+    SignalCategory,
+    classify_device_signal,
+    classify_signal_info,
+)
+
+
+def _info(signal_class=None, role=None, with_embedded=False):
+    info = {"signal_class": signal_class, "component_name": "comp", "obj_name": "dev_comp"}
+    if with_embedded:
+        info["describe"] = {"signal_info": {"role": role or "main", "signals": [["comp", 5]]}}
+    return info
+
+
+def _device(signals: dict):
+    return SimpleNamespace(_info={"signals": signals})
+
+
+def test_sync_signal_classes_are_sync():
+    for cls in ("Signal", "EpicsSignal", "EpicsSignalRO", "SetableSignal", "ReadOnlySignal"):
+        assert classify_signal_info(_info(signal_class=cls)) == SignalCategory.SYNC
+
+
+def test_async_signal_classes_are_async():
+    for cls in ("AsyncSignal", "AsyncMultiSignal", "DynamicSignal"):
+        assert classify_signal_info(_info(signal_class=cls)) == SignalCategory.ASYNC
+
+
+def test_dynamic_signal_subclass_detected_via_embedded_info():
+    """A DynamicSignal subclass serializes its concrete class name; the
+    embedded signal_info block must still classify it as async."""
+    info = _info(signal_class="MyBeamlineAsyncSignal", with_embedded=True)
+    assert classify_signal_info(info) == SignalCategory.ASYNC
+
+
+def test_non_curve_roles_are_unknown():
+    for role in ("preview", "diagnostic", "file_event", "progress"):
+        info = _info(signal_class="PreviewSignal", role=role, with_embedded=True)
+        assert classify_signal_info(info) == SignalCategory.UNKNOWN
+
+
+def test_missing_or_empty_info_is_unknown():
+    assert classify_signal_info(None) == SignalCategory.UNKNOWN
+    assert classify_signal_info({}) == SignalCategory.UNKNOWN
+    assert classify_signal_info({"signal_class": None}) == SignalCategory.UNKNOWN
+
+
+def test_monitored_device_with_mixed_signals():
+    """One (monitored) device exposing both
+    a synchronous and an asynchronous signal must classify per signal, not
+    per device."""
+
+    device = _device(
+        {
+            "readback": _info(signal_class="Signal"),
+            "stream": _info(signal_class="AsyncSignal"),
+            "multi": _info(signal_class="AsyncMultiSignal"),
+        }
+    )
+    assert classify_device_signal(device, "readback") == SignalCategory.SYNC
+    assert classify_device_signal(device, "stream") == SignalCategory.ASYNC
+    assert classify_device_signal(device, "multi") == SignalCategory.ASYNC
+
+
+def test_entry_resolved_via_obj_name():
+    info = _info(signal_class="AsyncSignal")
+    info["obj_name"] = "dev1_stream"
+    device = _device({"stream": info})
+    assert classify_device_signal(device, "dev1_stream") == SignalCategory.ASYNC
+
+
+def test_unresolvable_device_or_entry_is_unknown():
+    assert classify_device_signal(None, "x") == SignalCategory.UNKNOWN
+    assert classify_device_signal(SimpleNamespace(), "x") == SignalCategory.UNKNOWN
+    assert classify_device_signal(_device({}), "missing") == SignalCategory.UNKNOWN
+    assert classify_device_signal(_device({"a": _info("Signal")}), "") == SignalCategory.UNKNOWN

--- a/tests/unit_tests/test_waveform.py
+++ b/tests/unit_tests/test_waveform.py
@@ -897,12 +897,20 @@ def test_setup_async_curve(qtbot, mocked_client, monkeypatch):
     connect_spy = MagicMock()
     monkeypatch.setattr(wf.bec_dispatcher, "connect_slot", connect_spy)
 
+    # _setup_async_curve dedupes subscriptions per scan; reset the tracking so this
+    # isolated call performs the (single) subscription.
+    wf._async_streams_setup = {}
     wf._setup_async_curve(c)
     connect_spy.assert_called_once()
     endpoint_called = connect_spy.call_args[0][1].endpoint
     # We expect MessageEndpoints.device_async_readback('222', 'async_device')
     assert "222" in endpoint_called
     assert "async_device" in endpoint_called
+
+    # A second curve that resolves to the same stream reuses the one subscription
+    # instead of subscribing again.
+    wf._setup_async_curve(c)
+    connect_spy.assert_called_once()
 
 
 def test_on_async_readback_add_update(qtbot, mocked_client):

--- a/tests/unit_tests/test_waveform.py
+++ b/tests/unit_tests/test_waveform.py
@@ -1642,3 +1642,48 @@ def test_history_curve_scan_not_found_returns_none(qtbot, mocked_client):
     # No history scans injected for this widget
     c = wf.plot(device_y="bpm4i", signal_y="bpm4i", scan_id="unknown_scan")
     assert c is None
+
+
+def test_categorise_device_curves_monitored_device_with_async_signal(qtbot, mocked_client):
+    """Device listed under 'monitored'
+    readout priority may expose an asynchronous signal; the curve must be
+    classified by the signal class, not the parent device's readout priority."""
+    wf = create_widget(qtbot, Waveform, client=mocked_client)
+    dummy_scan = create_dummy_scan_item()
+    wf.scan_item = dummy_scan
+
+    # bpm4i is listed under 'monitored' in the dummy scan; give it an
+    # additional async signal, as a mixed device would have.
+    device = mocked_client.device_manager.devices["bpm4i"]
+    device.signals["bpm4i_stream"] = {"value": 0.0}
+    device._info["signals"]["bpm4i_stream"] = {
+        "kind_str": "hinted",
+        "component_name": "bpm4i_stream",
+        "obj_name": "bpm4i_stream",
+        "signal_class": "AsyncSignal",
+    }
+
+    c_sync = wf.plot(arg1="bpm4i", label="sync-curve")
+    c_async = wf.plot(device_y="bpm4i", signal_y="bpm4i_stream", label="async-curve")
+
+    mode = wf._categorise_device_curves()
+
+    assert mode == "mixed"
+    assert c_sync in wf._sync_curves
+    assert c_async in wf._async_curves
+
+
+def test_categorise_device_curves_falls_back_to_readout_priority(qtbot, mocked_client):
+    """When no signal info is available (e.g. history data for a removed
+    device), classification falls back to the scan's readout-priority lists."""
+    wf = create_widget(qtbot, Waveform, client=mocked_client)
+    dummy_scan = create_dummy_scan_item()
+    wf.scan_item = dummy_scan
+
+    c_async = wf.plot(arg1="async_device", label="fallback-curve")
+    # Simulate the device's signal info being unavailable.
+    mocked_client.device_manager.devices["async_device"]._info = {}
+
+    wf._categorise_device_curves()
+
+    assert c_async in wf._async_curves


### PR DESCRIPTION
## Description

Async curve classification based on the signal class and not on readout priority of the device.

## Related Issues

- closes #1185 
- closes #1099

## Type of Change

- No rely on readout priority
- Remove double sub for async data

## How to test

- Add Waveform to Companion app
- You can test with the simulated device with mix of signals which can be found here https://github.com/bec-project/ophyd_devices/pull/207

add config to eg demo config like this:

```yaml
mixed_mon:
  readoutPriority: monitored
  deviceClass: ophyd_devices.sim.sim_monitor.SimMonitorMixedSignals
  deviceConfig:
    sim_init:
      model: GaussianModel
      params: { amplitude: 100, center: 0, sigma: 5 }
  deviceTags:
    - beamline
  enabled: true
  readOnly: false
  softwareTrigger: true
  ```


