### PR TITLE
fix(dock_area): fix hiding title window for the first dock 

### DIFF
--- a/bec_widgets/widgets/containers/dock_area/basic_dock_area.py
+++ b/bec_widgets/widgets/containers/dock_area/basic_dock_area.py
@@ -601,7 +601,7 @@ class DockAreaWidget(BECWidget, QWidget):
             apply_widget_icon=spec.apply_widget_icon,
         )
         self.dock_manager.setFocus()
-        self._apply_dock_preferences(dock)
+        self._apply_all_dock_preferences()
         if spec.promote_central:
             self.set_central_dock(dock)
         return dock
@@ -1251,6 +1251,20 @@ class DockAreaWidget(BECWidget, QWidget):
 
         apply()
 
+    def _apply_all_dock_preferences(self) -> None:
+        """
+        Re-apply the stored appearance preferences of every dock.
+
+        Qt ADS force-reshows the first dock area's title bar when a container grows
+        from one dock area to two (``DockContainerWidgetPrivate::addDockAreasToList``),
+        so preferences already applied to existing docks must be re-asserted whenever
+        a dock is added.
+        """
+        for dock in self.dock_list():
+            if dock is None or not isValid(dock):
+                continue
+            self._apply_dock_preferences(dock)
+
     def set_central_dock(self, dock: CDockWidget | QWidget | str) -> None:
         """
         Promote an existing dock to be the dock manager's central widget.
@@ -1433,6 +1447,7 @@ class DockAreaWidget(BECWidget, QWidget):
                 self.dock_manager.addDockWidgetTab(
                     QtAds.DockWidgetArea.RightDockWidgetArea, dock, target
                 )
+        self._apply_all_dock_preferences()
 
     @SafeSlot(str)
     def delete(self, object_name: str) -> bool:

--- a/tests/unit_tests/test_dock_area.py
+++ b/tests/unit_tests/test_dock_area.py
@@ -490,6 +490,21 @@ class TestBasicDockArea:
             assert vertical == [2, 3]
             assert overrides == {(): [9], (1, 0): [5, 5]}
 
+    def test_first_dock_title_bar_preference_survives_second_dock(self, basic_dock_area):
+        first = QWidget(parent=basic_dock_area)
+        first.setObjectName("first_panel")
+        second = QWidget(parent=basic_dock_area)
+        second.setObjectName("second_panel")
+
+        first_dock = basic_dock_area.new(first, return_dock=True, show_title_bar=False)
+        assert first_dock.dockAreaWidget().titleBar().isHidden()
+
+        # Adding a second dock makes ADS force-reshow the first area's title bar;
+        # the stored preference must win.
+        basic_dock_area.new(second, where="bottom", relative_to=first_dock, show_title_bar=False)
+
+        assert first_dock.dockAreaWidget().titleBar().isHidden()
+
     def test_show_settings_action_defaults_disabled(self, basic_dock_area):
         widget = QWidget(parent=basic_dock_area)
         widget.setObjectName("settings_default")


### PR DESCRIPTION
## Description

There is a bespoke logic for showing the title bar in the original QtADS repo which is countering our intended behaviour.

See this method for more info [DockContainerWidgetPrivate::addDockAreasToList](https://github.com/githubuser0xFFFF/Qt-Advanced-Docking-System/blob/812ce784ce9ee2eba89d6a91e46cc4bcc86e9fd0/src/DockContainerWidget.cpp#L980)