### PR TITLE
test: start mocked client with no current scan to prevent mock leakage into scan_item

### DIFF
--- a/tests/unit_tests/client_mocks.py
+++ b/tests/unit_tests/client_mocks.py
@@ -13,6 +13,9 @@ from bec_widgets.tests.utils import FakePositioner, Positioner
 
 @pytest.fixture(scope="function")
 def mocked_client(bec_dispatcher):
+    # A fresh session has no scan executed; otherwise the auto-generated MagicMock
+    # leaks into widgets as scan_item and its mock metadata ends up in device lookups.
+    bec_dispatcher.client.queue.scan_storage.current_scan = None
 
     # Ensure isinstance check for Positioner passes
     original_isinstance = isinstance


### PR DESCRIPTION
## Description

There was leak of scan_item in tests, which would look like this in CI (it would pass anyway but should be fixed):

```
Traceback (most recent call last):
  File "/home/runner/work/bec_widgets/bec_widgets/bec_widgets/bec_widgets/widgets/plots/waveform/waveform.py", line 1673, in update_sync_curves
    x_data = self._get_x_data(device_name, device_entry)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/bec_widgets/bec_widgets/bec_widgets/bec_widgets/widgets/plots/waveform/waveform.py", line 2255, in _get_x_data
    signal_x = self.entry_validator.validate_signal(device_x, None)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/bec_widgets/bec_widgets/bec_widgets/bec_widgets/utils/entry_validator.py", line 17, in validate_signal
    raise ValueError(f"Device '{name}' not found in current BEC session")
ValueError: Device '<MagicMock name='ScanManager().scan_storage.current_scan.metadata.__getitem__().__getitem__()' id='140115129984272'>' not found in current BEC session
```