### PR TITLE
feat/heatmap-scan-history

### DIFF
--- a/bec_widgets/cli/designer_plugins.py
+++ b/bec_widgets/cli/designer_plugins.py
@@ -91,6 +91,10 @@ designer_plugins = {
     ),
     "SBBMonitor": ("bec_widgets.widgets.editors.sbb_monitor.sbb_monitor", "SBBMonitor"),
     "ScanControl": ("bec_widgets.widgets.control.scan_control.scan_control", "ScanControl"),
+    "ScanIndexComboBox": (
+        "bec_widgets.widgets.utility.scan_index_combobox.scan_index_combobox",
+        "ScanIndexComboBox",
+    ),
     "ScanMetadata": ("bec_widgets.widgets.editors.scan_metadata.scan_metadata", "ScanMetadata"),
     "ScanProgressBar": (
         "bec_widgets.widgets.progress.scan_progressbar.scan_progressbar",
@@ -156,6 +160,7 @@ widget_icons = {
     "RingProgressBar": "track_changes",
     "SBBMonitor": "train",
     "ScanControl": "tune",
+    "ScanIndexComboBox": "history",
     "ScanMetadata": "list_alt",
     "ScanProgressBar": "timelapse",
     "ScatterWaveform": "scatter_plot",

--- a/bec_widgets/widgets/plots/heatmap/heatmap.py
+++ b/bec_widgets/widgets/plots/heatmap/heatmap.py
@@ -9,13 +9,15 @@ import pyqtgraph as pg
 from bec_lib import bec_logger, messages
 from bec_lib.endpoints import MessageEndpoints
 from bec_lib.utils.import_utils import lazy_import, lazy_import_from
+from bec_qthemes import material_icon
 from pydantic import BaseModel, Field, field_validator
 from qtpy.QtCore import QObject, Qt, QThread, QTimer, Signal
 from qtpy.QtGui import QTransform
+from qtpy.QtWidgets import QDialog, QPushButton, QVBoxLayout
 from toolz import partition
 
 from bec_widgets.utils.bec_connector import ConnectionConfig
-from bec_widgets.utils.colors import Colors
+from bec_widgets.utils.colors import Colors, get_accent_colors
 from bec_widgets.utils.error_popups import SafeProperty, SafeSlot
 from bec_widgets.utils.settings_dialog import SettingsDialog
 from bec_widgets.utils.toolbars.actions import MaterialIconAction
@@ -23,6 +25,7 @@ from bec_widgets.widgets.plots.heatmap.settings.heatmap_setting import HeatmapSe
 from bec_widgets.widgets.plots.image.image_base import ImageBase
 from bec_widgets.widgets.plots.image.image_item import ImageItem
 from bec_widgets.widgets.plots.plot_base import PlotBase
+from bec_widgets.widgets.services.scan_history_browser.components import ScanHistoryView
 
 logger = bec_logger.logger
 
@@ -268,6 +271,11 @@ class Heatmap(ImageBase):
         self._interpolation_worker: _StepInterpolationWorker | None = None
         self._pending_interpolation_request: _InterpolationRequest | None = None
         self.heatmap_dialog = None
+        self.scan_history_dialog = None
+        self.scan_history_widget = None
+        # Scan ID the widget is pinned to when plotting from history; None means live mode.
+        self._history_scan_id: str | None = None
+        self._selected_history_scan_id: str | None = None
         bg_color = pg.mkColor((240, 240, 240, 150))
         self.config_label = pg.LegendItem(
             labelTextColor=(0, 0, 0), offset=(-30, 1), brush=pg.mkBrush(bg_color), horSpacing=0
@@ -425,8 +433,10 @@ class Heatmap(ImageBase):
             self.update_with_scan_history(scan_id=scan_id)
             return
 
+        self._history_scan_id = None
         self._fetch_running_scan()
-        self.sync_signal_update.emit()
+        # Also notifies settings widgets and triggers a plot update via sync_signal_update
+        self.heatmap_property_changed.emit()
 
     def _fetch_running_scan(self):
         scan = self.client.queue.scan_storage.current_scan
@@ -480,7 +490,12 @@ class Heatmap(ImageBase):
         else:
             self.scan_id = self.scan_item.scan_id
 
-        self.sync_signal_update.emit()
+        # Pin the widget to the history scan; live scan updates are ignored until
+        # plot() is called again without a scan_id.
+        self._history_scan_id = self.scan_id
+
+        # Also notifies settings widgets and triggers a plot update via sync_signal_update
+        self.heatmap_property_changed.emit()
 
     def update_labels(self):
         """
@@ -529,6 +544,20 @@ class Heatmap(ImageBase):
             self.show_heatmap_settings
         )
 
+        self.toolbar.components.add_safe(
+            "scan_history",
+            MaterialIconAction(
+                icon_name="manage_search",
+                tooltip="Open Scan History browser",
+                checkable=True,
+                parent=self,
+            ),
+        )
+        self.toolbar.get_bundle("axis_popup").add_action("scan_history")
+        self.toolbar.components.get_action("scan_history").action.triggered.connect(
+            self.show_scan_history_popup
+        )
+
         # disable all processing actions except for the fft and log
         bundle = self.toolbar.get_bundle("image_processing")
         for name, action in bundle.bundle_actions.items():
@@ -569,6 +598,71 @@ class Heatmap(ImageBase):
             self.heatmap_dialog.activateWindow()
             heatmap_settings_action.setChecked(True)  # keep it toggled
 
+    ################################################################################
+    # Scan History browser popup
+
+    def show_scan_history_popup(self):
+        """
+        Show the scan history popup with the scan history browser and a plotting button.
+        Requesting a plot pins the heatmap to the selected scan instead of the live acquisition.
+        """
+        scan_history_action = self.toolbar.components.get_action("scan_history").action
+        if self.scan_history_dialog is None or not self.scan_history_dialog.isVisible():
+            self.scan_history_widget = ScanHistoryView(parent=self)
+            self.scan_history_widget.scan_selected.connect(self._on_history_scan_selected)
+            self.scan_history_widget.no_scan_selected.connect(self._on_history_scan_deselected)
+            request_plotting_button = QPushButton(
+                material_icon("play_arrow", size=(24, 24), color=get_accent_colors().success),
+                "Request Plotting",
+            )
+            request_plotting_button.clicked.connect(self._request_history_plot)
+            self.scan_history_dialog = QDialog(modal=False)
+            self.scan_history_dialog.setWindowTitle(f"{self.object_name} - Scan History Browser")
+            self.scan_history_dialog.layout = QVBoxLayout(self.scan_history_dialog)
+            self.scan_history_dialog.layout.addWidget(self.scan_history_widget)
+            self.scan_history_dialog.layout.addWidget(request_plotting_button)
+            self.scan_history_dialog.finished.connect(self._scan_history_closed)
+            self.scan_history_dialog.show()
+            self.scan_history_dialog.resize(380, 320)
+            scan_history_action.setChecked(True)
+        else:
+            # If already open, bring it to the front
+            self.scan_history_dialog.raise_()
+            self.scan_history_dialog.activateWindow()
+            scan_history_action.setChecked(True)  # keep it toggle
+
+    @SafeSlot(dict, dict)
+    def _on_history_scan_selected(self, content: dict, metadata: dict):
+        """Track the scan selected in the scan history browser."""
+        self._selected_history_scan_id = content["scan_id"]
+
+    @SafeSlot()
+    def _on_history_scan_deselected(self):
+        """Clear the tracked scan when no scan is selected in the scan history browser."""
+        self._selected_history_scan_id = None
+
+    @SafeSlot()
+    def _request_history_plot(self):
+        """Plot the currently configured devices for the scan selected in the history browser."""
+        if self._selected_history_scan_id is None:
+            logger.info("No scan selected in the scan history browser; skipping plot request.")
+            return
+        self.update_with_scan_history(scan_id=self._selected_history_scan_id)
+
+    def _scan_history_closed(self):
+        """
+        Slot for when the scan history dialog is closed.
+        """
+        if self.scan_history_dialog is None:
+            return
+        self.scan_history_widget.close()
+        self.scan_history_widget.deleteLater()
+        self.scan_history_widget = None
+        self.scan_history_dialog.deleteLater()
+        self.scan_history_dialog = None
+        self._selected_history_scan_id = None
+        self.toolbar.components.get_action("scan_history").action.setChecked(False)
+
     def toggle_interpolation_info(self):
         """
         Toggle the visibility of the interpolation info label.
@@ -595,6 +689,8 @@ class Heatmap(ImageBase):
             msg(dict): The message content.
             meta(dict): The message metadata.
         """
+        if self._history_scan_id is not None:
+            return
         current_scan_id = msg.get("scan_id", None)
         if current_scan_id is None:
             return
@@ -612,6 +708,8 @@ class Heatmap(ImageBase):
 
     @SafeSlot(dict, dict)
     def on_scan_progress(self, msg: dict, meta: dict):
+        if self._history_scan_id is not None:
+            return
         self.sync_signal_update.emit()
         status = msg.get("done")
         if status:
@@ -877,7 +975,9 @@ class Heatmap(ImageBase):
         self.config_label.setOffset((-30, 1))
         self.config_label.setVisible(True)
         self.config_label.clear()
-        self.config_label.addItem(self.plot_item, f"Scan: {scan_msg.scan_number}")
+        # Indicate whether the widget follows the live acquisition or is pinned to a history scan
+        mode = "history" if self._history_scan_id is not None else "live"
+        self.config_label.addItem(self.plot_item, f"Scan: {scan_msg.scan_number} ({mode})")
         self.config_label.addItem(self.plot_item, f"Scan Name: {scan_msg.scan_name}")
         if scan_msg.scan_name != "grid_scan" or self._image_config.enforce_interpolation:
             self.config_label.addItem(
@@ -1581,6 +1681,9 @@ class Heatmap(ImageBase):
 
     def cleanup(self):
         self._finish_interpolation_thread()
+        if self.scan_history_dialog is not None:
+            self.scan_history_dialog.reject()
+            self.scan_history_dialog = None
         super().cleanup()
 
 

--- a/bec_widgets/widgets/plots/heatmap/settings/heatmap_setting.py
+++ b/bec_widgets/widgets/plots/heatmap/settings/heatmap_setting.py
@@ -113,8 +113,10 @@ class HeatmapSettings(SettingWidget):
             self.ui.enforce_interpolation.setChecked(
                 getattr(self.target_widget._image_config, "enforce_interpolation", False)
             )
+        self.ui.scan_index.refresh_scan_indices()
+        self.ui.scan_index.set_scan_id(self.target_widget._history_scan_id)
 
-    @SafeSlot()
+    @SafeSlot(popup_error=True)
     def accept_changes(self):
         """
         Apply all properties from the settings widget to the target widget.
@@ -130,6 +132,7 @@ class HeatmapSettings(SettingWidget):
         interpolation = self.ui.interpolation.currentText()
         oversampling_factor = self.ui.oversampling_factor.value()
         enforce_interpolation = self.ui.enforce_interpolation.isChecked()
+        scan_id = self.ui.scan_index.scan_id
 
         self.target_widget.plot(
             device_x=device_x,
@@ -143,6 +146,7 @@ class HeatmapSettings(SettingWidget):
             interpolation=interpolation,
             oversampling_factor=oversampling_factor,
             enforce_interpolation=enforce_interpolation,
+            scan_id=scan_id,
             reload=True,
         )
 
@@ -159,5 +163,7 @@ class HeatmapSettings(SettingWidget):
         self.ui.device_z.deleteLater()
         self.ui.signal_z.close()
         self.ui.signal_z.deleteLater()
+        self.ui.scan_index.close()
+        self.ui.scan_index.deleteLater()
         self.ui.interpolation.close()
         self.ui.interpolation.deleteLater()

--- a/bec_widgets/widgets/plots/heatmap/settings/heatmap_settings_horizontal.ui
+++ b/bec_widgets/widgets/plots/heatmap/settings/heatmap_settings_horizontal.ui
@@ -161,6 +161,26 @@
           </property>
          </widget>
         </item>
+        <item row="4" column="1">
+         <widget class="QLabel" name="label_scan_index">
+          <property name="text">
+           <string>Scan #</string>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="3" alignment="Qt::AlignmentFlag::AlignRight">
+         <widget class="ScanIndexComboBox" name="scan_index">
+          <property name="minimumSize">
+           <size>
+            <width>100</width>
+            <height>26</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>Plot the selected scan from history, or 'live' for live acquisition.</string>
+          </property>
+         </widget>
+        </item>
        </layout>
       </widget>
      </item>
@@ -319,6 +339,11 @@
    <class>BECColorMapWidget</class>
    <extends>QWidget</extends>
    <header>bec_color_map_widget</header>
+  </customwidget>
+  <customwidget>
+   <class>ScanIndexComboBox</class>
+   <extends>QComboBox</extends>
+   <header>scan_index_combo_box</header>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/bec_widgets/widgets/plots/heatmap/settings/heatmap_settings_vertical.ui
+++ b/bec_widgets/widgets/plots/heatmap/settings/heatmap_settings_vertical.ui
@@ -49,6 +49,24 @@
     </layout>
    </item>
    <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_scan">
+     <item>
+      <widget class="QLabel" name="label_scan_index">
+       <property name="text">
+        <string>Scan #</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="ScanIndexComboBox" name="scan_index">
+       <property name="toolTip">
+        <string>Plot the selected scan from history, or 'live' for live acquisition.</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
     <widget class="QGroupBox" name="groupBox">
      <property name="title">
       <string>X Device</string>
@@ -261,6 +279,11 @@
    <class>BECColorMapWidget</class>
    <extends>QWidget</extends>
    <header>bec_color_map_widget</header>
+  </customwidget>
+  <customwidget>
+   <class>ScanIndexComboBox</class>
+   <extends>QComboBox</extends>
+   <header>scan_index_combo_box</header>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/bec_widgets/widgets/plots/waveform/settings/curve_settings/curve_tree.py
+++ b/bec_widgets/widgets/plots/waveform/settings/curve_settings/curve_tree.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING
 
 from bec_lib.logger import bec_logger
 from bec_qthemes._icon.material_icons import material_icon
-from qtpy.QtGui import QValidator
 from qtpy.QtWidgets import (
     QApplication,
     QCheckBox,
@@ -39,6 +38,7 @@ from bec_widgets.widgets.control.device_input.device_combobox.device_combobox im
 from bec_widgets.widgets.control.device_input.signal_combobox.signal_combobox import SignalComboBox
 from bec_widgets.widgets.dap.dap_combo_box.dap_combo_box import DapComboBox
 from bec_widgets.widgets.plots.waveform.curve import CurveConfig, DeviceSignal
+from bec_widgets.widgets.utility.scan_index_combobox.scan_index_combobox import ScanIndexComboBox
 from bec_widgets.widgets.utility.visual.color_button_native.color_button_native import (
     ColorButtonNative,
 )
@@ -49,31 +49,6 @@ if TYPE_CHECKING:  # pragma: no cover
 
 
 logger = bec_logger.logger
-
-
-class ScanIndexValidator(QValidator):
-    """Validator to allow only 'live' or integer scan numbers from an allowed set."""
-
-    def __init__(self, allowed_scans: set[int] | None = None, parent=None):
-        super().__init__(parent)
-        self.allowed_scans = allowed_scans or set()
-
-    def validate(self, input_str: str, pos: int):
-        # Accept empty or 'live'
-        if input_str == "" or input_str == "live":
-            return QValidator.State.Acceptable, input_str, pos
-        # Allow partial editing of "live"
-        if "live".startswith(input_str):
-            return QValidator.State.Intermediate, input_str, pos
-        # Accept integer only if present in the allowed set
-        if input_str.isdigit():
-            try:
-                num = int(input_str)
-            except ValueError:
-                return QValidator.State.Invalid, input_str, pos
-            if num in self.allowed_scans:
-                return QValidator.State.Acceptable, input_str, pos
-        return QValidator.State.Invalid, input_str, pos
 
 
 def _normalize_dap_selection(
@@ -184,6 +159,7 @@ class CurveRow(QTreeWidgetItem):
         # BEC user input
         self.device_edit = None
         self.dap_combo = None
+        self.scan_index_combo = None
         self.composite_models: list[str] = []
 
         self.dev = device_manager
@@ -205,51 +181,9 @@ class CurveRow(QTreeWidgetItem):
         """Create the Scan # editable combobox in column 3."""
         if self.source not in ("device", "history"):
             return
-        self.scan_index_combo = QComboBox()
-        self.scan_index_combo.setEditable(True)
-        # Populate 'live' and all available history scan indices
-        self.scan_index_combo.addItem("live", None)
-
-        scan_number_list = []
-        scan_id_list = []
-        try:
-            history = getattr(self.curve_tree.client, "history", None)
-            if history is not None:
-                scan_number_list = getattr(history, "_scan_numbers", []) or []
-                scan_id_list = getattr(history, "_scan_ids", []) or []
-        except Exception as e:
-            logger.error(f"Cannot fetch scan numbers from BEC client: {e}")
-            # If scan numbers cannot be fetched, only provide 'live' option
-            scan_number_list = []
-            scan_id_list = []
-
-        # Restrict input to 'live' or valid scan numbers
-        allowed = set()
-        try:
-            allowed = set(int(n) for n in scan_number_list if isinstance(n, (int, str)))
-        except Exception:
-            allowed = set()
-        validator = ScanIndexValidator(allowed, self.scan_index_combo)
-        self.scan_index_combo.lineEdit().setValidator(validator)
-
-        # Add items: show scan numbers, store scan IDs as item data
-        if scan_number_list and scan_id_list and len(scan_number_list) == len(scan_id_list):
-            for num, sid in zip(scan_number_list, scan_id_list):
-                self.scan_index_combo.addItem(str(num), sid)
-        else:
-            logger.error("Scan number and ID lists are mismatched or empty.")
-
+        self.scan_index_combo = ScanIndexComboBox(parent=self.tree, client=self.curve_tree.client)
         # Select current based on existing config
-        selected = False
-        if getattr(self.config, "scan_id", None):  # scan_id matching only
-            for i in range(self.scan_index_combo.count()):
-                if self.scan_index_combo.itemData(i) == self.config.scan_id:
-                    self.scan_index_combo.setCurrentIndex(i)
-                    selected = True
-                    break
-        if not selected:
-            self.scan_index_combo.setCurrentText("live")
-
+        self.scan_index_combo.set_scan_id(self.config.scan_id)
         self.tree.setItemWidget(self, 3, self.scan_index_combo)
 
     def _init_actions(self):
@@ -461,6 +395,11 @@ class CurveRow(QTreeWidgetItem):
             self.entry_edit.deleteLater()
             self.entry_edit = None
 
+        if self.scan_index_combo is not None:
+            self.scan_index_combo.close()
+            self.scan_index_combo.deleteLater()
+            self.scan_index_combo = None
+
         if getattr(self, "dap_combo", None) is not None:
             self.dap_combo.close()
             self.dap_combo.deleteLater()
@@ -514,23 +453,18 @@ class CurveRow(QTreeWidgetItem):
                     )
 
             self.config.signal = DeviceSignal(device=device_name, signal=device_entry)
-            scan_combo_text = self.scan_index_combo.currentText()
-            if scan_combo_text == "live" or scan_combo_text == "":
+            scan_number = self.scan_index_combo.scan_number
+            if scan_number is None:
                 self.config.scan_number = None
                 self.config.scan_id = None
                 self.config.source = "device"
                 self.config.label = f"{device_name}-{device_entry}"
-            if scan_combo_text.isdigit():
-                try:
-                    scan_num = int(scan_combo_text)
-                except ValueError:
-                    scan_num = None
-                self.config.scan_number = scan_num
-                self.config.scan_id = self.scan_index_combo.currentData()
+            else:
+                self.config.scan_number = scan_number
+                self.config.scan_id = self.scan_index_combo.scan_id
                 self.config.source = "history"
                 # Label history curves with scan number suffix
-                if scan_num is not None:
-                    self.config.label = f"{device_name}-{device_entry}-scan-{scan_num}"
+                self.config.label = f"{device_name}-{device_entry}-scan-{scan_number}"
         else:
             # DAP logic
             parent_conf_dict = {}

--- a/bec_widgets/widgets/utility/scan_index_combobox/register_scan_index_combo_box.py
+++ b/bec_widgets/widgets/utility/scan_index_combobox/register_scan_index_combo_box.py
@@ -1,0 +1,17 @@
+def main():  # pragma: no cover
+    from qtpy import PYSIDE6
+
+    if not PYSIDE6:
+        print("PYSIDE6 is not available in the environment. Cannot patch designer.")
+        return
+    from PySide6.QtDesigner import QPyDesignerCustomWidgetCollection
+
+    from bec_widgets.widgets.utility.scan_index_combobox.scan_index_combo_box_plugin import (
+        ScanIndexComboBoxPlugin,
+    )
+
+    QPyDesignerCustomWidgetCollection.addCustomWidget(ScanIndexComboBoxPlugin())
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/bec_widgets/widgets/utility/scan_index_combobox/scan_index_combo_box.pyproject
+++ b/bec_widgets/widgets/utility/scan_index_combobox/scan_index_combo_box.pyproject
@@ -1,0 +1,1 @@
+{'files': ['scan_index_combobox.py']}

--- a/bec_widgets/widgets/utility/scan_index_combobox/scan_index_combo_box_plugin.py
+++ b/bec_widgets/widgets/utility/scan_index_combobox/scan_index_combo_box_plugin.py
@@ -1,0 +1,57 @@
+# Copyright (C) 2022 The Qt Company Ltd.
+# SPDX-License-Identifier: LicenseRef-Qt-Commercial OR BSD-3-Clause
+
+from qtpy.QtDesigner import QDesignerCustomWidgetInterface
+from qtpy.QtWidgets import QWidget
+
+from bec_widgets.utils.bec_designer import designer_material_icon
+from bec_widgets.widgets.utility.scan_index_combobox.scan_index_combobox import ScanIndexComboBox
+
+DOM_XML = """
+<ui language='c++'>
+    <widget class='ScanIndexComboBox' name='scan_index_combo_box'>
+    </widget>
+</ui>
+"""
+
+
+class ScanIndexComboBoxPlugin(QDesignerCustomWidgetInterface):  # pragma: no cover
+    def __init__(self):
+        super().__init__()
+        self._form_editor = None
+
+    def createWidget(self, parent):
+        if parent is None:
+            return QWidget()
+        t = ScanIndexComboBox(parent)
+        return t
+
+    def domXml(self):
+        return DOM_XML
+
+    def group(self):
+        return "BEC Utils"
+
+    def icon(self):
+        return designer_material_icon(ScanIndexComboBox.ICON_NAME)
+
+    def includeFile(self):
+        return "scan_index_combo_box"
+
+    def initialize(self, form_editor):
+        self._form_editor = form_editor
+
+    def isContainer(self):
+        return False
+
+    def isInitialized(self):
+        return self._form_editor is not None
+
+    def name(self):
+        return "ScanIndexComboBox"
+
+    def toolTip(self):
+        return ""
+
+    def whatsThis(self):
+        return self.toolTip()

--- a/bec_widgets/widgets/utility/scan_index_combobox/scan_index_combobox.py
+++ b/bec_widgets/widgets/utility/scan_index_combobox/scan_index_combobox.py
@@ -1,0 +1,152 @@
+"""Editable combobox for selecting a scan from history or live acquisition."""
+
+from __future__ import annotations
+
+from qtpy.QtCore import Slot
+from qtpy.QtWidgets import QComboBox
+
+from bec_widgets.utils.bec_connector import ConnectionConfig
+from bec_widgets.utils.bec_widget import BECWidget
+from bec_widgets.utils.error_popups import SafeSlot
+
+LIVE_ENTRY = "live"
+
+
+class ScanIndexComboBox(BECWidget, QComboBox):
+    """
+    Editable combobox listing 'live' and the scan numbers available in the BEC scan
+    history. Scan numbers are displayed as text while the corresponding scan IDs are
+    stored as item data, so a selection maps to either live mode (scan_id is None)
+    or a historical scan.
+
+    Typing is not restricted: input that matches neither 'live' nor a listed scan
+    number is flagged with a red border while editing, and reading scan_id or
+    scan_number for such input raises ValueError. The default editable-combobox
+    completer autocompletes against the listed entries while typing.
+    """
+
+    ICON_NAME = "history"
+    RPC = False
+    PLUGIN = True
+
+    def __init__(
+        self,
+        parent=None,
+        client=None,
+        config: ConnectionConfig | None = None,
+        gui_id: str | None = None,
+        **kwargs,
+    ):
+        super().__init__(parent=parent, client=client, gui_id=gui_id, config=config, **kwargs)
+        self._is_valid_input = False
+        self.setEditable(True)
+        self.setInsertPolicy(QComboBox.NoInsert)
+        self.currentTextChanged.connect(self.check_validity)
+        self.refresh_scan_indices()
+
+    @SafeSlot()
+    def refresh_scan_indices(self):
+        """Repopulate the combobox with 'live' and all scan numbers from the scan history."""
+        # Unlike the scan_id property, tolerate invalid typed text here: a refresh
+        # simply falls back to 'live' instead of raising.
+        index = self.findText(self.currentText())
+        current_scan_id = self.itemData(index) if index >= 0 else None
+        self.clear()
+        self.addItem(LIVE_ENTRY, None)
+
+        # client.history is None until the client services are started (e.g. in Qt Designer)
+        history = self.client.history
+        scan_number_list = history._scan_numbers if history is not None else []
+        scan_id_list = history._scan_ids if history is not None else []
+
+        # Add items: show scan numbers, store scan IDs as item data,
+        # ordered live -> latest scan -> oldest scan
+        pairs = sorted(zip(scan_number_list, scan_id_list), key=lambda pair: pair[0], reverse=True)
+        for num, sid in pairs:
+            self.addItem(str(num), sid)
+
+        self.set_scan_id(current_scan_id)
+        # The current text may be unchanged while the item list changed, so no
+        # currentTextChanged signal is emitted; re-check validity explicitly.
+        self.check_validity(self.currentText())
+
+    @property
+    def is_valid_input(self) -> bool:
+        """Whether the current text is 'live' or one of the listed scan numbers."""
+        return self._is_valid_input
+
+    @property
+    def scan_id(self) -> str | None:
+        """The scan ID of the selected scan, or None for 'live'.
+
+        Raises:
+            ValueError: If the current text is neither 'live' nor a listed scan number.
+        """
+        text = self.currentText()
+        # Look up by text: typing into the editable combobox does not move the
+        # current index, so currentData() could return a stale scan ID.
+        index = self.findText(text)
+        if index < 0:
+            raise ValueError(
+                f"'{text}' is not a valid scan selection; choose '{LIVE_ENTRY}' or one of the "
+                "listed scan numbers."
+            )
+        return self.itemData(index)
+
+    @property
+    def scan_number(self) -> int | None:
+        """The scan number of the selected scan, or None for 'live'.
+
+        Raises:
+            ValueError: If the current text is neither 'live' nor a listed scan number.
+        """
+        if self.scan_id is None:
+            return None
+        return int(self.currentText())
+
+    @SafeSlot(str)
+    @SafeSlot()
+    def set_scan_id(self, scan_id: str | None = None):
+        """
+        Select the scan with the given scan ID, or 'live' if the scan ID is None or not found.
+
+        Args:
+            scan_id (str | None): The scan ID to select.
+        """
+        if scan_id is not None:
+            for i in range(self.count()):
+                if self.itemData(i) == scan_id:
+                    self.setCurrentIndex(i)
+                    return
+        self.setCurrentText(LIVE_ENTRY)
+
+    @Slot(str)
+    def check_validity(self, input_text: str) -> None:
+        """Validate the current text and update the visual state.
+
+        Args:
+            input_text: Current combobox text.
+        """
+        self._is_valid_input = bool(input_text) and self.findText(input_text) >= 0
+        self._update_validity_style(self._is_valid_input)
+
+    def setEnabled(self, enabled: bool) -> None:  # noqa: N802
+        super().setEnabled(enabled)
+        self._update_validity_style(self._is_valid_input)
+
+    def _update_validity_style(self, is_valid: bool) -> None:
+        if is_valid or not self.isEnabled():
+            self.setStyleSheet("")
+            return
+        self.setStyleSheet("QComboBox { border: 1px solid red; }")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    import sys
+
+    from qtpy.QtWidgets import QApplication
+
+    app = QApplication(sys.argv)
+    combo = ScanIndexComboBox()
+    combo.show()
+    sys.exit(app.exec_())

--- a/tests/unit_tests/test_curve_settings.py
+++ b/tests/unit_tests/test_curve_settings.py
@@ -3,14 +3,10 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from bec_lib.scan_history import ScanHistory
-from qtpy.QtGui import QValidator
 from qtpy.QtWidgets import QComboBox, QVBoxLayout
 
 from bec_widgets.widgets.plots.waveform.settings.curve_settings.curve_setting import CurveSetting
-from bec_widgets.widgets.plots.waveform.settings.curve_settings.curve_tree import (
-    CurveTree,
-    ScanIndexValidator,
-)
+from bec_widgets.widgets.plots.waveform.settings.curve_settings.curve_tree import CurveTree
 from bec_widgets.widgets.plots.waveform.waveform import Waveform
 from tests.unit_tests.client_mocks import dap_plugin_message, mocked_client, mocked_client_with_dap
 from tests.unit_tests.conftest import create_widget
@@ -447,32 +443,10 @@ def test_primary_model_change_removes_duplicate_composite_model(curve_tree_fixtu
     assert dap_child.composite_button.text() == "Composite (2)"
 
 
-def test_scan_index_validator_behavior():
-    """
-    Test ScanIndexValidator allows empty, 'live', partial 'live', valid scan numbers,
-    and rejects invalid or disallowed inputs under the new allowed-set API.
-    """
-    validator = ScanIndexValidator(allowed_scans={1, 2, 3})
-
-    def state(txt):
-        s, _, _ = validator.validate(txt, 0)
-        return s
-
-    assert state("") == QValidator.State.Acceptable
-    assert state("live") == QValidator.State.Acceptable
-    assert state("l") == QValidator.State.Intermediate
-    assert state("liv") == QValidator.State.Intermediate
-    assert state("1") == QValidator.State.Acceptable
-    assert state("3") == QValidator.State.Acceptable
-    assert state("4") == QValidator.State.Invalid
-    assert state("0") == QValidator.State.Invalid
-    assert state("abc") == QValidator.State.Invalid
-
-
 def test_export_data_history_curve(curve_tree_fixture, scan_history_factory):
     """
     Test that export_data for a history curve row correctly serializes scan_number
-    and resets scan_id when a numeric scan is selected.
+    and scan_id when a numeric scan is typed into the scan index combobox.
     """
     curve_tree, wf = curve_tree_fixture
     # Inject two history scans into the waveform client
@@ -494,5 +468,5 @@ def test_export_data_history_curve(curve_tree_fixture, scan_history_factory):
     exported = device_row.export_data()
     assert exported["source"] == "history"
     assert exported["scan_number"] == 2
-    assert exported["scan_id"] is None
+    assert exported["scan_id"] == "hid2"
     assert exported["label"] == "bpm4i-bpm4i-scan-2"

--- a/tests/unit_tests/test_heatmap_widget.py
+++ b/tests/unit_tests/test_heatmap_widget.py
@@ -948,3 +948,149 @@ def test_device_properties_with_none_values(heatmap_widget):
     # Entry None should not change anything
     heatmap_widget.signal_y = None
     assert heatmap_widget.signal_y  # Should still have validated entry
+
+
+def test_heatmap_history_mode_ignores_live_scan_updates(heatmap_widget):
+    """
+    Once pinned to a history scan, the heatmap ignores live scan status/progress updates
+    until plot() is called again without a scan_id.
+    """
+    history_scan = mock.MagicMock()
+    history_scan.scan_id = "scan-456"
+
+    with mock.patch.object(heatmap_widget, "get_history_scan_item", return_value=history_scan):
+        heatmap_widget.update_with_scan_history(scan_id="scan-456")
+
+    assert heatmap_widget._history_scan_id == "scan-456"
+
+    scan_msg = messages.ScanStatusMessage(scan_id="live-scan", status="open", metadata={}, info={})
+    with mock.patch.object(heatmap_widget, "reset") as reset_mock:
+        heatmap_widget.on_scan_status(scan_msg.content, scan_msg.metadata)
+    reset_mock.assert_not_called()
+    assert heatmap_widget.scan_id == "scan-456"
+
+    with mock.patch.object(heatmap_widget, "sync_signal_update") as sync_mock:
+        heatmap_widget.on_scan_progress({"done": False}, {})
+    sync_mock.emit.assert_not_called()
+
+    # Plotting without a scan_id returns to live mode
+    heatmap_widget.plot(device_x="samx", device_y="samy", device_z="bpm4i")
+    assert heatmap_widget._history_scan_id is None
+    with mock.patch.object(heatmap_widget, "reset") as reset_mock:
+        heatmap_widget.on_scan_status(scan_msg.content, scan_msg.metadata)
+    reset_mock.assert_called_once()
+
+
+def test_heatmap_scan_history_popup(heatmap_widget, qtbot):
+    """
+    Test that the scan history popup opens with the browser view and a plot request button,
+    and that requesting a plot pins the heatmap to the selected scan.
+    """
+    scan_action = heatmap_widget.toolbar.components.get_action("scan_history").action
+    assert not scan_action.isChecked()
+    assert heatmap_widget.scan_history_dialog is None
+
+    heatmap_widget.show_scan_history_popup()
+    qtbot.waitUntil(lambda: heatmap_widget.scan_history_dialog is not None)
+    assert heatmap_widget.scan_history_dialog.isVisible()
+    assert scan_action.isChecked()
+    assert heatmap_widget.scan_history_widget is not None
+
+    # Without a selection, requesting a plot does nothing
+    with mock.patch.object(heatmap_widget, "update_with_scan_history") as update_mock:
+        heatmap_widget._request_history_plot()
+    update_mock.assert_not_called()
+
+    # With a selection, requesting a plot pins to the selected scan
+    heatmap_widget._on_history_scan_selected({"scan_id": "scan-789"}, {})
+    with mock.patch.object(heatmap_widget, "update_with_scan_history") as update_mock:
+        heatmap_widget._request_history_plot()
+    update_mock.assert_called_once_with(scan_id="scan-789")
+
+    heatmap_widget._on_history_scan_deselected()
+    assert heatmap_widget._selected_history_scan_id is None
+
+    heatmap_widget.scan_history_dialog.close()
+    qtbot.waitUntil(lambda: heatmap_widget.scan_history_dialog is None)
+    assert not scan_action.isChecked()
+
+
+def test_heatmap_settings_scan_index(heatmap_widget, qtbot):
+    """
+    Test that the settings dialog exposes the scan index combobox and that accepting
+    the dialog with a history scan selected plots that scan.
+    """
+    heatmap_widget.plot(device_x="samx", device_y="samy", device_z="bpm4i")
+    heatmap_widget.show_heatmap_settings()
+    qtbot.waitUntil(lambda: heatmap_widget.heatmap_dialog is not None)
+
+    dialog = heatmap_widget.heatmap_dialog
+    assert hasattr(dialog.widget.ui, "scan_index")
+    assert dialog.widget.ui.scan_index.currentText() == "live"
+
+    dialog.widget.ui.scan_index.addItem("42", "scan-hist-42")
+    dialog.widget.ui.scan_index.setCurrentIndex(dialog.widget.ui.scan_index.count() - 1)
+
+    with mock.patch.object(heatmap_widget, "update_with_scan_history") as update_mock:
+        dialog.accept()
+    qtbot.waitUntil(lambda: heatmap_widget.heatmap_dialog is None)
+    update_mock.assert_called_once_with(scan_id="scan-hist-42")
+
+
+def test_heatmap_config_label_shows_live_or_history(heatmap_widget):
+    """The config label marks the scan number with (live) or (history) depending on the mode."""
+    scan_msg = mock.MagicMock()
+    scan_msg.scan_number = 5
+    scan_msg.scan_name = "line_scan"
+    heatmap_widget.status_message = scan_msg
+    heatmap_widget._image_config.show_config_label = True
+
+    heatmap_widget.redraw_config_label()
+    labels = [label.text for _, label in heatmap_widget.config_label.items]
+    assert "Scan: 5 (live)" in labels
+
+    heatmap_widget._history_scan_id = "scan-1"
+    heatmap_widget.redraw_config_label()
+    labels = [label.text for _, label in heatmap_widget.config_label.items]
+    assert "Scan: 5 (history)" in labels
+
+
+def test_heatmap_settings_scan_index_syncs_with_widget(heatmap_widget, qtbot, scan_history_factory):
+    """
+    The scan index combobox in the settings dialog mirrors the heatmap state:
+    it shows the pinned history scan number, or 'live' in live mode, with scans
+    ordered live -> latest -> oldest.
+    """
+    from bec_lib.scan_history import ScanHistory
+
+    msgs = [
+        scan_history_factory(scan_id="hid1", scan_number=1),
+        scan_history_factory(scan_id="hid2", scan_number=2),
+    ]
+    heatmap_widget.client.history = ScanHistory(heatmap_widget.client, False)
+    for msg in msgs:
+        heatmap_widget.client.history._scan_data[msg.scan_id] = msg
+        heatmap_widget.client.history._scan_ids.append(msg.scan_id)
+        heatmap_widget.client.history._scan_numbers.append(msg.scan_number)
+
+    heatmap_widget.plot(device_x="samx", device_y="samy", device_z="bpm4i")
+    heatmap_widget.show_heatmap_settings()
+    qtbot.waitUntil(lambda: heatmap_widget.heatmap_dialog is not None)
+    combo = heatmap_widget.heatmap_dialog.widget.ui.scan_index
+
+    assert [combo.itemText(i) for i in range(combo.count())] == ["live", "2", "1"]
+    assert combo.currentText() == "live"
+
+    # Pinning the widget to a history scan updates the open settings dialog
+    history_scan = mock.MagicMock()
+    history_scan.scan_id = "hid2"
+    with mock.patch.object(heatmap_widget, "get_history_scan_item", return_value=history_scan):
+        heatmap_widget.update_with_scan_history(scan_id="hid2")
+    assert combo.currentText() == "2"
+
+    # Returning to live mode updates the dialog as well
+    heatmap_widget.plot(device_x="samx", device_y="samy", device_z="bpm4i")
+    assert combo.currentText() == "live"
+
+    heatmap_widget.heatmap_dialog.reject()
+    qtbot.waitUntil(lambda: heatmap_widget.heatmap_dialog is None)

--- a/tests/unit_tests/test_scan_index_combobox.py
+++ b/tests/unit_tests/test_scan_index_combobox.py
@@ -1,0 +1,164 @@
+import pytest
+from bec_lib.scan_history import ScanHistory
+from qtpy.QtCore import Qt
+
+from bec_widgets.widgets.utility.scan_index_combobox.scan_index_combobox import ScanIndexComboBox
+
+# pylint: disable=unused-import
+from tests.unit_tests.client_mocks import mocked_client
+from tests.unit_tests.conftest import create_widget
+
+
+@pytest.fixture
+def scan_index_combo(qtbot, mocked_client, scan_history_factory):
+    """ScanIndexComboBox with two history scans injected into the client."""
+    msgs = [
+        scan_history_factory(scan_id="hid1", scan_number=1),
+        scan_history_factory(scan_id="hid2", scan_number=2),
+    ]
+    mocked_client.history = ScanHistory(mocked_client, False)
+    for msg in msgs:
+        mocked_client.history._scan_data[msg.scan_id] = msg
+        mocked_client.history._scan_ids.append(msg.scan_id)
+        mocked_client.history._scan_numbers.append(msg.scan_number)
+    combo = create_widget(qtbot, ScanIndexComboBox, client=mocked_client)
+    return combo
+
+
+def test_scan_index_combobox_populates_history(scan_index_combo):
+    """The combobox lists 'live' plus all scan numbers (latest first) with scan IDs as item data."""
+    assert scan_index_combo.count() == 3
+    assert scan_index_combo.itemText(0) == "live"
+    assert scan_index_combo.itemData(0) is None
+    assert scan_index_combo.itemText(1) == "2"
+    assert scan_index_combo.itemData(1) == "hid2"
+    assert scan_index_combo.itemText(2) == "1"
+    assert scan_index_combo.itemData(2) == "hid1"
+
+
+def test_scan_index_combobox_scan_id_and_number(scan_index_combo):
+    """scan_id/scan_number map the selection to live (None) or a history scan."""
+    assert scan_index_combo.currentText() == "live"
+    assert scan_index_combo.scan_id is None
+    assert scan_index_combo.scan_number is None
+
+    scan_index_combo.setCurrentIndex(1)
+    assert scan_index_combo.scan_id == "hid2"
+    assert scan_index_combo.scan_number == 2
+
+    # Typing a scan number does not move the current index; scan_id must follow the text
+    scan_index_combo.setCurrentText("live")
+    scan_index_combo.setCurrentText("1")
+    assert scan_index_combo.scan_id == "hid1"
+    assert scan_index_combo.scan_number == 1
+
+
+def test_scan_index_combobox_set_scan_id(scan_index_combo):
+    """set_scan_id selects the matching scan or falls back to 'live'."""
+    scan_index_combo.set_scan_id("hid1")
+    assert scan_index_combo.currentText() == "1"
+
+    scan_index_combo.set_scan_id("unknown")
+    assert scan_index_combo.currentText() == "live"
+
+    scan_index_combo.set_scan_id("hid2")
+    assert scan_index_combo.currentText() == "2"
+    scan_index_combo.set_scan_id(None)
+    assert scan_index_combo.currentText() == "live"
+
+
+def test_scan_index_combobox_refresh_keeps_selection(scan_index_combo):
+    """refresh_scan_indices repopulates the items without losing the current selection."""
+    scan_index_combo.set_scan_id("hid2")
+    scan_index_combo.refresh_scan_indices()
+    assert scan_index_combo.count() == 3
+    assert scan_index_combo.currentText() == "2"
+    assert scan_index_combo.scan_id == "hid2"
+
+
+@pytest.mark.parametrize("history", [None, "empty"])
+def test_scan_index_combobox_empty_history(qtbot, mocked_client, history):
+    """
+    With no scan history (client not started) or an empty one, only 'live' is offered
+    and any typed scan number is flagged as invalid.
+    """
+    mocked_client.history = ScanHistory(mocked_client, False) if history == "empty" else None
+    combo = create_widget(qtbot, ScanIndexComboBox, client=mocked_client)
+
+    assert combo.count() == 1
+    assert combo.currentText() == "live"
+    assert combo.scan_id is None
+    assert combo.scan_number is None
+    assert combo.is_valid_input
+
+    # Typing is not blocked by a validator, but scan numbers are flagged since none exist
+    assert combo.lineEdit().validator() is None
+    combo.lineEdit().clear()
+    qtbot.keyClicks(combo.lineEdit(), "1")
+    assert combo.currentText() == "1"
+    assert not combo.is_valid_input
+    with pytest.raises(ValueError):
+        _ = combo.scan_id
+
+
+def test_scan_index_combobox_typing_multi_digit_scan(qtbot, mocked_client, scan_history_factory):
+    """
+    Multi-digit scan numbers can be typed even when their prefixes are not scan numbers
+    themselves, and the completer autocompletes against the listed entries.
+    """
+    msgs = [
+        scan_history_factory(scan_id="hid101", scan_number=101),
+        scan_history_factory(scan_id="hid105", scan_number=105),
+    ]
+    mocked_client.history = ScanHistory(mocked_client, False)
+    for msg in msgs:
+        mocked_client.history._scan_data[msg.scan_id] = msg
+        mocked_client.history._scan_ids.append(msg.scan_id)
+        mocked_client.history._scan_numbers.append(msg.scan_number)
+    combo = create_widget(qtbot, ScanIndexComboBox, client=mocked_client)
+
+    combo.lineEdit().clear()
+    qtbot.keyClicks(combo.lineEdit(), "101")
+    assert combo.currentText() == "101"
+    assert combo.is_valid_input
+    assert combo.styleSheet() == ""
+    assert combo.scan_id == "hid101"
+    assert combo.scan_number == 101
+
+    # The default editable-combobox completer offers the listed entries while typing
+    completer = combo.completer()
+    assert completer is not None
+    completer.setCompletionPrefix("l")
+    assert completer.currentCompletion() == "live"
+    completer.setCompletionPrefix("10")
+    assert completer.currentCompletion() == "105"
+
+
+def test_scan_index_combobox_invalid_input_flagged(scan_index_combo, qtbot):
+    """
+    Unknown scan numbers can be typed; they are flagged with a red border, raise on
+    read-out, and are not inserted as new items when committed.
+    """
+    combo = scan_index_combo
+    combo.lineEdit().clear()
+    qtbot.keyClicks(combo.lineEdit(), "99")
+    assert combo.currentText() == "99"
+    assert not combo.is_valid_input
+    assert "red" in combo.styleSheet()
+    with pytest.raises(ValueError):
+        _ = combo.scan_id
+    with pytest.raises(ValueError):
+        _ = combo.scan_number
+
+    qtbot.keyClick(combo.lineEdit(), Qt.Key_Return)
+    assert combo.count() == 3
+
+    # A refresh with invalid text falls back to 'live' instead of raising
+    combo.refresh_scan_indices()
+    assert combo.currentText() == "live"
+    assert combo.is_valid_input
+
+    combo.setCurrentText("2")
+    assert combo.is_valid_input
+    assert combo.styleSheet() == ""
+    assert combo.scan_id == "hid2"


### PR DESCRIPTION
## Description

New general combobox to fetch scan number or set live mode isolated from `CurveTree` now reusable. ScanHistory access for Heatmap widget.

## Related Issues

no issues found

## How to test

- Plot something from history in Waveform and Heatmap

## Potential side effects

- If user plots in heatmap scan which is not compatible with heatmap visualization then basically nothing happen.

