### PR TITLE
fix: qt redis connector for separated connector

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,15 +34,6 @@ jobs:
     if: needs.check_pr_status.outputs.branch-pr == ''
     uses: ./.github/workflows/formatter.yml
 
-  benchmark:
-    needs: [check_pr_status]
-    if: needs.check_pr_status.outputs.branch-pr == ''
-    permissions:
-      contents: write
-      issues: write
-      pull-requests: write
-    uses: ./.github/workflows/benchmark.yml
-
   unit-test:
     needs: [check_pr_status, formatter]
     if: needs.check_pr_status.outputs.branch-pr == ''
@@ -92,3 +83,12 @@ jobs:
 
     secrets:
       GH_READ_TOKEN: ${{ secrets.GH_READ_TOKEN }}
+
+  benchmark:
+    needs: [check_pr_status, unit-test, unit-test-matrix]
+    if: needs.check_pr_status.outputs.branch-pr == ''
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    uses: ./.github/workflows/benchmark.yml

--- a/bec_widgets/utils/bec_dispatcher.py
+++ b/bec_widgets/utils/bec_dispatcher.py
@@ -12,6 +12,7 @@ import redis
 from bec_lib.client import BECClient
 from bec_lib.logger import bec_logger
 from bec_lib.redis_connector import MessageObject, RedisConnector
+from bec_lib.redis_connector.buffered_redis_connector import BufferedRedisConnector
 from bec_lib.service_config import ServiceConfig
 from qtpy.QtCore import QObject
 from qtpy.QtCore import Signal as pyqtSignal
@@ -99,22 +100,11 @@ class QtThreadSafeCallback(QObject):
         self.cb_signal.emit(msg_content, metadata)
 
 
-class QtRedisConnector(RedisConnector):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
+class QtBufferedRedisConnector(BufferedRedisConnector):
     def _execute_callback(self, cb, msg, kwargs):
         if not isinstance(cb, QtThreadSafeCallback):
             return super()._execute_callback(cb, msg, kwargs)
-        # if msg.msg_type == "bundle_message":
-        #    # big warning: how to handle bundle messages?
-        #    # message with messages inside ; which slot to call?
-        #    # bundle_msg = msg
-        #    # for msg in bundle_msg:
-        #    #    ...
-        #    # for now, only consider the 1st message
-        #    msg = msg[0]
-        #    raise RuntimeError(f"
+
         if isinstance(msg, MessageObject):
             if isinstance(msg.value, list):
                 msg = msg.value[0]
@@ -130,6 +120,10 @@ class QtRedisConnector(RedisConnector):
             msg = msg["data"]
             _log_rpc_dispatcher_receive(msg.content, msg.metadata)
             cb(msg.content, msg.metadata)
+
+
+class QtRedisConnector(RedisConnector):
+    connector_cls = QtBufferedRedisConnector
 
 
 class BECDispatcher:

--- a/bec_widgets/utils/bec_dispatcher.py
+++ b/bec_widgets/utils/bec_dispatcher.py
@@ -12,7 +12,7 @@ import redis
 from bec_lib.client import BECClient
 from bec_lib.logger import bec_logger
 from bec_lib.redis_connector import MessageObject, RedisConnector
-from bec_lib.redis_connector.buffered_redis_connector import BufferedRedisConnector
+from bec_lib.redis_connector.managed_redis_connection import ManagedRedisConnection
 from bec_lib.service_config import ServiceConfig
 from qtpy.QtCore import QObject
 from qtpy.QtCore import Signal as pyqtSignal
@@ -100,7 +100,7 @@ class QtThreadSafeCallback(QObject):
         self.cb_signal.emit(msg_content, metadata)
 
 
-class QtBufferedRedisConnector(BufferedRedisConnector):
+class QtManagedRedisConnection(ManagedRedisConnection):
     def _execute_callback(self, cb, msg, kwargs):
         if not isinstance(cb, QtThreadSafeCallback):
             return super()._execute_callback(cb, msg, kwargs)
@@ -123,7 +123,7 @@ class QtBufferedRedisConnector(BufferedRedisConnector):
 
 
 class QtRedisConnector(RedisConnector):
-    connector_cls = QtBufferedRedisConnector
+    connector_cls = QtManagedRedisConnection
 
 
 class BECDispatcher:

--- a/tests/unit_tests/test_bec_dispatcher.py
+++ b/tests/unit_tests/test_bec_dispatcher.py
@@ -240,7 +240,7 @@ def test_qt_redis_connector_logs_rpc_before_qt_callback(monkeypatch):
     )
 
     try:
-        connector._execute_callback(cb, {"data": rpc_msg}, {})
+        connector._buffered_connection._execute_callback(cb, {"data": rpc_msg}, {})
 
         info_mock.assert_called_once()
         info_message = info_mock.call_args.args[0]

--- a/tests/unit_tests/test_bec_dispatcher.py
+++ b/tests/unit_tests/test_bec_dispatcher.py
@@ -240,7 +240,7 @@ def test_qt_redis_connector_logs_rpc_before_qt_callback(monkeypatch):
     )
 
     try:
-        connector._buffered_connection._execute_callback(cb, {"data": rpc_msg}, {})
+        connector._managed_connection._execute_callback(cb, {"data": rpc_msg}, {})
 
         info_mock.assert_called_once()
         info_message = info_mock.call_args.args[0]


### PR DESCRIPTION
small fix for https://github.com/bec-project/bec/pull/963

CI run with both branches: https://github.com/bec-project/bec_widgets/actions/runs/27814551061 (note e2e fails because it doesn't respect the branch input)