### PR TITLE
Image various fixes to prevent segfault

### DIFF
--- a/bec_widgets/widgets/plots/image/image.py
+++ b/bec_widgets/widgets/plots/image/image.py
@@ -959,6 +959,8 @@ class Image(ImageBase):
         Returns:
             np.ndarray: The updated image buffer with adjusted shapes.
         """
+        # Guard for wrong data shapes
+        new_data = np.atleast_1d(np.asarray(new_data))
         new_len = new_data.shape[0]
         if not hasattr(image, "buffer"):
             image.buffer = []

--- a/bec_widgets/widgets/plots/image/image_base.py
+++ b/bec_widgets/widgets/plots/image/image_base.py
@@ -1036,6 +1036,8 @@ class ImageBase(PlotBase):
         """
 
         # FIXME: this should be made more general
+        if not self.layer_manager:
+            return False
         return self.layer_manager["main"].image.autorange
 
     @autorange.setter
@@ -1056,6 +1058,8 @@ class ImageBase(PlotBase):
             enabled(bool): Whether to enable autorange.
             sync(bool): Whether to synchronize the autorange state across all layers.
         """
+        if not self.layer_manager:
+            return
         for layer in self.layer_manager:
             if not layer.sync.autorange:
                 continue
@@ -1077,6 +1081,8 @@ class ImageBase(PlotBase):
             - "mean": Use the mean value of the image for autoranging.
 
         """
+        if not self.layer_manager:
+            return "mean"
         return self.layer_manager["main"].image.autorange_mode
 
     @autorange_mode.setter
@@ -1089,6 +1095,8 @@ class ImageBase(PlotBase):
         """
         # for qt Designer
         if mode not in ["max", "mean"]:
+            return
+        if not self.layer_manager:
             return
         for layer in self.layer_manager:
             if not layer.sync.autorange_mode:
@@ -1125,6 +1133,8 @@ class ImageBase(PlotBase):
         """
         Synchronize the autorange switch with the current autorange state and mode if changed from outside.
         """
+        if not self.layer_manager:
+            return
         action: SwitchableToolBarAction = self.toolbar.components.get_action("image_autorange")  # type: ignore
         with action.signal_blocker():
             action.set_default_action(f"{self.layer_manager['main'].image.autorange_mode}")
@@ -1133,7 +1143,7 @@ class ImageBase(PlotBase):
     def _sync_colorbar_levels(self):
         """Immediately propagate current levels to the active colorbar."""
 
-        if not self._color_bar:
+        if not self._color_bar or not self.layer_manager:
             return
 
         total_vrange = (0, 0)

--- a/bec_widgets/widgets/plots/image/image_base.py
+++ b/bec_widgets/widgets/plots/image/image_base.py
@@ -954,6 +954,11 @@ class ImageBase(PlotBase):
 
         vmin, vmax = value.x(), value.y()
 
+        # Non-finite levels would crash pyqtgraph's colorbar
+        if not (np.isfinite(vmin) and np.isfinite(vmax)):
+            logger.warning(f"Ignoring non-finite v_range ({vmin}, {vmax}).")
+            return
+
         for layer in self.layer_manager:
             if not layer.sync.v_range:
                 continue

--- a/bec_widgets/widgets/plots/image/image_item.py
+++ b/bec_widgets/widgets/plots/image/image_item.py
@@ -142,6 +142,13 @@ class ImageItem(BECConnector, pg.ImageItem):
         self.set_v_range(vrange, disable_autorange=True)
 
     def set_v_range(self, vrange: tuple[float, float], disable_autorange=True):
+        vmin, vmax = vrange
+        if not (np.isfinite(vmin) and np.isfinite(vmax)):
+            logger.warning(f"Ignoring non-finite v_range ({vmin}, {vmax}).")
+            return
+        if vmin > vmax:
+            vmin, vmax = vmax, vmin
+        vrange = (float(vmin), float(vmax))
         if disable_autorange:
             self.config.autorange = False
             self.vRangeChangedManually.emit(vrange)
@@ -200,8 +207,10 @@ class ImageItem(BECConnector, pg.ImageItem):
         """Update the v_range based on the stats of the image."""
         fumble_factor = 2
         if self.config.autorange_mode == "mean":
-            vmin = max(stats.mean - fumble_factor * stats.std, 0)
+            vmin = stats.mean - fumble_factor * stats.std
             vmax = stats.mean + fumble_factor * stats.std
+            if stats.minimum >= 0:
+                vmin = max(vmin, 0)
         elif self.config.autorange_mode == "max":
             vmin, vmax = stats.minimum, stats.maximum
         else:

--- a/bec_widgets/widgets/plots/image/image_processor.py
+++ b/bec_widgets/widgets/plots/image/image_processor.py
@@ -28,10 +28,10 @@ class ImageStats:
             ImageStats: The statistics of the image data.
         """
         return cls(
-            maximum=np.nanmax(data),
-            minimum=np.nanmin(data),
-            mean=np.nanmean(data),
-            std=np.nanstd(data),
+            maximum=float(np.nanmax(data)),
+            minimum=float(np.nanmin(data)),
+            mean=float(np.nanmean(data)),
+            std=float(np.nanstd(data)),
         )
 
 
@@ -123,11 +123,11 @@ class ImageProcessor(QObject):
         Returns:
             np.ndarray: The processed data.
         """
-        # TODO this is not final solution -> data should stay as int16
-        data = data.astype(np.float32)
-        offset = 1e-6
-        data_offset = data + offset
-        return np.log10(data_offset)
+        data = np.asarray(data, dtype=np.float32)
+        # Detector data is counts (>= 0): clipping at 0.1 maps zero-count pixels
+        # to -1 and single counts to 0, keeping the log image finite without
+        # stretching the display range down to the float epsilon.
+        return np.log10(np.clip(data, 0.1, None))
 
     def update_image_stats(self, data: np.ndarray) -> None:
         """Get the statistics of the image data.
@@ -136,10 +136,10 @@ class ImageProcessor(QObject):
             data(np.ndarray): The image data.
 
         """
-        self.config.stats.maximum = np.max(data)
-        self.config.stats.minimum = np.min(data)
-        self.config.stats.mean = np.mean(data)
-        self.config.stats.std = np.std(data)
+        self.config.stats.maximum = float(np.nanmax(data))
+        self.config.stats.minimum = float(np.nanmin(data))
+        self.config.stats.mean = float(np.nanmean(data))
+        self.config.stats.std = float(np.nanstd(data))
 
     def process_image(self, data: np.ndarray) -> np.ndarray:
         """Core processing logic without threading overhead."""

--- a/tests/unit_tests/test_image_view_next_gen.py
+++ b/tests/unit_tests/test_image_view_next_gen.py
@@ -1440,3 +1440,20 @@ def test_image_processor_log_is_finite_for_non_positive():
     assert out[0, 0] == pytest.approx(-1.0)
     assert out[1, 0] == pytest.approx(-1.0)
     assert proc.log(np.array([[1.0]]))[0, 0] == pytest.approx(0.0)
+
+
+##############################################
+# Shape / dtype edge cases in the data path
+##############################################
+
+
+def test_adjust_image_buffer_coerces_list_and_scalar(qtbot, mocked_client):
+    """Non-ndarray payloads (python list, 0-d scalar) must not crash the
+    1D buffer accumulation."""
+    view = create_widget(qtbot, Image, client=mocked_client)
+    image = view.main_image
+
+    buf = view.adjust_image_buffer(image, [1, 2, 3])  # python list
+    assert buf.shape == (1, 3)
+    buf = view.adjust_image_buffer(image, np.array(42.0))  # 0-d scalar
+    assert buf.shape[0] == 2

--- a/tests/unit_tests/test_image_view_next_gen.py
+++ b/tests/unit_tests/test_image_view_next_gen.py
@@ -1457,3 +1457,25 @@ def test_adjust_image_buffer_coerces_list_and_scalar(qtbot, mocked_client):
     assert buf.shape == (1, 3)
     buf = view.adjust_image_buffer(image, np.array(42.0))  # 0-d scalar
     assert buf.shape[0] == 2
+
+
+##############################################
+# Teardown safety
+##############################################
+
+
+def test_layer_accessors_safe_after_teardown(qtbot, mocked_client):
+    """Once layer_manager is gone (post-cleanup), signal-driven accessors must
+    not raise. They used to subscript None or resurrect the 'main' layer."""
+    view = create_widget(qtbot, Image, client=mocked_client)
+    view.enable_full_colorbar = True
+    view.layer_manager = None  # simulate post-cleanup state
+
+    # None of these should raise:
+    assert view.autorange is False
+    assert view.autorange_mode == "mean"
+    view.toggle_autorange(True, "mean")
+    view._set_autorange(True)
+    view.autorange_mode = "max"
+    view._sync_autorange_switch()
+    view._sync_colorbar_levels()

--- a/tests/unit_tests/test_image_view_next_gen.py
+++ b/tests/unit_tests/test_image_view_next_gen.py
@@ -5,6 +5,7 @@ from bec_lib.endpoints import MessageEndpoints
 from qtpy.QtCore import QPointF, Qt
 
 from bec_widgets.widgets.plots.image.image import Image
+from bec_widgets.widgets.plots.image.image_processor import ImageProcessor, ProcessingConfig
 from tests.unit_tests.client_mocks import mocked_client
 from tests.unit_tests.conftest import create_widget
 
@@ -1366,3 +1367,76 @@ def test_signal_syncs_from_toolbar(qtbot, mocked_client):
     view._sync_signal_from_toolbar()
 
     assert view.signal == "img_b"
+
+
+##############################################
+# Log scale / non-finite data crash regression
+##############################################
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        -np.abs(np.random.rand(20, 30)).astype(np.float32) - 1.0,  # all negative -> all NaN
+        np.zeros((20, 30), dtype=np.uint16),  # all zeros -> uniform floor
+        np.where(np.eye(20, 30) > 0, -5.0, 3.0).astype(np.float32),  # mixed sign
+    ],
+    ids=["all_negative", "all_zeros", "mixed_sign"],
+)
+def test_log_scale_does_not_crash_with_full_colorbar(qtbot, mocked_client, data):
+    """Log scaling of non-positive data must not produce NaN levels that crash
+    the full (HistogramLUTItem) colorbar. Regression for fix/image-crashing."""
+    view = create_widget(qtbot, Image, client=mocked_client)
+    view.enable_full_colorbar = True
+    assert isinstance(view._color_bar, pg.HistogramLUTItem)
+
+    view.log = True
+    # This is the exact path that used to raise "Cannot set range [nan, nan]".
+    view.on_image_update_2d({"data": data}, {})
+
+    vmin, vmax = view.main_image.v_range
+    assert np.isfinite(vmin) and np.isfinite(vmax)
+    assert vmin <= vmax
+    # Colorbar levels stay finite as well.
+    low, high = view._color_bar.getLevels()
+    assert np.isfinite(low) and np.isfinite(high)
+
+
+def test_log_scale_all_negative_keeps_finite_image(qtbot, mocked_client):
+    """All-negative input must still yield a finite, displayed image under log."""
+    view = create_widget(qtbot, Image, client=mocked_client)
+    view.log = True
+    data = (-np.abs(np.random.rand(15, 15)) - 1.0).astype(np.float32)
+
+    view.on_image_update_2d({"data": data}, {})
+
+    assert view.main_image.image is not None
+    assert np.all(np.isfinite(view.main_image.image))
+
+
+def test_set_v_range_ignores_non_finite_levels(qtbot, mocked_client):
+    """Non-finite v_range requests are rejected rather than forwarded to pg."""
+    view = create_widget(qtbot, Image, client=mocked_client)
+    view.on_image_update_2d({"data": np.random.rand(10, 10)}, {})
+    good = view.main_image.v_range
+
+    view.main_image.set_v_range((np.nan, np.nan))
+    assert view.main_image.v_range == good  # unchanged
+
+    # Inverted ranges are normalised, not propagated as-is.
+    view.main_image.set_v_range((10.0, 2.0))
+    lo, hi = view.main_image.v_range
+    assert (lo, hi) == (2.0, 10.0)
+
+
+def test_image_processor_log_is_finite_for_non_positive():
+    """ImageProcessor.log must never emit NaN/inf for zero/negative input."""
+    proc = ImageProcessor(config=ProcessingConfig(log=True))
+    data = np.array([[-100.0, -1.0], [0.0, 1000.0]], dtype=np.float32)
+    out = proc.log(data)
+    assert np.all(np.isfinite(out))
+    # Non-positive pixels collapse to the floor log10(0.1) == -1; a count of 1
+    # maps to 0.
+    assert out[0, 0] == pytest.approx(-1.0)
+    assert out[1, 0] == pytest.approx(-1.0)
+    assert proc.log(np.array([[1.0]]))[0, 0] == pytest.approx(0.0)


### PR DESCRIPTION
## Description

Looks like the main reason could be how the log scale is handled for the colorBar histogram from pyqtgraph, but also some additional fixes to prevent nonfinite values. There might be some defensive patterns since I am not completely sure how to reproduce the segfautls from BL testing.
