### PR TITLE
feat/crosshair-pin

### DIFF
--- a/bec_widgets/utils/crosshair.py
+++ b/bec_widgets/utils/crosshair.py
@@ -7,7 +7,7 @@ import numpy as np
 import pyqtgraph as pg
 from qtpy.QtCore import QObject, QPointF, Qt, Signal
 from qtpy.QtGui import QCursor, QTransform
-from qtpy.QtWidgets import QApplication
+from qtpy.QtWidgets import QApplication, QMenu
 
 from bec_widgets.utils.error_popups import SafeSlot
 from bec_widgets.widgets.plots.image.image_item import ImageItem
@@ -24,6 +24,31 @@ class CrosshairScatterItem(pg.ScatterPlotItem):
         pass
 
 
+class PinScatterItem(CrosshairScatterItem):
+    """Scatter item for the pinned marker, owning its removal context menu.
+
+    Right-clicks must be handled at the item level: item click events are
+    delivered before the ViewBox's, so accepting the event here is the only way
+    to keep pyqtgraph's plot context menu from opening on top of the pin menu.
+    """
+
+    def __init__(self, *args, on_remove=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._on_remove = on_remove
+
+    def mouseClickEvent(self, ev):
+        if ev.button() == Qt.MouseButton.RightButton and self._on_remove is not None:
+            ev.accept()
+            menu = QMenu()
+            remove_action = menu.addAction("Remove pinned marker")
+            chosen = menu.exec_(QCursor.pos())
+            menu.deleteLater()
+            if chosen == remove_action:
+                self._on_remove()
+            return
+        super().mouseClickEvent(ev)
+
+
 class Crosshair(QObject):
     # QT Position of mouse cursor
     positionChanged = Signal(tuple)
@@ -37,6 +62,10 @@ class Crosshair(QObject):
     # Signal for 2D plot
     coordinatesChanged2D = Signal(tuple)
     coordinatesClicked2D = Signal(tuple)
+    # Pinned marker signals (a persistent marker placed on click)
+    coordinatesPinned1D = Signal(tuple)
+    coordinatesPinned2D = Signal(tuple)
+    pinCleared = Signal()
 
     def __init__(
         self,
@@ -101,6 +130,14 @@ class Crosshair(QObject):
         self.marker_clicked_1d = {}
         self.marker_2d_row = None
         self.marker_2d_col = None
+        # Pinned marker (a single persistent marker placed on click). The live
+        # crosshair keeps tracking the cursor; the pin stays until removed.
+        self.pinned_point = None
+        self.pinned_label = None
+        self.pinned_v_line = None
+        self.pinned_h_line = None
+        self.pinned_pos = None
+        self._pin_hit_radius_px = 12  # how close (scene px) a click counts as "on the pin"
         self.update_markers()
         self.check_log()
         self.check_derivatives()
@@ -489,13 +526,16 @@ class Crosshair(QObject):
             event: The mouse clicked event
         """
 
-        # we only accept left mouse clicks
+        # we only accept left mouse clicks; right-clicks on the pin are handled
+        # by the PinScatterItem itself (item events precede the ViewBox menu).
         if event.button() != Qt.MouseButton.LeftButton:
             return
         self.update_markers()
         if self.plot_item.vb.sceneBoundingRect().contains(event._scenePos):
             mouse_point = self.plot_item.vb.mapSceneToView(event._scenePos)
             x, y = mouse_point.x(), mouse_point.y()
+            # Keep the raw click position; ``x``/``y`` are reused/snapped below.
+            pin_x, pin_y = mouse_point.x(), mouse_point.y()
             scaled_x, scaled_y = self.scale_emitted_coordinates(mouse_point.x(), mouse_point.y())
             self.crosshairClicked.emit((scaled_x, scaled_y))
             self.positionClicked.emit((x, y))
@@ -544,6 +584,147 @@ class Crosshair(QObject):
                     self.coordinatesClicked2D.emit(coordinate_to_emit)
                 else:
                     continue
+
+            # Pinned marker: double-click clears it, clicking the existing pin
+            # removes it, otherwise (re)place a single pin at the clicked point.
+            if event.double():
+                self.clear_pin()
+            elif self._pin_hit(event._scenePos):
+                self.clear_pin()
+            else:
+                self.set_pin(pin_x, pin_y, x_snap_values, y_snap_values)
+
+    def set_pin(self, x: float, y: float, x_snap=None, y_snap=None):
+        """Place (or move) the single pinned marker at the data point nearest to (x, y).
+
+        The pin is independent of the live crosshair: it stays in place until removed.
+        Emits :attr:`coordinatesPinned1D` / :attr:`coordinatesPinned2D` with the snapped
+        coordinates so consumers (e.g. the image ROI panels) can freeze a reference.
+
+        Args:
+            x (float): The x-coordinate of the click, in plot coordinates.
+            y (float): The y-coordinate of the click, in plot coordinates.
+            x_snap, y_snap: Optionally pre-computed snap dictionaries (from
+                :meth:`snap_to_data`) to avoid recomputing them.
+        """
+        # Make sure the tracked items are current (e.g. when called programmatically).
+        self.update_markers()
+        if x_snap is None or y_snap is None:
+            x_snap, y_snap = self.snap_to_data(x, y)
+        if x_snap is None or y_snap is None:
+            return
+
+        precision = self._current_precision()
+        draw_pt = None
+        pinned_1d = None
+        pinned_2d = None
+        for item in self.items:
+            if isinstance(item, pg.PlotDataItem):
+                name = item.name() or str(id(item))
+                sx, sy = x_snap.get(name), y_snap.get(name)
+                if sx is None or sy is None:
+                    continue
+                draw_pt = (sx, sy)
+                sx_s, sy_s = self.scale_emitted_coordinates(sx, sy)
+                pinned_1d = (name, round(sx_s, precision), round(sy_s, precision))
+                break
+            elif isinstance(item, pg.ImageItem):
+                name = item.objectName() or str(id(item))
+                px, py = x_snap.get(name), y_snap.get(name)
+                if px is None or py is None:
+                    continue
+                # Pin the marker at the pixel centre, mapped back into plot coordinates.
+                if isinstance(item, ImageItem) and item.image_transform is not None:
+                    pt = item.image_transform.map(QPointF(px + 0.5, py + 0.5))
+                    draw_pt = (pt.x(), pt.y())
+                else:
+                    draw_pt = (px + 0.5, py + 0.5)
+                pinned_2d = (name, px, py)
+                break
+
+        if draw_pt is None:
+            return
+
+        self._draw_pin(draw_pt[0], draw_pt[1])
+        self.pinned_pos = draw_pt
+        if pinned_2d is not None:
+            self.coordinatesPinned2D.emit(pinned_2d)
+        if pinned_1d is not None:
+            self.coordinatesPinned1D.emit(pinned_1d)
+
+    def _draw_pin(self, x: float, y: float):
+        """Create/move the pinned marker at plot coordinates (x, y).
+
+        The pin is drawn as a frozen crosshair: dashed infinite lines plus a small dot
+        and a coordinate label, so it is visually distinct from the live crosshair.
+        """
+        pin_pen = pg.mkPen("#f2c037", width=1, style=Qt.PenStyle.DashLine)
+        if self.pinned_v_line is None:
+            self.pinned_v_line = pg.InfiniteLine(angle=90, movable=False, pen=pin_pen)
+            self.pinned_v_line.skip_auto_range = True
+            self.pinned_v_line.is_crosshair = True
+            self.pinned_v_line.setZValue(999)
+            self.plot_item.addItem(self.pinned_v_line, ignoreBounds=True)
+        if self.pinned_h_line is None:
+            self.pinned_h_line = pg.InfiniteLine(angle=0, movable=False, pen=pin_pen)
+            self.pinned_h_line.skip_auto_range = True
+            self.pinned_h_line.is_crosshair = True
+            self.pinned_h_line.setZValue(999)
+            self.plot_item.addItem(self.pinned_h_line, ignoreBounds=True)
+        self.pinned_v_line.setPos(x)
+        self.pinned_h_line.setPos(y)
+
+        if self.pinned_point is None:
+            self.pinned_point = PinScatterItem(
+                size=9,
+                symbol="o",
+                pen=pg.mkPen("#3a2d00", width=1.5),
+                brush=pg.mkBrush("#f2c037"),
+                on_remove=self.clear_pin,
+            )
+            self.pinned_point.skip_auto_range = True
+            self.pinned_point.is_crosshair = True
+            self.pinned_point.setZValue(1000)
+            self.plot_item.addItem(self.pinned_point)
+        self.pinned_point.setData([x], [y])
+
+        if self.pinned_label is None:
+            self.pinned_label = pg.TextItem("", anchor=(0, 1), color="#f2c037", fill=(0, 0, 0, 150))
+            self.pinned_label.skip_auto_range = True
+            self.pinned_label.setZValue(1000)
+            self.plot_item.addItem(self.pinned_label)
+        x_scaled, y_scaled = self.scale_emitted_coordinates(x, y)
+        precision = self._current_precision()
+        self.pinned_label.setText(f"pin ({x_scaled:.{precision}f}, {y_scaled:.{precision}f})")
+        self.pinned_label.setPos(x, y)
+        self.pinned_label.setVisible(True)
+
+    def clear_pin(self):
+        """Remove the pinned marker (if any) and notify consumers via :attr:`pinCleared`."""
+        had_pin = self.pinned_pos is not None
+        if self.pinned_point is not None:
+            self.plot_item.removeItem(self.pinned_point)
+            self.pinned_point = None
+        if self.pinned_v_line is not None:
+            self.plot_item.removeItem(self.pinned_v_line)
+            self.pinned_v_line = None
+        if self.pinned_h_line is not None:
+            self.plot_item.removeItem(self.pinned_h_line)
+            self.pinned_h_line = None
+        if self.pinned_label is not None:
+            self.plot_item.removeItem(self.pinned_label)
+            self.pinned_label = None
+        self.pinned_pos = None
+        if had_pin:
+            self.pinCleared.emit()
+
+    def _pin_hit(self, scene_pos) -> bool:
+        """Return True if a click at ``scene_pos`` (scene pixels) lands on the pinned marker."""
+        if self.pinned_pos is None:
+            return False
+        pin_scene = self.plot_item.vb.mapViewToScene(QPointF(*self.pinned_pos))
+        delta = pin_scene - scene_pos
+        return (delta.x() ** 2 + delta.y() ** 2) ** 0.5 <= self._pin_hit_radius_px
 
     def _get_transformed_position(
         self, x: float, y: float, transform: QTransform
@@ -626,11 +807,16 @@ class Crosshair(QObject):
         self.is_log_x = self.plot_item.axes["bottom"]["item"].logMode
         self.is_log_y = self.plot_item.axes["left"]["item"].logMode
         self.clear_markers()
+        # The pin is stored in view coordinates, which change meaning when the
+        # axis scale changes; a stale pin would be drawn at the wrong data point.
+        self.clear_pin()
 
     def check_derivatives(self):
         """Checks if the derivatives are enabled and updates the internal state accordingly."""
         self.is_derivative = self.plot_item.ctrl.derivativeCheck.isChecked()
         self.clear_markers()
+        # Same as check_log: the plotted data changes meaning, so drop the pin.
+        self.clear_pin()
 
     @SafeSlot()
     def reset(self):
@@ -641,6 +827,7 @@ class Crosshair(QObject):
         if self.marker_2d_col is not None:
             self.plot_item.removeItem(self.marker_2d_col)
             self.marker_2d_col = None
+        self.clear_pin()
         self.clear_markers()
 
     def cleanup(self):

--- a/bec_widgets/utils/crosshair.py
+++ b/bec_widgets/utils/crosshair.py
@@ -718,6 +718,51 @@ class Crosshair(QObject):
         if had_pin:
             self.pinCleared.emit()
 
+    def release_pin(self):
+        """Detach the pin from this crosshair *without* removing it from the plot.
+
+        Used when the crosshair is unhooked (e.g. toggled off) but the pin should
+        stay on the plot. Returns a state dict that :meth:`adopt_pin` can use to
+        re-attach the same items to a future crosshair, or ``None`` if there is no pin.
+        """
+        if self.pinned_pos is None:
+            return None
+        state = {
+            "point": self.pinned_point,
+            "v_line": self.pinned_v_line,
+            "h_line": self.pinned_h_line,
+            "label": self.pinned_label,
+            "pos": self.pinned_pos,
+        }
+        # Detach the removal callback: this crosshair is about to be deleted and a
+        # detached pin has no owner to clear it through.
+        if self.pinned_point is not None:
+            self.pinned_point._on_remove = None
+        # Drop our references without removing the graphics items from the plot.
+        self.pinned_point = None
+        self.pinned_v_line = None
+        self.pinned_h_line = None
+        self.pinned_label = None
+        self.pinned_pos = None
+        return state
+
+    def adopt_pin(self, state):
+        """Re-attach a pin previously detached with :meth:`release_pin`.
+
+        The graphics items are already on the plot item; this only restores the
+        references so the crosshair can manage (move / clear) the pin again.
+        """
+        if not state:
+            return
+        self.pinned_point = state.get("point")
+        self.pinned_v_line = state.get("v_line")
+        self.pinned_h_line = state.get("h_line")
+        self.pinned_label = state.get("label")
+        self.pinned_pos = state.get("pos")
+        # Rebind the removal callback to this crosshair (the previous owner is gone).
+        if self.pinned_point is not None:
+            self.pinned_point._on_remove = self.clear_pin
+
     def _pin_hit(self, scene_pos) -> bool:
         """Return True if a click at ``scene_pos`` (scene pixels) lands on the pinned marker."""
         if self.pinned_pos is None:

--- a/bec_widgets/utils/crosshair.py
+++ b/bec_widgets/utils/crosshair.py
@@ -130,6 +130,7 @@ class Crosshair(QObject):
         self.marker_clicked_1d = {}
         self.marker_2d_row = None
         self.marker_2d_col = None
+        self._image_marker_geometry = None
         # Pinned marker (a single persistent marker placed on click). The live
         # crosshair keeps tracking the cursor; the pin stays until removed.
         self.pinned_point = None
@@ -331,27 +332,72 @@ class Crosshair(QObject):
         Update markers when the image changes, e.g. when the
         image shape or transformation changes.
         """
+        self.update_image_marker_geometry()
+        self.update_pinned_label()
+
+        # Explicit callers may need the live crosshair refreshed from the
+        # cursor. Image update notifications intentionally do not take this
+        # path: synthesizing mouse moves for each incoming frame is expensive.
+        views = self.plot_item.vb.scene().views()
+        if not views:
+            return
+        view = views[0]
+        global_pos = QCursor.pos()
+        view_pos = view.mapFromGlobal(global_pos)
+        scene_pos = view.mapToScene(view_pos)
+
+        if self.plot_item.vb.sceneBoundingRect().contains(scene_pos):
+            plot_pt = self.plot_item.vb.mapSceneToView(scene_pos)
+            self.mouse_moved(manual_pos=(plot_pt.x(), plot_pt.y()))
+
+    def update_image_marker_geometry(self) -> None:
+        """Update 2D marker geometry only when the image geometry changes."""
+        geometry = {}
         for item in self.items:
-            if not isinstance(item, pg.ImageItem):
+            if not isinstance(item, pg.ImageItem) or item.image is None:
                 continue
+            transform = item.image_transform or QTransform()
+            geometry[id(item)] = (
+                item.image.shape[0],
+                item.image.shape[1],
+                self._transform_signature(transform),
+            )
+
+        if geometry == self._image_marker_geometry:
+            return
+
+        self._image_marker_geometry = geometry
+        for item in self.items:
+            if not isinstance(item, pg.ImageItem) or item.image is None:
+                continue
+            transform = item.image_transform or QTransform()
             if self.marker_2d_row is not None:
                 self.marker_2d_row.setSize([item.image.shape[0], 1])
-                self.marker_2d_row.setTransform(item.image_transform)
+                self.marker_2d_row.setTransform(transform)
             if self.marker_2d_col is not None:
                 self.marker_2d_col.setSize([1, item.image.shape[1]])
-                self.marker_2d_col.setTransform(item.image_transform)
-            # Get the current mouse position
-            views = self.plot_item.vb.scene().views()
-            if not views:
-                return
-            view = views[0]
-            global_pos = QCursor.pos()
-            view_pos = view.mapFromGlobal(global_pos)
-            scene_pos = view.mapToScene(view_pos)
+                self.marker_2d_col.setTransform(transform)
 
-            if self.plot_item.vb.sceneBoundingRect().contains(scene_pos):
-                plot_pt = self.plot_item.vb.mapSceneToView(scene_pos)
-                self.mouse_moved(manual_pos=(plot_pt.x(), plot_pt.y()))
+    @staticmethod
+    def _transform_signature(transform: QTransform) -> tuple[float, ...]:
+        """Return a value-based transform signature for geometry change detection."""
+        return (
+            transform.m11(),
+            transform.m12(),
+            transform.m13(),
+            transform.m21(),
+            transform.m22(),
+            transform.m23(),
+            transform.m31(),
+            transform.m32(),
+            transform.m33(),
+        )
+
+    def update_pinned_label(self) -> None:
+        """Refresh the pinned marker label against the current plotted data."""
+        if self.pinned_pos is None or self.pinned_label is None:
+            return
+        self.pinned_label.setText(self._coord_label_text(*self.pinned_pos, prefix="pin "))
 
     def snap_to_data(
         self, x: float, y: float
@@ -698,9 +744,7 @@ class Crosshair(QObject):
             self.pinned_label.skip_auto_range = True
             self.pinned_label.setZValue(1000)
             self.plot_item.addItem(self.pinned_label)
-        x_scaled, y_scaled = self.scale_emitted_coordinates(x, y)
-        precision = self._current_precision()
-        self.pinned_label.setText(f"pin ({x_scaled:.{precision}f}, {y_scaled:.{precision}f})")
+        self.pinned_label.setText(self._coord_label_text(x, y, prefix="pin "))
         self.pinned_label.setPos(x, y)
         self.pinned_label.setVisible(True)
 
@@ -811,6 +855,7 @@ class Crosshair(QObject):
 
     def clear_markers(self):
         """Clears the markers from the plot."""
+        self._image_marker_geometry = None
         for marker in self.marker_moved_1d.values():
             self.plot_item.removeItem(marker)
         for markers in self.marker_clicked_1d.values():
@@ -842,9 +887,16 @@ class Crosshair(QObject):
             pos (tuple): The (x, y) position of the crosshair.
         """
         x, y = pos
+        # Update coordinate label
+        self.coord_label.setText(self._coord_label_text(x, y))
+        self.coord_label.setPos(x, y)
+        self.coord_label.setVisible(True)
+
+    def _coord_label_text(self, x: float, y: float, *, prefix: str = "") -> str:
+        """Return coordinate label text, including image intensity for 2D plots."""
         x_scaled, y_scaled = self.scale_emitted_coordinates(x, y)
         precision = self._current_precision()
-        text = f"({x_scaled:.{precision}f}, {y_scaled:.{precision}f})"
+        text = f"{prefix}({x_scaled:.{precision}f}, {y_scaled:.{precision}f})"
         for item in self.items:
             if isinstance(item, pg.ImageItem):
                 image = item.image
@@ -865,10 +917,7 @@ class Crosshair(QObject):
                 intensity = image[ix, iy]
                 text += f"\nIntensity: {intensity:.{precision}f}"
                 break
-        # Update coordinate label
-        self.coord_label.setText(text)
-        self.coord_label.setPos(x, y)
-        self.coord_label.setVisible(True)
+        return text
 
     def check_log(self):
         """Checks if the x or y axis is in log scale and updates the internal state accordingly."""

--- a/bec_widgets/utils/crosshair.py
+++ b/bec_widgets/utils/crosshair.py
@@ -865,18 +865,23 @@ class Crosshair(QObject):
 
     @SafeSlot()
     def reset(self):
-        """Resets the crosshair to its initial state."""
+        """Reset the transient crosshair markers (e.g. on new data / a new scan).
+
+        The pinned marker is intentionally *not* cleared here: it is a persistent
+        user annotation that survives data and scan changes. Use :meth:`clear_pin`
+        for an explicit removal and :meth:`cleanup` for full teardown.
+        """
         if self.marker_2d_row is not None:
             self.plot_item.removeItem(self.marker_2d_row)
             self.marker_2d_row = None
         if self.marker_2d_col is not None:
             self.plot_item.removeItem(self.marker_2d_col)
             self.marker_2d_col = None
-        self.clear_pin()
         self.clear_markers()
 
     def cleanup(self):
         self.reset()
+        self.clear_pin()
         self.plot_item.removeItem(self.v_line)
         self.plot_item.removeItem(self.h_line)
         self.plot_item.removeItem(self.coord_label)

--- a/bec_widgets/utils/crosshair.py
+++ b/bec_widgets/utils/crosshair.py
@@ -137,6 +137,9 @@ class Crosshair(QObject):
         self.pinned_v_line = None
         self.pinned_h_line = None
         self.pinned_pos = None
+        # Last emitted pin payload, kept so the pin can be re-announced to consumers
+        # after it is re-adopted: ("2d", payload) | ("1d", payload) | None.
+        self._pinned_emit = None
         self._pin_hit_radius_px = 12  # how close (scene px) a click counts as "on the pin"
         self.update_markers()
         self.check_log()
@@ -648,8 +651,10 @@ class Crosshair(QObject):
         self._draw_pin(draw_pt[0], draw_pt[1])
         self.pinned_pos = draw_pt
         if pinned_2d is not None:
+            self._pinned_emit = ("2d", pinned_2d)
             self.coordinatesPinned2D.emit(pinned_2d)
-        if pinned_1d is not None:
+        elif pinned_1d is not None:
+            self._pinned_emit = ("1d", pinned_1d)
             self.coordinatesPinned1D.emit(pinned_1d)
 
     def _draw_pin(self, x: float, y: float):
@@ -715,6 +720,7 @@ class Crosshair(QObject):
             self.plot_item.removeItem(self.pinned_label)
             self.pinned_label = None
         self.pinned_pos = None
+        self._pinned_emit = None
         if had_pin:
             self.pinCleared.emit()
 
@@ -733,6 +739,7 @@ class Crosshair(QObject):
             "h_line": self.pinned_h_line,
             "label": self.pinned_label,
             "pos": self.pinned_pos,
+            "emit": self._pinned_emit,
         }
         # Detach the removal callback: this crosshair is about to be deleted and a
         # detached pin has no owner to clear it through.
@@ -744,6 +751,7 @@ class Crosshair(QObject):
         self.pinned_h_line = None
         self.pinned_label = None
         self.pinned_pos = None
+        self._pinned_emit = None
         return state
 
     def adopt_pin(self, state):
@@ -759,9 +767,24 @@ class Crosshair(QObject):
         self.pinned_h_line = state.get("h_line")
         self.pinned_label = state.get("label")
         self.pinned_pos = state.get("pos")
+        self._pinned_emit = state.get("emit")
         # Rebind the removal callback to this crosshair (the previous owner is gone).
         if self.pinned_point is not None:
             self.pinned_point._on_remove = self.clear_pin
+
+    def reemit_pin(self):
+        """Re-announce the current pin's coordinates to consumers.
+
+        Used after :meth:`adopt_pin` so dependent state (e.g. the image ROI panels'
+        frozen reference profiles) can be rebuilt for a pin that survived a toggle.
+        """
+        if self._pinned_emit is None:
+            return
+        kind, payload = self._pinned_emit
+        if kind == "2d":
+            self.coordinatesPinned2D.emit(payload)
+        elif kind == "1d":
+            self.coordinatesPinned1D.emit(payload)
 
     def _pin_hit(self, scene_pos) -> bool:
         """Return True if a click at ``scene_pos`` (scene pixels) lands on the pinned marker."""

--- a/bec_widgets/utils/crosshair.py
+++ b/bec_widgets/utils/crosshair.py
@@ -393,6 +393,20 @@ class Crosshair(QObject):
             transform.m33(),
         )
 
+    @SafeSlot()
+    def update_on_image_change(self) -> None:
+        """Refresh image-dependent crosshair state after the image data changed.
+
+        The live and the pinned coordinate use the same mechanism: each label is
+        rebuilt from its coordinate against the current image (the live label
+        otherwise only refreshes on mouse moves, which would leave a stale
+        intensity under a streaming image).
+        """
+        self.update_image_marker_geometry()
+        if self.coord_label.isVisible():
+            self.update_coord_label((self.v_line.value(), self.h_line.value()))
+        self.update_pinned_label()
+
     def update_pinned_label(self) -> None:
         """Refresh the pinned marker label against the current plotted data."""
         if self.pinned_pos is None or self.pinned_label is None:
@@ -744,9 +758,10 @@ class Crosshair(QObject):
             self.pinned_label.skip_auto_range = True
             self.pinned_label.setZValue(1000)
             self.plot_item.addItem(self.pinned_label)
-        self.pinned_label.setText(self._coord_label_text(x, y, prefix="pin "))
+        self.pinned_pos = (x, y)
         self.pinned_label.setPos(x, y)
         self.pinned_label.setVisible(True)
+        self.update_pinned_label()
 
     def clear_pin(self):
         """Remove the pinned marker (if any) and notify consumers via :attr:`pinCleared`."""

--- a/bec_widgets/widgets/plots/heatmap/heatmap.py
+++ b/bec_widgets/widgets/plots/heatmap/heatmap.py
@@ -741,8 +741,6 @@ class Heatmap(ImageBase):
         if self._color_bar is not None:
             self._color_bar.blockSignals(False)
         self.image_updated.emit()
-        if self.crosshair is not None:
-            self.crosshair.update_markers_on_image_change()
 
     def _request_step_scan_interpolation(
         self,

--- a/bec_widgets/widgets/plots/heatmap/heatmap.py
+++ b/bec_widgets/widgets/plots/heatmap/heatmap.py
@@ -740,6 +740,8 @@ class Heatmap(ImageBase):
         self.main_image.set_data(img, transform=transform)
         if self._color_bar is not None:
             self._color_bar.blockSignals(False)
+        # Crosshair labels and pinned profiles refresh via image_updated
+        # (ImageBase._on_image_updated_refresh).
         self.image_updated.emit()
 
     def _request_step_scan_interpolation(

--- a/bec_widgets/widgets/plots/image/image_base.py
+++ b/bec_widgets/widgets/plots/image/image_base.py
@@ -658,6 +658,10 @@ class ImageBase(PlotBase):
             self.crosshair.coordinatesPinned2D.connect(self.pin_image_slices)
             self.crosshair.pinCleared.connect(self.clear_pinned_slices)
             self.image_updated.connect(self.update_image_slices)
+            # If a pin survived a previous toggle, rebuild its frozen profiles now that
+            # the consumer slots are connected again.
+            if self.crosshair.pinned_pos is not None:
+                self.crosshair.reemit_pin()
         else:
             self.unhook_crosshair()
             # Hide the ROI panels (the crosshair is destroyed, so its pin signals

--- a/bec_widgets/widgets/plots/image/image_base.py
+++ b/bec_widgets/widgets/plots/image/image_base.py
@@ -276,9 +276,14 @@ class ImageBase(PlotBase):
         )
         self.layer_manager.add("main")
         self._init_image_base_toolbar()
-        self._crosshair_image_update_proxy = pg.SignalProxy(
-            self.image_updated, rateLimit=10, slot=self._on_crosshair_image_update
-        )
+        # The pinned array coordinates are tracked at widget level so the pinned
+        # profiles can refresh regardless of the crosshair lifecycle.
+        self.crosshair_coordinates_pinned.connect(self._on_pin_coordinates)
+        self.crosshair_pin_cleared.connect(self._on_pin_cleared)
+        # Live and pinned crosshair coordinates share one refresh mechanism; the
+        # live label otherwise only refreshes on mouse moves, which would leave a
+        # stale intensity under a streaming image.
+        self.image_updated.connect(self._on_image_updated_refresh)
 
         self.autorange = True
         self.autorange_mode = "mean"
@@ -309,10 +314,32 @@ class ImageBase(PlotBase):
             self.x_roi.apply_theme(theme)
             self.y_roi.apply_theme(theme)
 
-    @SafeSlot(object)
-    def _on_crosshair_image_update(self, _event=None) -> None:
-        """Rate-limited crosshair refresh after image data changes."""
-        self.update_crosshair_on_image_change()
+    @SafeSlot(tuple)
+    def _on_pin_coordinates(self, coordinates: tuple) -> None:
+        """Track the pinned array coordinates.
+
+        Args:
+            coordinates (tuple): ``(name, row, col)`` as emitted by the crosshair.
+        """
+        self._pinned_slice_coords = (coordinates[1], coordinates[2])
+
+    @SafeSlot()
+    def _on_pin_cleared(self) -> None:
+        """Forget the pinned coordinates once the pin is removed."""
+        self._pinned_slice_coords = None
+
+    @SafeSlot()
+    def _on_image_updated_refresh(self) -> None:
+        """Refresh crosshair labels and pinned profiles after the image changed.
+
+        The live and the pinned coordinate use the same mechanism: each label and
+        each profile is rebuilt from its coordinate against the current image.
+        """
+        if self.crosshair is not None:
+            self.crosshair.update_on_image_change()
+        else:
+            self._update_detached_pin_label()
+        self.update_image_slices(pinned=True)
 
     def add_layer(self, name: str | None = None, **kwargs) -> ImageLayer:
         """
@@ -617,11 +644,14 @@ class ImageBase(PlotBase):
         self.y_roi.plot_item.setYLink(self.plot_item)
 
         # Persistent live profile curves (updated in place so a pinned reference
-        # curve is not wiped on every crosshair move) and the frozen pinned curves.
+        # curve is not wiped on every crosshair move) and the pinned curves that
+        # follow the image data at a fixed pixel.
         self.x_roi_curve = None
         self.y_roi_curve = None
         self.x_roi_pinned = None
         self.y_roi_pinned = None
+        # Pinned pixel (array indices) for the pinned profile refreshes.
+        self._pinned_slice_coords: tuple[int, int] | None = None
         self.x_roi.apply_theme("dark")
         self.y_roi.apply_theme("dark")
 
@@ -662,65 +692,91 @@ class ImageBase(PlotBase):
             self.side_panel_x.show_panel(self.x_panel_index)
             self.side_panel_y.show_panel(self.y_panel_index)
             self.crosshair.coordinatesChanged2D.connect(self.update_image_slices)
-            # Clicking pins a static copy of the current X/Y profiles for comparison.
+            # Clicking pins the X/Y profiles at a fixed pixel for comparison.
             self.crosshair.coordinatesPinned2D.connect(self.pin_image_slices)
             self.crosshair.pinCleared.connect(self.clear_pinned_slices)
             self.image_updated.connect(self.update_image_slices)
-            # If a pin survived a previous toggle, rebuild its frozen profiles now that
+            self.update_image_slices()
+            # If a pin survived a previous toggle, rebuild its profiles now that
             # the consumer slots are connected again.
             if self.crosshair.pinned_pos is not None:
                 self.crosshair.reemit_pin()
         else:
             self.unhook_crosshair()
             # Hide the ROI panels (the crosshair is destroyed, so its pin signals
-            # disconnect automatically; just drop any frozen reference curves).
+            # disconnect automatically; just drop the pinned reference curves).
             self.clear_pinned_slices()
             self.side_panel_x.hide_panel()
             self.side_panel_y.hide_panel()
             self.image_updated.disconnect(self.update_image_slices)
 
     @SafeSlot()
-    def update_image_slices(self, coordinates: tuple[int, int, int] = None):
+    def update_image_slices(
+        self, coordinates: tuple[int, int, int] | None = None, *, pinned: bool = False
+    ):
         """
-        Update the image slices based on the crosshair position.
+        Update the X/Y profile curves at a pixel position.
+
+        The live crosshair and the pinned marker share this logic; ``pinned``
+        selects which pair of curves is updated and how it is styled. The live
+        pixel comes from ``coordinates`` (or the crosshair lines), the pinned
+        pixel is the stored pin position.
 
         Args:
-            coordinates(tuple): The coordinates of the crosshair.
+            coordinates(tuple): ``(name, row, col)`` pixel coordinates for the
+                live curves; ignored for the pinned curves.
+            pinned(bool): Update the pinned reference curves instead of the live ones.
         """
-        if coordinates is None:
-            # Try to get coordinates from crosshair position (like in crosshair mouse_moved)
-            if (
-                hasattr(self, "crosshair")
-                and hasattr(self.crosshair, "v_line")
-                and hasattr(self.crosshair, "h_line")
-            ):
-                x = int(round(self.crosshair.v_line.value()))
-                y = int(round(self.crosshair.h_line.value()))
-            else:
+        if pinned:
+            if self._pinned_slice_coords is None:
                 return
+            row, col = self._pinned_slice_coords
+        elif coordinates is not None:
+            row, col = coordinates[1], coordinates[2]
+        elif (
+            hasattr(self, "crosshair")
+            and hasattr(self.crosshair, "v_line")
+            and hasattr(self.crosshair, "h_line")
+        ):
+            # Fall back to the crosshair line positions (like crosshair mouse_moved).
+            row = int(round(self.crosshair.v_line.value()))
+            col = int(round(self.crosshair.h_line.value()))
         else:
-            x = coordinates[1]
-            y = coordinates[2]
+            return
+
         image_item = self.layer_manager["main"].image
-        slices = self._compute_image_slices(image_item, x, y)
+        slices = self._compute_image_slices(image_item, row, col)
         if slices is None:
             return
         h_world_x, h_slice, v_world_y, v_slice = slices
 
-        # Update the live curves in place. They are persistent (rather than
-        # clear()+plot() each time) so a pinned reference curve survives.
+        # Curves are persistent and updated in place (rather than clear()+plot())
+        # so the other pair survives every refresh.
+        if pinned:
+            if self.x_roi_pinned is None:
+                # Solid pen on purpose: Qt's dash stroker on a many-segment profile
+                # curve is 10-20x more expensive to paint and dominates the whole
+                # panel repaint.
+                pen = pg.mkPen("#f2c037", width=2)
+                self.x_roi_pinned = self.x_roi.plot_item.plot(h_world_x, h_slice, pen=pen)
+                self.y_roi_pinned = self.y_roi.plot_item.plot(v_slice, v_world_y, pen=pen)
+                # Keep the pinned styling when the ROI plots re-pen on theme change.
+                self.x_roi_pinned.is_pinned_reference = True
+                self.y_roi_pinned.is_pinned_reference = True
+            else:
+                self.x_roi_pinned.setData(h_world_x, h_slice)
+                self.y_roi_pinned.setData(v_slice, v_world_y)
+            return
+
         if self.x_roi_curve is None:
             self.x_roi_curve = self.x_roi.plot_item.plot(
                 h_world_x, h_slice, pen=pg.mkPen(self.x_roi.curve_color, width=3)
             )
-        else:
-            self.x_roi_curve.setData(h_world_x, h_slice)
-
-        if self.y_roi_curve is None:
             self.y_roi_curve = self.y_roi.plot_item.plot(
                 v_slice, v_world_y, pen=pg.mkPen(self.y_roi.curve_color, width=3)
             )
         else:
+            self.x_roi_curve.setData(h_world_x, h_slice)
             self.y_roi_curve.setData(v_slice, v_world_y)
 
     def _compute_image_slices(self, image_item, row: int, col: int):
@@ -762,34 +818,22 @@ class ImageBase(PlotBase):
         return h_world_x, h_slice, v_world_y, v_slice
 
     @SafeSlot(tuple)
-    def pin_image_slices(self, coordinates: tuple):
-        """Freeze the X/Y profiles at the pinned pixel as static reference curves.
+    def pin_image_slices(self, _coordinates: tuple):
+        """Create or update the pinned profile curves at the pinned pixel.
 
         Args:
-            coordinates (tuple): ``(name, row, col)`` pixel coordinates of the pin, as
-                emitted by the crosshair's ``coordinatesPinned2D`` signal.
+            _coordinates (tuple): ``(name, row, col)`` from ``coordinatesPinned2D``;
+                the pixel itself is tracked by ``_on_pin_coordinates``.
         """
-        image_item = self.layer_manager["main"].image
-        slices = self._compute_image_slices(image_item, coordinates[1], coordinates[2])
-        if slices is None:
-            return
-        h_world_x, h_slice, v_world_y, v_slice = slices
-        # Single pin: drop any previously frozen curves first.
-        self.clear_pinned_slices()
-        # Solid pen on purpose: Qt's dash stroker on a many-segment profile curve is
-        # 10-20x more expensive to paint than a solid stroke, which stalls the GUI
-        # thread on every image update while a pin is active. The straight pin
-        # InfiniteLines can stay dashed cheaply; these data curves cannot.
-        pen = pg.mkPen("#f2c037", width=2)
-        self.x_roi_pinned = self.x_roi.plot_item.plot(h_world_x, h_slice, pen=pen)
-        self.y_roi_pinned = self.y_roi.plot_item.plot(v_slice, v_world_y, pen=pen)
-        # Keep the frozen reference styling when the ROI plots re-pen on theme change.
-        self.x_roi_pinned.is_pinned_reference = True
-        self.y_roi_pinned.is_pinned_reference = True
+        self.update_image_slices(pinned=True)
 
     @SafeSlot()
     def clear_pinned_slices(self):
-        """Remove the frozen pinned profile curves, if present."""
+        """Remove the pinned profile curves, if present.
+
+        The pinned coordinates are kept: the pin itself may still exist (e.g. the
+        ROI panels were toggled off) and its label keeps following the image.
+        """
         if self.x_roi_pinned is not None:
             self.x_roi.plot_item.removeItem(self.x_roi_pinned)
             self.x_roi_pinned = None
@@ -1133,9 +1177,6 @@ class ImageBase(PlotBase):
         Cleanup the widget.
         """
         self.toolbar.cleanup()
-        if self._crosshair_image_update_proxy is not None:
-            self._crosshair_image_update_proxy.disconnect()
-            self._crosshair_image_update_proxy = None
 
         # Remove all ROIs
         rois = self.rois

--- a/bec_widgets/widgets/plots/image/image_base.py
+++ b/bec_widgets/widgets/plots/image/image_base.py
@@ -607,6 +607,13 @@ class ImageBase(PlotBase):
         self.x_roi.plot_item.setXLink(self.plot_item)
         self.y_roi = ImageROIPlot(parent=self)
         self.y_roi.plot_item.setYLink(self.plot_item)
+
+        # Persistent live profile curves (updated in place so a pinned reference
+        # curve is not wiped on every crosshair move) and the frozen pinned curves.
+        self.x_roi_curve = None
+        self.y_roi_curve = None
+        self.x_roi_pinned = None
+        self.y_roi_pinned = None
         self.x_roi.apply_theme("dark")
         self.y_roi.apply_theme("dark")
 
@@ -647,10 +654,15 @@ class ImageBase(PlotBase):
             self.side_panel_x.show_panel(self.x_panel_index)
             self.side_panel_y.show_panel(self.y_panel_index)
             self.crosshair.coordinatesChanged2D.connect(self.update_image_slices)
+            # Clicking pins a static copy of the current X/Y profiles for comparison.
+            self.crosshair.coordinatesPinned2D.connect(self.pin_image_slices)
+            self.crosshair.pinCleared.connect(self.clear_pinned_slices)
             self.image_updated.connect(self.update_image_slices)
         else:
             self.unhook_crosshair()
-            # Hide the ROI panels
+            # Hide the ROI panels (the crosshair is destroyed, so its pin signals
+            # disconnect automatically; just drop any frozen reference curves).
+            self.clear_pinned_slices()
             self.side_panel_x.hide_panel()
             self.side_panel_y.hide_panel()
             self.image_updated.disconnect(self.update_image_slices)
@@ -678,14 +690,46 @@ class ImageBase(PlotBase):
             x = coordinates[1]
             y = coordinates[2]
         image_item = self.layer_manager["main"].image
+        slices = self._compute_image_slices(image_item, x, y)
+        if slices is None:
+            return
+        h_world_x, h_slice, v_world_y, v_slice = slices
+
+        # Update the live curves in place. They are persistent (rather than
+        # clear()+plot() each time) so a pinned reference curve survives.
+        if self.x_roi_curve is None:
+            self.x_roi_curve = self.x_roi.plot_item.plot(
+                h_world_x, h_slice, pen=pg.mkPen(self.x_roi.curve_color, width=3)
+            )
+        else:
+            self.x_roi_curve.setData(h_world_x, h_slice)
+
+        if self.y_roi_curve is None:
+            self.y_roi_curve = self.y_roi.plot_item.plot(
+                v_slice, v_world_y, pen=pg.mkPen(self.y_roi.curve_color, width=3)
+            )
+        else:
+            self.y_roi_curve.setData(v_slice, v_world_y)
+
+    def _compute_image_slices(self, image_item, row: int, col: int):
+        """Compute the horizontal/vertical profile slices through the image at (row, col).
+
+        Args:
+            image_item: The image item to slice.
+            row (int): Pixel index along the image's first axis.
+            col (int): Pixel index along the image's second axis.
+
+        Returns:
+            tuple | None: ``(h_world_x, h_slice, v_world_y, v_slice)`` in world coordinates,
+            or ``None`` if there is no image or the pixel is out of bounds.
+        """
         image = image_item.image
         if image is None:
-            return
+            return None
         max_row, max_col = image.shape[0] - 1, image.shape[1] - 1
-        row, col = x, y
         if not (0 <= row <= max_row and 0 <= col <= max_col):
-            return
-        # Horizontal slice
+            return None
+        # Horizontal slice (varies along the first axis at the fixed column)
         h_slice = image[:, col]
         x_pixel_indices = np.arange(h_slice.shape[0])
         if image_item.image_transform is None:
@@ -694,10 +738,7 @@ class ImageBase(PlotBase):
             h_world_x = [
                 image_item.image_transform.map(xi + 0.5, col + 0.5)[0] for xi in x_pixel_indices
             ]
-        self.x_roi.plot_item.clear()
-        self.x_roi.plot_item.plot(h_world_x, h_slice, pen=pg.mkPen(self.x_roi.curve_color, width=3))
-
-        # Vertical slice
+        # Vertical slice (varies along the second axis at the fixed row)
         v_slice = image[row, :]
         y_pixel_indices = np.arange(v_slice.shape[0])
         if image_item.image_transform is None:
@@ -706,8 +747,43 @@ class ImageBase(PlotBase):
             v_world_y = [
                 image_item.image_transform.map(row + 0.5, yi + 0.5)[1] for yi in y_pixel_indices
             ]
-        self.y_roi.plot_item.clear()
-        self.y_roi.plot_item.plot(v_slice, v_world_y, pen=pg.mkPen(self.y_roi.curve_color, width=3))
+        return h_world_x, h_slice, v_world_y, v_slice
+
+    @SafeSlot(tuple)
+    def pin_image_slices(self, coordinates: tuple):
+        """Freeze the X/Y profiles at the pinned pixel as static reference curves.
+
+        Args:
+            coordinates (tuple): ``(name, row, col)`` pixel coordinates of the pin, as
+                emitted by the crosshair's ``coordinatesPinned2D`` signal.
+        """
+        image_item = self.layer_manager["main"].image
+        slices = self._compute_image_slices(image_item, coordinates[1], coordinates[2])
+        if slices is None:
+            return
+        h_world_x, h_slice, v_world_y, v_slice = slices
+        # Single pin: drop any previously frozen curves first.
+        self.clear_pinned_slices()
+        # Solid pen on purpose: Qt's dash stroker on a many-segment profile curve is
+        # 10-20x more expensive to paint than a solid stroke, which stalls the GUI
+        # thread on every image update while a pin is active. The straight pin
+        # InfiniteLines can stay dashed cheaply; these data curves cannot.
+        pen = pg.mkPen("#f2c037", width=2)
+        self.x_roi_pinned = self.x_roi.plot_item.plot(h_world_x, h_slice, pen=pen)
+        self.y_roi_pinned = self.y_roi.plot_item.plot(v_slice, v_world_y, pen=pen)
+        # Keep the frozen reference styling when the ROI plots re-pen on theme change.
+        self.x_roi_pinned.is_pinned_reference = True
+        self.y_roi_pinned.is_pinned_reference = True
+
+    @SafeSlot()
+    def clear_pinned_slices(self):
+        """Remove the frozen pinned profile curves, if present."""
+        if self.x_roi_pinned is not None:
+            self.x_roi.plot_item.removeItem(self.x_roi_pinned)
+            self.x_roi_pinned = None
+        if self.y_roi_pinned is not None:
+            self.y_roi.plot_item.removeItem(self.y_roi_pinned)
+            self.y_roi_pinned = None
 
     ################################################################################
     # Widget Specific Properties

--- a/bec_widgets/widgets/plots/image/image_base.py
+++ b/bec_widgets/widgets/plots/image/image_base.py
@@ -276,6 +276,9 @@ class ImageBase(PlotBase):
         )
         self.layer_manager.add("main")
         self._init_image_base_toolbar()
+        self._crosshair_image_update_proxy = pg.SignalProxy(
+            self.image_updated, rateLimit=10, slot=self._on_crosshair_image_update
+        )
 
         self.autorange = True
         self.autorange_mode = "mean"
@@ -305,6 +308,11 @@ class ImageBase(PlotBase):
         if self.x_roi is not None and self.y_roi is not None:
             self.x_roi.apply_theme(theme)
             self.y_roi.apply_theme(theme)
+
+    @SafeSlot(object)
+    def _on_crosshair_image_update(self, _event=None) -> None:
+        """Rate-limited crosshair refresh after image data changes."""
+        self.update_crosshair_on_image_change()
 
     def add_layer(self, name: str | None = None, **kwargs) -> ImageLayer:
         """
@@ -1125,6 +1133,9 @@ class ImageBase(PlotBase):
         Cleanup the widget.
         """
         self.toolbar.cleanup()
+        if self._crosshair_image_update_proxy is not None:
+            self._crosshair_image_update_proxy.disconnect()
+            self._crosshair_image_update_proxy = None
 
         # Remove all ROIs
         rois = self.rois

--- a/bec_widgets/widgets/plots/image/image_roi_plot.py
+++ b/bec_widgets/widgets/plots/image/image_roi_plot.py
@@ -26,6 +26,9 @@ class ImageROIPlot(RoundedFrame):
         else:
             self.curve_color = "k"
         for curve in self.plot_item.curves:
+            if getattr(curve, "is_pinned_reference", False):
+                # Frozen reference profiles keep their own (dashed) styling.
+                continue
             curve.setPen(pg.mkPen(self.curve_color, width=3))
         super().apply_theme(theme)
 

--- a/bec_widgets/widgets/plots/plot_base.py
+++ b/bec_widgets/widgets/plots/plot_base.py
@@ -163,6 +163,9 @@ class PlotBase(BECWidget, QWidget):
         # PlotItem Addons
         self.plot_item.addLegend()
         self.crosshair = None
+        # Holds a pin that outlived its crosshair (e.g. crosshair toggled off) so it
+        # can be re-adopted when the crosshair is hooked again.
+        self._detached_pin = None
         self.fps_monitor = None
         self.fps_label = QLabel(alignment=Qt.AlignmentFlag.AlignRight)
         self._user_x_label = ""
@@ -1086,10 +1089,25 @@ class PlotBase(BECWidget, QWidget):
             self.crosshair.coordinatesPinned1D.connect(self.crosshair_coordinates_pinned)
             self.crosshair.coordinatesPinned2D.connect(self.crosshair_coordinates_pinned)
             self.crosshair.pinCleared.connect(self.crosshair_pin_cleared)
+            # Re-adopt a pin that survived a previous toggle-off.
+            if self._detached_pin is not None:
+                self.crosshair.adopt_pin(self._detached_pin)
+                self._detached_pin = None
 
-    def unhook_crosshair(self) -> None:
-        """Unhook the crosshair from all plots."""
+    def unhook_crosshair(self, preserve_pin: bool = True) -> None:
+        """Unhook the crosshair from all plots.
+
+        Args:
+            preserve_pin (bool): When True (the default, e.g. the crosshair is toggled
+                off from the toolbar), keep any active pin on the plot so it survives
+                the toggle and is re-adopted on the next hook. When False (e.g. on
+                widget teardown), the pin is discarded as well.
+        """
         if self.crosshair is not None:
+            if preserve_pin:
+                self._detached_pin = self.crosshair.release_pin()
+                if self._detached_pin is not None and self._detached_pin.get("point") is not None:
+                    self._detached_pin["point"]._on_remove = self._discard_detached_pin
             self.crosshair.crosshairChanged.disconnect(self.crosshair_position_changed)
             self.crosshair.crosshairClicked.disconnect(self.crosshair_position_clicked)
             self.crosshair.coordinatesChanged1D.disconnect(self.crosshair_coordinates_changed)
@@ -1102,6 +1120,21 @@ class PlotBase(BECWidget, QWidget):
             self.crosshair.cleanup()
             self.crosshair.deleteLater()
             self.crosshair = None
+        if not preserve_pin:
+            self._discard_detached_pin()
+
+    def _discard_detached_pin(self) -> None:
+        """Remove a detached (crosshair-less) pin's items from the plot, if any."""
+        if self._detached_pin is None:
+            return
+        had_pin = self._detached_pin.get("pos") is not None
+        for key in ("point", "v_line", "h_line", "label"):
+            item = self._detached_pin.get(key)
+            if item is not None:
+                self.plot_item.removeItem(item)
+        self._detached_pin = None
+        if had_pin:
+            self.crosshair_pin_cleared.emit()
 
     def toggle_crosshair(self, enabled: bool | None = None) -> None:
         """Toggle the crosshair on all plots.
@@ -1152,7 +1185,7 @@ class PlotBase(BECWidget, QWidget):
 
     def cleanup(self):
         self.toolbar.cleanup()
-        self.unhook_crosshair()
+        self.unhook_crosshair(preserve_pin=False)
         self.unhook_fps_monitor(delete_label=True)
         self.tick_item.cleanup()
         self.arrow_item.cleanup()

--- a/bec_widgets/widgets/plots/plot_base.py
+++ b/bec_widgets/widgets/plots/plot_base.py
@@ -116,6 +116,8 @@ class PlotBase(BECWidget, QWidget):
     crosshair_position_clicked = Signal(tuple)
     crosshair_coordinates_changed = Signal(tuple)
     crosshair_coordinates_clicked = Signal(tuple)
+    crosshair_coordinates_pinned = Signal(tuple)
+    crosshair_pin_cleared = Signal()
 
     def __init__(
         self,
@@ -1081,6 +1083,9 @@ class PlotBase(BECWidget, QWidget):
             self.crosshair.coordinatesClicked1D.connect(self.crosshair_coordinates_clicked)
             self.crosshair.coordinatesChanged2D.connect(self.crosshair_coordinates_changed)
             self.crosshair.coordinatesClicked2D.connect(self.crosshair_coordinates_clicked)
+            self.crosshair.coordinatesPinned1D.connect(self.crosshair_coordinates_pinned)
+            self.crosshair.coordinatesPinned2D.connect(self.crosshair_coordinates_pinned)
+            self.crosshair.pinCleared.connect(self.crosshair_pin_cleared)
 
     def unhook_crosshair(self) -> None:
         """Unhook the crosshair from all plots."""
@@ -1091,6 +1096,9 @@ class PlotBase(BECWidget, QWidget):
             self.crosshair.coordinatesClicked1D.disconnect(self.crosshair_coordinates_clicked)
             self.crosshair.coordinatesChanged2D.disconnect(self.crosshair_coordinates_changed)
             self.crosshair.coordinatesClicked2D.disconnect(self.crosshair_coordinates_clicked)
+            self.crosshair.coordinatesPinned1D.disconnect(self.crosshair_coordinates_pinned)
+            self.crosshair.coordinatesPinned2D.disconnect(self.crosshair_coordinates_pinned)
+            self.crosshair.pinCleared.disconnect(self.crosshair_pin_cleared)
             self.crosshair.cleanup()
             self.crosshair.deleteLater()
             self.crosshair = None

--- a/bec_widgets/widgets/plots/plot_base.py
+++ b/bec_widgets/widgets/plots/plot_base.py
@@ -1136,16 +1136,12 @@ class PlotBase(BECWidget, QWidget):
         if had_pin:
             self.crosshair_pin_cleared.emit()
 
-    def update_crosshair_on_image_change(self) -> None:
-        """Refresh image-dependent crosshair state without replaying mouse movement."""
-        if self.crosshair is not None:
-            self.crosshair.update_image_marker_geometry()
-            self.crosshair.update_pinned_label()
-            return
-        self._update_detached_pin_label()
-
     def _update_detached_pin_label(self) -> None:
-        """Refresh a detached pin label against the current image data."""
+        """Refresh a detached pin label against the current image data.
+
+        Uses the same pull mechanism as the crosshair labels: the label is rebuilt
+        from the pinned coordinate against the currently plotted image.
+        """
         if self._detached_pin is None:
             return
         pos = self._detached_pin.get("pos")

--- a/bec_widgets/widgets/plots/plot_base.py
+++ b/bec_widgets/widgets/plots/plot_base.py
@@ -1136,6 +1136,65 @@ class PlotBase(BECWidget, QWidget):
         if had_pin:
             self.crosshair_pin_cleared.emit()
 
+    def update_crosshair_on_image_change(self) -> None:
+        """Refresh image-dependent crosshair state without replaying mouse movement."""
+        if self.crosshair is not None:
+            self.crosshair.update_image_marker_geometry()
+            self.crosshair.update_pinned_label()
+            return
+        self._update_detached_pin_label()
+
+    def _update_detached_pin_label(self) -> None:
+        """Refresh a detached pin label against the current image data."""
+        if self._detached_pin is None:
+            return
+        pos = self._detached_pin.get("pos")
+        label = self._detached_pin.get("label")
+        if pos is None or label is None:
+            return
+
+        x, y = pos
+        precision = self._current_crosshair_precision()
+        x_scaled, y_scaled = self._scale_crosshair_coordinates(x, y)
+        text = f"pin ({x_scaled:.{precision}f}, {y_scaled:.{precision}f})"
+        for item in self.plot_item.items:
+            if not isinstance(item, pg.ImageItem) or item.image is None:
+                continue
+
+            if item.image_transform is not None:
+                inv_transform, _ = item.image_transform.inverted()
+                pt = inv_transform.map(QPointF(x, y))
+                px, py = pt.x(), pt.y()
+            else:
+                px, py = x, y
+
+            ix = int(np.clip(px, 0, item.image.shape[0] - 1))
+            iy = int(np.clip(py, 0, item.image.shape[1] - 1))
+            text += f"\nIntensity: {item.image[ix, iy]:.{precision}f}"
+            break
+
+        label.setText(text)
+
+    def _current_crosshair_precision(self) -> int:
+        """Return crosshair precision using the same dynamic rule as Crosshair."""
+        view_range = self.plot_item.vb.viewRange()
+        x_span = abs(view_range[0][1] - view_range[0][0])
+        y_span = abs(view_range[1][1] - view_range[1][0])
+        spans = [span for span in (x_span, y_span) if span > 0]
+        span = min(spans) if spans else 1.0
+
+        exponent = np.floor(np.log10(span))
+        decimals = max(0, int(-exponent) + 1)
+        return max(self._minimal_crosshair_precision, decimals)
+
+    def _scale_crosshair_coordinates(self, x: float, y: float) -> tuple[float, float]:
+        """Scale coordinates for log axes using Crosshair's display convention."""
+        if self.plot_item.axes["bottom"]["item"].logMode:
+            x = 10**x
+        if self.plot_item.axes["left"]["item"].logMode:
+            y = 10**y
+        return x, y
+
     def toggle_crosshair(self, enabled: bool | None = None) -> None:
         """Toggle the crosshair on all plots.
 

--- a/tests/unit_tests/test_crosshair.py
+++ b/tests/unit_tests/test_crosshair.py
@@ -376,3 +376,186 @@ def test_ignore_invisible_curves_on_move(qtbot, mocked_client):
     wf.crosshair.mouse_moved(event_mock)
     qtbot.wait(200)
     assert set(wf.crosshair.marker_moved_1d.keys()) == {"Curve_0"}
+
+
+###############################################
+# Pinned marker (click to pin, remove gestures)
+###############################################
+
+
+class _FakeClickEvent:
+    """Minimal stand-in for a pyqtgraph MouseClickEvent for routing tests."""
+
+    def __init__(self, scene_pos, button=Qt.LeftButton, double=False):
+        self._scenePos = scene_pos
+        self._button = button
+        self._double = double
+        self.accepted = False
+
+    def button(self):
+        return self._button
+
+    def double(self):
+        return self._double
+
+    def accept(self):
+        self.accepted = True
+
+
+def test_set_pin_1d_creates_marker_and_emits(plot_widget_with_crosshair):
+    crosshair, _ = plot_widget_with_crosshair
+    pinned = []
+    crosshair.coordinatesPinned1D.connect(pinned.append)
+
+    assert crosshair.pinned_point is None
+    crosshair.set_pin(2, 5)
+
+    assert crosshair.pinned_point is not None
+    assert crosshair.pinned_pos is not None
+    assert len(pinned) == 1
+    _, px, py = pinned[0]
+    assert np.isclose(px, 2) and np.isclose(py, 5)
+
+
+def test_pin_draws_dashed_crosshair_lines(plot_widget_with_crosshair):
+    crosshair, plot_item = plot_widget_with_crosshair
+    crosshair.set_pin(2, 5)
+
+    # A frozen, dashed crosshair (two infinite lines) is drawn at the pin.
+    assert crosshair.pinned_v_line is not None
+    assert crosshair.pinned_h_line is not None
+    assert np.isclose(crosshair.pinned_v_line.value(), 2)
+    assert np.isclose(crosshair.pinned_h_line.value(), 5)
+    assert crosshair.pinned_v_line.pen.style() == Qt.PenStyle.DashLine
+    assert crosshair.pinned_v_line in plot_item.items
+    assert crosshair.pinned_h_line in plot_item.items
+
+    crosshair.clear_pin()
+    assert crosshair.pinned_v_line is None
+    assert crosshair.pinned_h_line is None
+
+
+def test_clear_pin_emits_only_when_pinned(plot_widget_with_crosshair):
+    crosshair, _ = plot_widget_with_crosshair
+    cleared = []
+    crosshair.pinCleared.connect(lambda: cleared.append(True))
+
+    crosshair.set_pin(2, 5)
+    crosshair.clear_pin()
+    assert crosshair.pinned_point is None
+    assert crosshair.pinned_v_line is None
+    assert crosshair.pinned_h_line is None
+    assert crosshair.pinned_pos is None
+    assert cleared == [True]
+
+    # Clearing again is a no-op and must not re-emit.
+    crosshair.clear_pin()
+    assert cleared == [True]
+
+
+def test_single_click_pins(qtbot, plot_widget_with_crosshair):
+    crosshair, plot_item = plot_widget_with_crosshair
+    graphics_view = plot_item.vb.scene().views()[0]
+    qtbot.waitExposed(graphics_view)
+    pos = graphics_view.mapFromScene(plot_item.vb.mapViewToScene(QPointF(2, 5)))
+
+    qtbot.mouseClick(graphics_view.viewport(), Qt.LeftButton, pos=pos)
+    assert crosshair.pinned_point is not None
+    assert crosshair.pinned_pos is not None
+
+
+def test_reclick_on_pin_removes_it(plot_widget_with_crosshair):
+    crosshair, plot_item = plot_widget_with_crosshair
+    crosshair.set_pin(2, 5)
+    assert crosshair.pinned_point is not None
+
+    # A left click that lands on the existing pin toggles it off.
+    scene_pos = plot_item.vb.mapViewToScene(QPointF(*crosshair.pinned_pos))
+    crosshair.mouse_clicked(_FakeClickEvent(scene_pos, button=Qt.LeftButton))
+    assert crosshair.pinned_point is None
+
+
+def test_double_click_clears_pin(plot_widget_with_crosshair):
+    crosshair, plot_item = plot_widget_with_crosshair
+    crosshair.set_pin(2, 5)
+    assert crosshair.pinned_point is not None
+
+    scene_pos = plot_item.vb.mapViewToScene(QPointF(2, 5))
+    crosshair.mouse_clicked(_FakeClickEvent(scene_pos, double=True))
+    assert crosshair.pinned_point is None
+
+
+def test_right_click_on_pin_removes_via_menu(monkeypatch, plot_widget_with_crosshair):
+    """Right-clicks are handled by the pin item itself (accepting the event there
+    is what keeps pyqtgraph's plot context menu from opening on top)."""
+    from qtpy.QtWidgets import QMenu
+
+    crosshair, _ = plot_widget_with_crosshair
+    crosshair.set_pin(2, 5)
+    assert crosshair.pinned_point is not None
+
+    # Choose the (only) "Remove pinned marker" action without showing a real menu.
+    monkeypatch.setattr(QMenu, "exec_", lambda self, *a, **k: self.actions()[0])
+    event = _FakeClickEvent(None, button=Qt.RightButton)
+    crosshair.pinned_point.mouseClickEvent(event)
+
+    assert crosshair.pinned_point is None
+    assert event.accepted is True
+
+
+def test_right_click_on_pin_menu_cancelled_keeps_pin(monkeypatch, plot_widget_with_crosshair):
+    from qtpy.QtWidgets import QMenu
+
+    crosshair, _ = plot_widget_with_crosshair
+    crosshair.set_pin(2, 5)
+
+    monkeypatch.setattr(QMenu, "exec_", lambda self, *a, **k: None)  # menu dismissed
+    event = _FakeClickEvent(None, button=Qt.RightButton)
+    crosshair.pinned_point.mouseClickEvent(event)
+
+    assert crosshair.pinned_point is not None
+    assert event.accepted is True
+
+
+def test_right_click_without_pin_is_ignored(plot_widget_with_crosshair):
+    crosshair, plot_item = plot_widget_with_crosshair
+    scene_pos = plot_item.vb.mapViewToScene(QPointF(2, 5))
+    event = _FakeClickEvent(scene_pos, button=Qt.RightButton)
+    crosshair.mouse_clicked(event)
+    # No pin -> nothing handled at scene level, the event is left for
+    # pyqtgraph's own context menu.
+    assert event.accepted is False
+
+
+def test_log_mode_change_clears_pin(plot_widget_with_crosshair):
+    """The pin lives in view coordinates; toggling log mode must drop it instead
+    of leaving it at a now-meaningless position."""
+    crosshair, plot_item = plot_widget_with_crosshair
+    crosshair.set_pin(2, 5)
+    assert crosshair.pinned_point is not None
+
+    plot_item.ctrl.logYCheck.setChecked(True)
+
+    assert crosshair.pinned_point is None
+    assert crosshair.pinned_pos is None
+
+
+def test_set_pin_2d_emits_pixel_coordinates(image_widget_with_crosshair):
+    crosshair, _ = image_widget_with_crosshair
+    pinned = []
+    crosshair.coordinatesPinned2D.connect(pinned.append)
+
+    crosshair.set_pin(40, 60)
+    assert crosshair.pinned_point is not None
+    assert len(pinned) == 1
+    _, px, py = pinned[0]
+    assert (px, py) == (40, 60)
+
+
+def test_reset_clears_pin(image_widget_with_crosshair):
+    crosshair, _ = image_widget_with_crosshair
+    crosshair.set_pin(40, 60)
+    assert crosshair.pinned_point is not None
+    crosshair.reset()
+    assert crosshair.pinned_point is None
+    assert crosshair.pinned_pos is None

--- a/tests/unit_tests/test_crosshair.py
+++ b/tests/unit_tests/test_crosshair.py
@@ -540,6 +540,27 @@ def test_log_mode_change_clears_pin(plot_widget_with_crosshair):
     assert crosshair.pinned_pos is None
 
 
+def test_adopted_pin_rebinds_removal_callback(monkeypatch, plot_widget_with_crosshair):
+    """After release/adopt (crosshair toggled off/on) the pin's context-menu
+    removal must act on the adopting crosshair, not the deleted one."""
+    from qtpy.QtWidgets import QMenu
+
+    crosshair, _ = plot_widget_with_crosshair
+    crosshair.set_pin(2, 5)
+
+    state = crosshair.release_pin()
+    # While detached there is no owner: the menu is disabled.
+    assert state["point"]._on_remove is None
+
+    crosshair.adopt_pin(state)
+    assert crosshair.pinned_point is not None
+
+    monkeypatch.setattr(QMenu, "exec_", lambda self, *a, **k: self.actions()[0])
+    event = _FakeClickEvent(None, button=Qt.RightButton)
+    crosshair.pinned_point.mouseClickEvent(event)
+    assert crosshair.pinned_point is None
+
+
 def test_set_pin_2d_emits_pixel_coordinates(image_widget_with_crosshair):
     crosshair, _ = image_widget_with_crosshair
     pinned = []

--- a/tests/unit_tests/test_crosshair.py
+++ b/tests/unit_tests/test_crosshair.py
@@ -573,10 +573,17 @@ def test_set_pin_2d_emits_pixel_coordinates(image_widget_with_crosshair):
     assert (px, py) == (40, 60)
 
 
-def test_reset_clears_pin(image_widget_with_crosshair):
+def test_reset_preserves_pin_cleanup_removes_it(image_widget_with_crosshair):
     crosshair, _ = image_widget_with_crosshair
     crosshair.set_pin(40, 60)
     assert crosshair.pinned_point is not None
+
+    # A data/scan reset keeps the pin (a persistent annotation).
     crosshair.reset()
+    assert crosshair.pinned_point is not None
+    assert crosshair.pinned_pos is not None
+
+    # Full teardown removes it.
+    crosshair.cleanup()
     assert crosshair.pinned_point is None
     assert crosshair.pinned_pos is None

--- a/tests/unit_tests/test_crosshair.py
+++ b/tests/unit_tests/test_crosshair.py
@@ -587,6 +587,8 @@ def test_set_pin_2d_emits_pixel_coordinates(image_widget_with_crosshair):
 
 
 def test_set_pin_2d_label_includes_intensity(image_widget_with_crosshair):
+    """The pin label includes the image intensity at the pinned pixel and follows
+    image changes through update_on_image_change (same mechanism as the live label)."""
     crosshair, plot_item = image_widget_with_crosshair
     image = np.arange(10_000, dtype=float).reshape(100, 100)
     for item in plot_item.items:
@@ -597,6 +599,12 @@ def test_set_pin_2d_label_includes_intensity(image_widget_with_crosshair):
 
     assert crosshair.pinned_label is not None
     assert crosshair.pinned_label.toPlainText() == "pin (40.500, 60.500)\nIntensity: 4060.000"
+
+    for item in plot_item.items:
+        if isinstance(item, pg.ImageItem):
+            item.setImage(image + 100.0)
+    crosshair.update_on_image_change()
+    assert crosshair.pinned_label.toPlainText() == "pin (40.500, 60.500)\nIntensity: 4160.000"
 
 
 def test_reset_preserves_pin_cleanup_removes_it(image_widget_with_crosshair):

--- a/tests/unit_tests/test_crosshair.py
+++ b/tests/unit_tests/test_crosshair.py
@@ -260,6 +260,19 @@ def test_update_coord_label_2D(image_widget_with_crosshair):
     assert crosshair.coord_label.isVisible()
 
 
+def test_update_markers_on_image_change_accepts_image_without_transform(
+    image_widget_with_crosshair,
+):
+    crosshair, plot_item = image_widget_with_crosshair
+    image_item = next(item for item in plot_item.items if isinstance(item, pg.ImageItem))
+    image_item.image_transform = None
+
+    crosshair.update_markers_on_image_change()
+
+    assert crosshair.marker_2d_row.transform() == QTransform()
+    assert crosshair.marker_2d_col.transform() == QTransform()
+
+
 def test_crosshair_precision_properties(plot_widget_with_crosshair):
     """
     Ensure Crosshair.precision and Crosshair.min_precision behave correctly
@@ -571,6 +584,19 @@ def test_set_pin_2d_emits_pixel_coordinates(image_widget_with_crosshair):
     assert len(pinned) == 1
     _, px, py = pinned[0]
     assert (px, py) == (40, 60)
+
+
+def test_set_pin_2d_label_includes_intensity(image_widget_with_crosshair):
+    crosshair, plot_item = image_widget_with_crosshair
+    image = np.arange(10_000, dtype=float).reshape(100, 100)
+    for item in plot_item.items:
+        if isinstance(item, pg.ImageItem):
+            item.setImage(image)
+
+    crosshair.set_pin(40, 60)
+
+    assert crosshair.pinned_label is not None
+    assert crosshair.pinned_label.toPlainText() == "pin (40.500, 60.500)\nIntensity: 4060.000"
 
 
 def test_reset_preserves_pin_cleanup_removes_it(image_widget_with_crosshair):

--- a/tests/unit_tests/test_image_view_next_gen.py
+++ b/tests/unit_tests/test_image_view_next_gen.py
@@ -2,7 +2,7 @@ import numpy as np
 import pyqtgraph as pg
 import pytest
 from bec_lib.endpoints import MessageEndpoints
-from qtpy.QtCore import QPointF
+from qtpy.QtCore import QPointF, Qt
 
 from bec_widgets.widgets.plots.image.image import Image
 from tests.unit_tests.client_mocks import mocked_client
@@ -23,6 +23,20 @@ def _set_signal_config(
         "component_name": signal_name,
         "describe": {"signal_info": {"ndim": ndim}},
     }
+
+
+class _FakeClickEvent:
+    """Minimal stand-in for a pyqtgraph MouseClickEvent."""
+
+    def __init__(self, button=Qt.LeftButton):
+        self._button = button
+        self.accepted = False
+
+    def button(self):
+        return self._button
+
+    def accept(self):
+        self.accepted = True
 
 
 def test_initialization_defaults(qtbot, mocked_client):
@@ -1054,6 +1068,36 @@ def test_pinned_roi_profiles_keep_style_on_theme_change(qtbot, mocked_client):
     # The frozen reference keeps its amber styling, the live curve is re-penned.
     assert pinned.opts["pen"].color().name() == "#f2c037"
     assert bec_image_view.x_roi_curve.opts["pen"].color().name() == "#000000"
+
+
+def test_detached_pin_can_be_removed_with_right_click(qtbot, mocked_client, monkeypatch):
+    """A pin left on the plot after disabling crosshair remains removable."""
+    from qtpy.QtWidgets import QMenu
+
+    bec_image_view = create_widget(qtbot, Image, client=mocked_client)
+    bec_image_view.on_image_update_2d({"data": np.arange(25).reshape(5, 5)}, {})
+    switch = bec_image_view.toolbar.components.get_action("image_switch_crosshair")
+    switch.actions["crosshair_roi"].action.trigger()
+    qtbot.wait(50)
+
+    bec_image_view.crosshair.set_pin(2.0, 3.0)
+    switch.actions["crosshair_roi"].action.trigger()
+    qtbot.wait(20)
+    assert bec_image_view.crosshair is None
+    assert bec_image_view._detached_pin is not None
+
+    pin_point = bec_image_view._detached_pin["point"]
+    cleared = []
+    bec_image_view.crosshair_pin_cleared.connect(lambda: cleared.append(True))
+    monkeypatch.setattr(QMenu, "exec_", lambda self, *a, **k: self.actions()[0])
+
+    event = _FakeClickEvent(button=Qt.RightButton)
+    pin_point.mouseClickEvent(event)
+
+    assert bec_image_view._detached_pin is None
+    assert pin_point not in bec_image_view.plot_item.items
+    assert event.accepted is True
+    assert cleared == [True]
 
 
 ##############################################

--- a/tests/unit_tests/test_image_view_next_gen.py
+++ b/tests/unit_tests/test_image_view_next_gen.py
@@ -1049,7 +1049,7 @@ def test_pinned_roi_profiles_freeze_and_clear(qtbot, mocked_client):
 
 def test_pinned_roi_profiles_keep_style_on_theme_change(qtbot, mocked_client):
     """Theme changes re-pen the live profile curves but must not restyle the
-    frozen (amber) pinned reference curves."""
+    frozen (dashed) pinned reference curves."""
     import numpy as np
 
     bec_image_view = create_widget(qtbot, Image, client=mocked_client)
@@ -1065,7 +1065,7 @@ def test_pinned_roi_profiles_keep_style_on_theme_change(qtbot, mocked_client):
 
     bec_image_view.x_roi.apply_theme("light")
 
-    # The frozen reference keeps its amber styling, the live curve is re-penned.
+    # The pinned reference keeps its amber styling, the live curve is re-penned.
     assert pinned.opts["pen"].color().name() == "#f2c037"
     assert bec_image_view.x_roi_curve.opts["pen"].color().name() == "#000000"
 
@@ -1156,6 +1156,88 @@ def test_detached_pin_can_be_removed_with_right_click(qtbot, mocked_client, monk
     assert pin_point not in bec_image_view.plot_item.items
     assert event.accepted is True
     assert cleared == [True]
+
+
+def test_pinned_profiles_follow_image_updates(qtbot, mocked_client):
+    """Pinned profile curves keep their position but follow incoming image data,
+    exactly like the pin's intensity label."""
+    bec_image_view = create_widget(qtbot, Image, client=mocked_client)
+    test_data = np.arange(25, dtype=float).reshape(5, 5)
+    bec_image_view.on_image_update_2d({"data": test_data}, {})
+    switch = bec_image_view.toolbar.components.get_action("image_switch_crosshair")
+    switch.actions["crosshair_roi"].action.trigger()
+    qtbot.wait(50)
+
+    bec_image_view.crosshair.set_pin(2.0, 3.0)
+    _, x_pinned = bec_image_view.x_roi_pinned.getData()
+    np.testing.assert_array_equal(x_pinned, test_data[:, 3])
+
+    updated = test_data + 100.0
+    bec_image_view.on_image_update_2d({"data": updated}, {})
+
+    qtbot.waitUntil(
+        lambda: np.array_equal(bec_image_view.x_roi_pinned.getData()[1], updated[:, 3]), timeout=500
+    )
+    y_pinned, _ = bec_image_view.y_roi_pinned.getData()
+    np.testing.assert_array_equal(y_pinned, updated[2])
+
+
+def test_detached_pin_profiles_follow_image_updates(qtbot, mocked_client):
+    """Pinned profiles keep following image data while the crosshair is toggled off."""
+    bec_image_view = create_widget(qtbot, Image, client=mocked_client)
+    test_data = np.arange(25, dtype=float).reshape(5, 5)
+    bec_image_view.on_image_update_2d({"data": test_data}, {})
+    switch = bec_image_view.toolbar.components.get_action("image_switch_crosshair")
+    switch.actions["crosshair_roi"].action.trigger()
+    qtbot.wait(50)
+
+    bec_image_view.crosshair.set_pin(2.0, 3.0)
+    bec_image_view.toggle_crosshair(False)  # pin becomes detached, panels stay active
+    assert bec_image_view.crosshair is None
+    assert bec_image_view.x_roi_pinned is not None
+
+    updated = test_data + 100.0
+    bec_image_view.on_image_update_2d({"data": updated}, {})
+
+    qtbot.waitUntil(
+        lambda: np.array_equal(bec_image_view.x_roi_pinned.getData()[1], updated[:, 3]), timeout=500
+    )
+
+
+def test_crosshair_moves_update_profiles_immediately(qtbot, mocked_client):
+    """Crosshair moves update the live profiles synchronously; new frames refresh
+    them at the current crosshair position."""
+    bec_image_view = create_widget(qtbot, Image, client=mocked_client)
+    test_data = np.arange(25, dtype=float).reshape(5, 5)
+    bec_image_view.on_image_update_2d({"data": test_data}, {})
+    switch = bec_image_view.toolbar.components.get_action("image_switch_crosshair")
+    switch.actions["crosshair_roi"].action.trigger()
+    qtbot.wait(50)
+
+    # Position the crosshair lines and emit the snapped pixel (as mouse_moved does).
+    bec_image_view.crosshair.mouse_moved(manual_pos=(1.2, 2.2))
+
+    np.testing.assert_array_equal(bec_image_view.x_roi_curve.getData()[1], test_data[:, 2])
+
+    # New frames refresh the live profile at the crosshair position.
+    updated = test_data + 100.0
+    bec_image_view.on_image_update_2d({"data": updated}, {})
+    np.testing.assert_array_equal(bec_image_view.x_roi_curve.getData()[1], updated[:, 2])
+
+
+def test_live_label_intensity_updates_on_image_update(qtbot, mocked_client):
+    """The live crosshair label refreshes its intensity when the image changes,
+    not only when the mouse moves."""
+    bec_image_view = create_widget(qtbot, Image, client=mocked_client)
+    test_data = np.arange(25, dtype=float).reshape(5, 5)
+    bec_image_view.on_image_update_2d({"data": test_data}, {})
+    bec_image_view.hook_crosshair()
+
+    bec_image_view.crosshair.mouse_moved(manual_pos=(2.5, 3.5))
+    assert "Intensity: 13.000" in bec_image_view.crosshair.coord_label.toPlainText()
+
+    bec_image_view.on_image_update_2d({"data": test_data + 100.0}, {})
+    assert "Intensity: 113.000" in bec_image_view.crosshair.coord_label.toPlainText()
 
 
 def test_active_pin_label_intensity_updates_on_image_update(qtbot, mocked_client):

--- a/tests/unit_tests/test_image_view_next_gen.py
+++ b/tests/unit_tests/test_image_view_next_gen.py
@@ -996,6 +996,66 @@ def test_roi_plot_data_from_image(qtbot, mocked_client):
     np.testing.assert_array_equal(h_slice, test_data[2])
 
 
+def test_pinned_roi_profiles_freeze_and_clear(qtbot, mocked_client):
+    """Clicking pins a frozen copy of the X/Y profiles that survives live updates."""
+    import numpy as np
+
+    bec_image_view = create_widget(qtbot, Image, client=mocked_client)
+    test_data = np.arange(25).reshape(5, 5)
+    bec_image_view.on_image_update_2d({"data": test_data}, {})
+
+    switch = bec_image_view.toolbar.components.get_action("image_switch_crosshair")
+    switch.actions["crosshair_roi"].action.trigger()
+    qtbot.wait(50)
+
+    assert bec_image_view.x_roi_pinned is None
+    assert bec_image_view.y_roi_pinned is None
+
+    # Pin at pixel (row=2, col=3) -> freezes the corresponding profiles.
+    bec_image_view.crosshair.set_pin(2.0, 3.0)
+    assert bec_image_view.x_roi_pinned is not None
+    assert bec_image_view.y_roi_pinned is not None
+    _, x_pinned = bec_image_view.x_roi_pinned.getData()
+    np.testing.assert_array_equal(x_pinned, test_data[:, 3])
+    y_pinned, _ = bec_image_view.y_roi_pinned.getData()
+    np.testing.assert_array_equal(y_pinned, test_data[2])
+
+    # A live update at another location must NOT wipe the frozen pinned curves.
+    pinned_item = bec_image_view.x_roi_pinned
+    bec_image_view.update_image_slices((0, 1, 1))
+    assert bec_image_view.x_roi_pinned is pinned_item
+    assert pinned_item in bec_image_view.x_roi.plot_item.listDataItems()
+
+    # Clearing the pin removes the frozen curves.
+    bec_image_view.crosshair.clear_pin()
+    assert bec_image_view.x_roi_pinned is None
+    assert bec_image_view.y_roi_pinned is None
+    assert pinned_item not in bec_image_view.x_roi.plot_item.listDataItems()
+
+
+def test_pinned_roi_profiles_keep_style_on_theme_change(qtbot, mocked_client):
+    """Theme changes re-pen the live profile curves but must not restyle the
+    frozen (amber) pinned reference curves."""
+    import numpy as np
+
+    bec_image_view = create_widget(qtbot, Image, client=mocked_client)
+    bec_image_view.on_image_update_2d({"data": np.arange(25).reshape(5, 5)}, {})
+    switch = bec_image_view.toolbar.components.get_action("image_switch_crosshair")
+    switch.actions["crosshair_roi"].action.trigger()
+    qtbot.wait(50)
+
+    bec_image_view.crosshair.set_pin(2.0, 3.0)
+    bec_image_view.update_image_slices((0, 2, 3))  # ensure the live curve exists
+    pinned = bec_image_view.x_roi_pinned
+    assert pinned.opts["pen"].color().name() == "#f2c037"
+
+    bec_image_view.x_roi.apply_theme("light")
+
+    # The frozen reference keeps its amber styling, the live curve is re-penned.
+    assert pinned.opts["pen"].color().name() == "#f2c037"
+    assert bec_image_view.x_roi_curve.opts["pen"].color().name() == "#000000"
+
+
 ##############################################
 # Device selection toolbar sync
 ##############################################

--- a/tests/unit_tests/test_image_view_next_gen.py
+++ b/tests/unit_tests/test_image_view_next_gen.py
@@ -1158,6 +1158,73 @@ def test_detached_pin_can_be_removed_with_right_click(qtbot, mocked_client, monk
     assert cleared == [True]
 
 
+def test_active_pin_label_intensity_updates_on_image_update(qtbot, mocked_client):
+    """Pinned crosshair label intensity follows image updates at the pinned position."""
+    bec_image_view = create_widget(qtbot, Image, client=mocked_client)
+    bec_image_view.on_image_update_2d({"data": np.arange(25).reshape(5, 5)}, {})
+    bec_image_view.hook_crosshair()
+
+    bec_image_view.crosshair.set_pin(2.0, 3.0)
+    assert bec_image_view.crosshair.pinned_label.toPlainText() == (
+        "pin (2.500, 3.500)\nIntensity: 13.000"
+    )
+
+    bec_image_view.on_image_update_2d({"data": np.arange(25).reshape(5, 5) + 100}, {})
+
+    qtbot.waitUntil(
+        lambda: bec_image_view.crosshair.pinned_label.toPlainText()
+        == "pin (2.500, 3.500)\nIntensity: 113.000",
+        timeout=500,
+    )
+
+
+def test_image_update_does_not_replay_active_crosshair_mouse_handling(
+    qtbot, mocked_client, monkeypatch
+):
+    """Image updates refresh a pin without re-snapping or emitting live crosshair updates."""
+    bec_image_view = create_widget(qtbot, Image, client=mocked_client)
+    bec_image_view.on_image_update_2d({"data": np.arange(25).reshape(5, 5)}, {})
+    bec_image_view.hook_crosshair()
+    bec_image_view.crosshair.set_pin(2.0, 3.0)
+
+    mouse_moves = []
+    monkeypatch.setattr(
+        bec_image_view.crosshair,
+        "mouse_moved",
+        lambda *args, **kwargs: mouse_moves.append((args, kwargs)),
+    )
+
+    bec_image_view.on_image_update_2d({"data": np.arange(25).reshape(5, 5) + 100}, {})
+
+    qtbot.waitUntil(
+        lambda: bec_image_view.crosshair.pinned_label.toPlainText()
+        == "pin (2.500, 3.500)\nIntensity: 113.000",
+        timeout=500,
+    )
+    assert mouse_moves == []
+
+
+def test_detached_pin_label_intensity_updates_on_image_update(qtbot, mocked_client):
+    """Detached pin labels keep following image updates while crosshair is disabled."""
+    bec_image_view = create_widget(qtbot, Image, client=mocked_client)
+    bec_image_view.on_image_update_2d({"data": np.arange(25).reshape(5, 5)}, {})
+    bec_image_view.hook_crosshair()
+    bec_image_view.crosshair.set_pin(2.0, 3.0)
+    bec_image_view.unhook_crosshair()
+
+    assert bec_image_view.crosshair is None
+    assert bec_image_view._detached_pin is not None
+    assert bec_image_view._detached_pin["label"].toPlainText() == (
+        "pin (2.500, 3.500)\nIntensity: 13.000"
+    )
+
+    bec_image_view.on_image_update_2d({"data": np.arange(25).reshape(5, 5) + 200}, {})
+
+    qtbot.waitUntil(
+        lambda: bec_image_view._detached_pin["label"].toPlainText()
+        == "pin (2.500, 3.500)\nIntensity: 213.000",
+        timeout=500,
+    )
 
 
 ##############################################

--- a/tests/unit_tests/test_image_view_next_gen.py
+++ b/tests/unit_tests/test_image_view_next_gen.py
@@ -1070,6 +1070,31 @@ def test_pinned_roi_profiles_keep_style_on_theme_change(qtbot, mocked_client):
     assert bec_image_view.x_roi_curve.opts["pen"].color().name() == "#000000"
 
 
+def test_pin_survives_scan_reset(qtbot, mocked_client):
+    """A scan transition (crosshair.reset()) must not wipe the pin or its frozen profiles."""
+    import numpy as np
+
+    bec_image_view = create_widget(qtbot, Image, client=mocked_client)
+    bec_image_view.on_image_update_2d({"data": np.arange(25).reshape(5, 5)}, {})
+    switch = bec_image_view.toolbar.components.get_action("image_switch_crosshair")
+    switch.actions["crosshair_roi"].action.trigger()
+    qtbot.wait(50)
+
+    bec_image_view.crosshair.set_pin(2.0, 3.0)
+    assert bec_image_view.x_roi_pinned is not None
+    pin_point = bec_image_view.crosshair.pinned_point
+    assert pin_point is not None
+
+    # Image._handle_scan_change calls crosshair.reset() on each new scan id.
+    bec_image_view.crosshair.reset()
+
+    # The pin marker and the frozen reference profiles must still be there.
+    assert bec_image_view.crosshair.pinned_point is pin_point
+    assert bec_image_view.crosshair.pinned_pos is not None
+    assert bec_image_view.x_roi_pinned is not None
+    assert bec_image_view.y_roi_pinned is not None
+
+
 def test_detached_pin_can_be_removed_with_right_click(qtbot, mocked_client, monkeypatch):
     """A pin left on the plot after disabling crosshair remains removable."""
     from qtpy.QtWidgets import QMenu
@@ -1098,6 +1123,8 @@ def test_detached_pin_can_be_removed_with_right_click(qtbot, mocked_client, monk
     assert pin_point not in bec_image_view.plot_item.items
     assert event.accepted is True
     assert cleared == [True]
+
+
 
 
 ##############################################

--- a/tests/unit_tests/test_image_view_next_gen.py
+++ b/tests/unit_tests/test_image_view_next_gen.py
@@ -1095,6 +1095,39 @@ def test_pin_survives_scan_reset(qtbot, mocked_client):
     assert bec_image_view.y_roi_pinned is not None
 
 
+def test_pin_and_profiles_restored_after_roi_toggle(qtbot, mocked_client):
+    """Toggling crosshair-ROI off then on restores both the marker and its frozen profiles."""
+    import numpy as np
+
+    bec_image_view = create_widget(qtbot, Image, client=mocked_client)
+    test_data = np.arange(25).reshape(5, 5)
+    bec_image_view.on_image_update_2d({"data": test_data}, {})
+    switch = bec_image_view.toolbar.components.get_action("image_switch_crosshair")
+    switch.actions["crosshair_roi"].action.trigger()
+    qtbot.wait(50)
+
+    bec_image_view.crosshair.set_pin(2.0, 3.0)
+    assert bec_image_view.x_roi_pinned is not None
+    pin_point = bec_image_view.crosshair.pinned_point
+
+    # Toggle the ROI crosshair off: marker persists, frozen curves are cleared.
+    switch.actions["crosshair_roi"].action.trigger()
+    qtbot.wait(20)
+    assert bec_image_view.crosshair is None
+    assert bec_image_view._detached_pin is not None
+    assert bec_image_view.x_roi_pinned is None
+
+    # Toggle back on: marker is re-adopted AND the frozen profiles are rebuilt.
+    switch.actions["crosshair_roi"].action.trigger()
+    qtbot.wait(20)
+    assert bec_image_view.crosshair is not None
+    assert bec_image_view.crosshair.pinned_point is pin_point
+    assert bec_image_view.x_roi_pinned is not None
+    assert bec_image_view.y_roi_pinned is not None
+    _, x_pinned = bec_image_view.x_roi_pinned.getData()
+    np.testing.assert_array_equal(x_pinned, test_data[:, 3])
+
+
 def test_detached_pin_can_be_removed_with_right_click(qtbot, mocked_client, monkeypatch):
     """A pin left on the plot after disabling crosshair remains removable."""
     from qtpy.QtWidgets import QMenu

--- a/tests/unit_tests/test_plot_base_next_gen.py
+++ b/tests/unit_tests/test_plot_base_next_gen.py
@@ -260,6 +260,64 @@ def test_crosshair_hook_unhook(qtbot, mocked_client):
     assert pb.crosshair is None
 
 
+def test_pin_survives_crosshair_toggle_off(qtbot, mocked_client):
+    """Toggling the crosshair off keeps the pinned marker; toggling on re-adopts it."""
+    pb = create_widget(qtbot, PlotBase, client=mocked_client)
+    pb.plot_item.plot(x=[1, 2, 3], y=[4, 5, 6], name="c")
+
+    pb.hook_crosshair()
+    pb.crosshair.set_pin(2, 5)
+    pin_items = [
+        pb.crosshair.pinned_point,
+        pb.crosshair.pinned_v_line,
+        pb.crosshair.pinned_h_line,
+        pb.crosshair.pinned_label,
+    ]
+    assert all(item is not None for item in pin_items)
+
+    # Toggle the crosshair off: the live crosshair is gone but the pin remains.
+    pb.toggle_crosshair()
+    assert pb.crosshair is None
+    assert pb._detached_pin is not None
+    for item in pin_items:
+        assert item in pb.plot_item.items
+
+    # Toggle back on: the new crosshair re-adopts the very same pin items.
+    pb.toggle_crosshair()
+    assert pb.crosshair is not None
+    assert pb._detached_pin is None
+    assert pb.crosshair.pinned_point is pin_items[0]
+    assert pb.crosshair.pinned_pos is not None
+
+    # The re-adopted pin is fully managed again and can be cleared.
+    pb.crosshair.clear_pin()
+    assert pb.crosshair.pinned_point is None
+    for item in pin_items:
+        assert item not in pb.plot_item.items
+
+
+def test_teardown_discards_detached_pin(qtbot, mocked_client):
+    """A pin left detached (crosshair off) is removed from the plot on teardown."""
+    pb = create_widget(qtbot, PlotBase, client=mocked_client)
+    pb.plot_item.plot(x=[1, 2, 3], y=[4, 5, 6], name="c")
+    pb.hook_crosshair()
+    pb.crosshair.set_pin(2, 5)
+    pin_items = [
+        pb.crosshair.pinned_point,
+        pb.crosshair.pinned_v_line,
+        pb.crosshair.pinned_h_line,
+        pb.crosshair.pinned_label,
+    ]
+    pb.toggle_crosshair()  # detach the pin
+    assert pb._detached_pin is not None
+
+    # Teardown (preserve_pin=False) must remove the detached pin's items.
+    pb.unhook_crosshair(preserve_pin=False)
+    assert pb._detached_pin is None
+    for item in pin_items:
+        assert item not in pb.plot_item.items
+
+
 def test_mouse_mode_switch_is_exclusive(qtbot, mocked_client):
     """The pan/rectangle mouse modes must be mutually exclusive and always one active."""
     import pyqtgraph as pg


### PR DESCRIPTION
## Description

Pin to highlight some coordinates in 1D and 2D plotting, removed by right click or double click. Adapted also for roi plots profiles for image widget.

## How to test

- use it in Image and waveform widget, pin/unpin etc.


## Screenshots / GIFs (if applicable)

https://github.com/user-attachments/assets/0ebfbce9-527b-406b-9f8a-e04a492a3f9c




