### PR TITLE
Theme Change subscriptions

### DIFF
--- a/bec_widgets/utils/bec_widget.py
+++ b/bec_widgets/utils/bec_widget.py
@@ -40,7 +40,6 @@ class BECWidget(BECConnector):
         client=None,
         config: ConnectionConfig = None,
         gui_id: str | None = None,
-        theme_update: bool = False,
         start_busy: bool = False,
         **kwargs,
     ):
@@ -53,19 +52,17 @@ class BECWidget(BECConnector):
         >>>         super().__init__(parent=parent, client=client, config=config, gui_id=gui_id)
 
 
+        Every BECWidget follows application theme changes; override ``apply_theme`` to react.
+
         Args:
             client(BECClient, optional): The BEC client.
             config(ConnectionConfig, optional): The connection configuration.
             gui_id(str, optional): The GUI ID.
-            theme_update(bool, optional): Whether to subscribe to theme updates. Defaults to False. When set to True, the
-                widget's apply_theme method will be called when the theme changes.
         """
         super().__init__(client=client, config=config, gui_id=gui_id, **kwargs)
         if not isinstance(self, QObject):
             raise RuntimeError(f"{repr(self)} is not a subclass of QWidget")
-        if theme_update:
-            logger.debug(f"Subscribing to theme updates for {self.__class__.__name__}")
-            self._connect_to_theme_change()
+        self._connect_to_theme_change()
 
         # Initialize optional busy loader overlay utility (lazy by default)
         self._busy_overlay: "BusyLoaderOverlay" | None = None

--- a/bec_widgets/utils/busy_loader.py
+++ b/bec_widgets/utils/busy_loader.py
@@ -269,7 +269,7 @@ if __name__ == "__main__":  # pragma: no cover
 
     class DemoWidget(BECWidget, QWidget):  # pragma: no cover
         def __init__(self, parent=None, start_busy: bool = False):
-            super().__init__(parent=parent, theme_update=True, start_busy=start_busy)
+            super().__init__(parent=parent, start_busy=start_busy)
 
             self._title = QLabel("Demo Content", self)
             self._title.setAlignment(Qt.AlignCenter)

--- a/bec_widgets/utils/forms_from_types/forms.py
+++ b/bec_widgets/utils/forms_from_types/forms.py
@@ -215,7 +215,7 @@ class PydanticModelForm(TypedForm):
         self._layout.addWidget(self._validity)
         self.value_changed.connect(self.validate_form)
 
-        self._connect_to_theme_change()
+        self._connect_pretty_display_theme()
 
     @SafeSlot()
     def clear(self): ...
@@ -224,8 +224,8 @@ class PydanticModelForm(TypedForm):
         if self._pretty_display:
             self.setStyleSheet(styles.pretty_display_theme(theme))
 
-    def _connect_to_theme_change(self):
-        """Connect to the theme change signal."""
+    def _connect_pretty_display_theme(self):
+        """Connect the pretty-display styling to the theme-updated signal."""
         qapp = QApplication.instance()
         if hasattr(qapp, "theme_signal"):
             qapp.theme_signal.theme_updated.connect(self.set_pretty_display_theme)  # type: ignore

--- a/bec_widgets/utils/help_inspector/help_inspector.py
+++ b/bec_widgets/utils/help_inspector/help_inspector.py
@@ -36,7 +36,7 @@ class HelpInspector(BECWidget, QtWidgets.QWidget):
     bec_widget_help = QtCore.Signal(str)  # Emits md formatted help string from BECWidget class
 
     def __init__(self, parent=None, client=None):
-        super().__init__(client=client, parent=parent, theme_update=True)
+        super().__init__(client=client, parent=parent)
         self._app = QtWidgets.QApplication.instance()
         layout = QtWidgets.QHBoxLayout(self)  # type: ignore
         layout.setContentsMargins(0, 0, 0, 0)

--- a/bec_widgets/utils/palette_viewer.py
+++ b/bec_widgets/utils/palette_viewer.py
@@ -25,7 +25,7 @@ class PaletteViewer(BECWidget, QWidget):
     RPC = False
 
     def __init__(self, *args, parent=None, **kwargs):
-        super().__init__(parent=parent, theme_update=True, **kwargs)
+        super().__init__(parent=parent, **kwargs)
         self.setFixedSize(400, 600)
         layout = QVBoxLayout(self)
         dark_mode_button = DarkModeButton(self)

--- a/bec_widgets/widgets/containers/main_window/main_window.py
+++ b/bec_widgets/widgets/containers/main_window/main_window.py
@@ -73,7 +73,6 @@ class BECMainWindow(BECWidget, QMainWindow):
 
         # Init ui
         self._init_ui()
-        self._connect_to_theme_change()
 
         # Connections to BEC Notifications
         self.bec_dispatcher.connect_slot(

--- a/bec_widgets/widgets/control/device_input/device_combobox/device_combobox.py
+++ b/bec_widgets/widgets/control/device_input/device_combobox/device_combobox.py
@@ -155,14 +155,7 @@ class DeviceComboBox(BECWidget, QComboBox):
         **kwargs,
     ):
         self.config = self._process_config(config)
-        super().__init__(
-            parent=parent,
-            client=client,
-            config=self.config,
-            gui_id=gui_id,
-            theme_update=True,
-            **kwargs,
-        )
+        super().__init__(parent=parent, client=client, config=self.config, gui_id=gui_id, **kwargs)
         self.get_bec_shortcuts()
 
         self._device_filter: list[BECDeviceFilter] = []

--- a/bec_widgets/widgets/control/device_manager/components/ophyd_validation/ophyd_validation.py
+++ b/bec_widgets/widgets/control/device_manager/components/ophyd_validation/ophyd_validation.py
@@ -309,7 +309,7 @@ class OphydValidation(BECWidget, QtWidgets.QWidget):
     multiple_validations_completed = QtCore.Signal(list)
 
     def __init__(self, parent=None, client=None, hide_legend: bool = False):
-        super().__init__(parent=parent, client=client, theme_update=True)
+        super().__init__(parent=parent, client=client)
         self._running_ophyd_tests = False
         self._keep_visible_after_validation: list[str] = []
         if not READY_TO_TEST:

--- a/bec_widgets/widgets/editors/monaco/monaco_widget.py
+++ b/bec_widgets/widgets/editors/monaco/monaco_widget.py
@@ -55,9 +55,7 @@ class MonacoWidget(BECWidget, QWidget):
     def __init__(
         self, parent=None, config=None, client=None, gui_id=None, init_lsp: bool = True, **kwargs
     ):
-        super().__init__(
-            parent=parent, client=client, gui_id=gui_id, config=config, theme_update=True, **kwargs
-        )
+        super().__init__(parent=parent, client=client, gui_id=gui_id, config=config, **kwargs)
         layout = QVBoxLayout()
         layout.setContentsMargins(0, 0, 0, 0)
         self.editor = qtmonaco.Monaco(self)

--- a/bec_widgets/widgets/plots/heatmap/heatmap.py
+++ b/bec_widgets/widgets/plots/heatmap/heatmap.py
@@ -257,7 +257,7 @@ class Heatmap(ImageBase):
                 device_y=None,
                 device_z=None,
             )
-        super().__init__(parent=parent, config=config, theme_update=True, **kwargs)
+        super().__init__(parent=parent, config=config, **kwargs)
         self._image_config = config
         self.scan_id = None
         self.old_scan_id = None

--- a/bec_widgets/widgets/plots/plot_base.py
+++ b/bec_widgets/widgets/plots/plot_base.py
@@ -191,7 +191,6 @@ class PlotBase(BECWidget, QWidget):
 
         self._init_ui()
 
-        self._connect_to_theme_change()
         self._update_theme(None)
 
     def apply_theme(self, theme: str):

--- a/bec_widgets/widgets/plots/waveform/waveform.py
+++ b/bec_widgets/widgets/plots/waveform/waveform.py
@@ -208,8 +208,6 @@ class Waveform(PlotBase):
 
         self.update_with_scan_history(-1)
 
-        # for updating a color scheme of curves
-        self._connect_to_theme_change()
         # To fix the ViewAll action with clipToView activated
         self._connect_viewbox_menu_actions()
 

--- a/bec_widgets/widgets/progress/bec_progressbar/bec_progressbar.py
+++ b/bec_widgets/widgets/progress/bec_progressbar/bec_progressbar.py
@@ -61,9 +61,7 @@ class BECProgressBar(BECWidget, QWidget):
         enable_dynamic_stylesheet: bool = True,
         **kwargs,
     ):
-        super().__init__(
-            parent=parent, client=client, gui_id=gui_id, config=config, theme_update=True, **kwargs
-        )
+        super().__init__(parent=parent, client=client, gui_id=gui_id, config=config, **kwargs)
 
         accent_colors = get_accent_colors()
 

--- a/bec_widgets/widgets/progress/ring_progress_bar/ring_progress_bar.py
+++ b/bec_widgets/widgets/progress/ring_progress_bar/ring_progress_bar.py
@@ -397,7 +397,7 @@ class RingProgressBar(BECWidget, QWidget):
     ]
 
     def __init__(self, parent: QWidget | None = None, client=None, **kwargs):
-        super().__init__(parent=parent, client=client, theme_update=True, **kwargs)
+        super().__init__(parent=parent, client=client, **kwargs)
 
         self.setWindowTitle("Ring Progress Bar")
 

--- a/bec_widgets/widgets/services/beamline_states/beamline_state_manager.py
+++ b/bec_widgets/widgets/services/beamline_states/beamline_state_manager.py
@@ -323,9 +323,7 @@ class BeamlineStateManager(BECWidget, QWidget):
         gui_id: str | None = None,
         **kwargs,
     ) -> None:
-        super().__init__(
-            parent=parent, client=client, config=config, gui_id=gui_id, theme_update=True, **kwargs
-        )
+        super().__init__(parent=parent, client=client, config=config, gui_id=gui_id, **kwargs)
         self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
         self._state_pills: dict[str, BeamlineStatePill] = {}
         self._section_headers: dict[str, _BeamlineStateSectionHeader] = {}

--- a/bec_widgets/widgets/services/beamline_states/beamline_state_pill.py
+++ b/bec_widgets/widgets/services/beamline_states/beamline_state_pill.py
@@ -85,9 +85,7 @@ class BeamlineStatePill(BECWidget, QWidget):
         gui_id: str | None = None,
         **kwargs,
     ) -> None:
-        super().__init__(
-            parent=parent, client=client, config=config, gui_id=gui_id, theme_update=True, **kwargs
-        )
+        super().__init__(parent=parent, client=client, config=config, gui_id=gui_id, **kwargs)
         self.setObjectName("BeamlineStatePill")
         self.setAttribute(Qt.WidgetAttribute.WA_StyledBackground, True)
         self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)

--- a/bec_widgets/widgets/services/bec_atlas_admin_view/experiment_selection/experiment_mat_card.py
+++ b/bec_widgets/widgets/services/bec_atlas_admin_view/experiment_selection/experiment_mat_card.py
@@ -48,7 +48,7 @@ class ExperimentMatCard(BECWidget, QWidget):
         title: str = "Next Experiment",
         **kwargs,
     ):
-        super().__init__(parent=parent, theme_update=True, **kwargs)
+        super().__init__(parent=parent, **kwargs)
 
         layout = QVBoxLayout(self)
         layout.setContentsMargins(12, 8, 12, 8)

--- a/bec_widgets/widgets/services/device_browser/device_item/device_config_form.py
+++ b/bec_widgets/widgets/services/device_browser/device_item/device_config_form.py
@@ -4,7 +4,6 @@ from functools import partial
 
 from bec_lib.atlas_models import Device as DeviceConfigModel
 from pydantic import BaseModel
-from qtpy.QtWidgets import QApplication
 
 from bec_widgets.utils.colors import get_theme_name
 from bec_widgets.utils.forms_from_types import styles
@@ -47,7 +46,6 @@ class DeviceConfigForm(PydanticModelForm):
         pred, _ = self._widget_types["dict"]
         self._widget_types["dict"] = pred, self._custom_device_config_item
         self._validity.setVisible(True)
-        self._connect_to_theme_change()
         self.populate()
 
     def _post_init(self): ...
@@ -68,12 +66,6 @@ class DeviceConfigForm(PydanticModelForm):
     def get_form_data(self):
         """Get the entered metadata as a dict."""
         return self._md_schema.model_validate(super().get_form_data()).model_dump()
-
-    def _connect_to_theme_change(self):
-        """Connect to the theme change signal."""
-        qapp = QApplication.instance()
-        if hasattr(qapp, "theme_signal"):
-            qapp.theme_signal.theme_updated.connect(self.set_pretty_display_theme)  # type: ignore
 
     def set_schema(self, schema: type[BaseModel]):
         if not issubclass(schema, DeviceConfigModel):

--- a/bec_widgets/widgets/services/device_browser/device_item/device_signal_display.py
+++ b/bec_widgets/widgets/services/device_browser/device_item/device_signal_display.py
@@ -20,19 +20,11 @@ class SignalDisplay(BECWidget, QWidget):
         device: str = "",
         config: ConnectionConfig = None,
         gui_id: str | None = None,
-        theme_update: bool = False,
         **kwargs,
     ):
         """A widget to display all the signals from a given device, and allow getting
         a fresh reading."""
-        super().__init__(
-            parent=parent,
-            client=client,
-            config=config,
-            gui_id=gui_id,
-            theme_update=theme_update,
-            **kwargs,
-        )
+        super().__init__(parent=parent, client=client, config=config, gui_id=gui_id, **kwargs)
         self.get_bec_shortcuts()
         self._layout = QVBoxLayout()
         self.setLayout(self._layout)

--- a/bec_widgets/widgets/services/scan_history_browser/components/scan_history_device_viewer.py
+++ b/bec_widgets/widgets/services/scan_history_browser/components/scan_history_device_viewer.py
@@ -94,17 +94,9 @@ class ScanHistoryDeviceViewer(BECWidget, QtWidgets.QWidget):
         client=None,
         config: ConnectionConfig = None,
         gui_id: str = None,
-        theme_update: bool = True,
         **kwargs,
     ):
-        super().__init__(
-            parent=parent,
-            client=client,
-            config=config,
-            gui_id=gui_id,
-            theme_update=theme_update,
-            **kwargs,
-        )
+        super().__init__(parent=parent, client=client, config=config, gui_id=gui_id, **kwargs)
         # Current scan history message
         self.scan_history_msg: ScanHistoryMessage | None = None
         self._last_device_name: str | None = None

--- a/bec_widgets/widgets/services/scan_history_browser/components/scan_history_metadata_viewer.py
+++ b/bec_widgets/widgets/services/scan_history_browser/components/scan_history_metadata_viewer.py
@@ -26,7 +26,6 @@ class ScanHistoryMetadataViewer(BECWidget, QtWidgets.QGroupBox):
         client=None,
         config: ConnectionConfig | None = None,
         gui_id: str | None = None,
-        theme_update: bool = True,
         scan_history_msg: ScanHistoryMessage | None = None,
     ):
         """
@@ -37,12 +36,9 @@ class ScanHistoryMetadataViewer(BECWidget, QtWidgets.QGroupBox):
             client: The BEC client.
             config (ConnectionConfig, optional): The connection configuration.
             gui_id (str, optional): The GUI ID.
-            theme_update (bool, optional): Whether to subscribe to theme updates. Defaults to True.
             scan_history_msg (ScanHistoryMessage, optional): The scan history message to display. Defaults
         """
-        super().__init__(
-            parent=parent, client=client, config=config, gui_id=gui_id, theme_update=theme_update
-        )
+        super().__init__(parent=parent, client=client, config=config, gui_id=gui_id)
         self._scan_history_msg_labels = {
             "scan_id": "Scan ID",
             "dataset_number": "Dataset Nr",

--- a/bec_widgets/widgets/services/scan_history_browser/components/scan_history_view.py
+++ b/bec_widgets/widgets/services/scan_history_browser/components/scan_history_view.py
@@ -89,17 +89,9 @@ class ScanHistoryView(BECWidget, QtWidgets.QTreeWidget):
         config: ConnectionConfig = None,
         gui_id: str = None,
         max_length: int = 100,
-        theme_update: bool = True,
         **kwargs,
     ):
-        super().__init__(
-            parent=parent,
-            client=client,
-            config=config,
-            gui_id=gui_id,
-            theme_update=theme_update,
-            **kwargs,
-        )
+        super().__init__(parent=parent, client=client, config=config, gui_id=gui_id, **kwargs)
         self.status_icons = self._create_status_icons()
         self.column_header = ["Scan Nr", "Scan Name", "Status"]
         self.scan_history: list[ScanHistoryMessage] = []  # newest at index 0

--- a/bec_widgets/widgets/services/scan_history_browser/scan_history_browser.py
+++ b/bec_widgets/widgets/services/scan_history_browser/scan_history_browser.py
@@ -24,7 +24,6 @@ class ScanHistoryBrowser(BECWidget, QtWidgets.QWidget):
         client=None,
         config: ConnectionConfig = None,
         gui_id: str | None = None,
-        theme_update: bool = False,
         **kwargs,
     ):
         """
@@ -35,27 +34,19 @@ class ScanHistoryBrowser(BECWidget, QtWidgets.QWidget):
             client: The BEC client.
             config (ConnectionConfig, optional): The connection configuration.
             gui_id (str, optional): The GUI ID.
-            theme_update (bool, optional): Whether to subscribe to theme updates. Defaults to False.
         """
-        super().__init__(
-            parent=parent,
-            client=client,
-            config=config,
-            gui_id=gui_id,
-            theme_update=theme_update,
-            **kwargs,
-        )
+        super().__init__(parent=parent, client=client, config=config, gui_id=gui_id, **kwargs)
         layout = QtWidgets.QHBoxLayout()
         self.setLayout(layout)
 
         self.scan_history_view = ScanHistoryView(
-            parent=self, client=client, config=config, gui_id=gui_id, theme_update=theme_update
+            parent=self, client=client, config=config, gui_id=gui_id
         )
         self.scan_history_metadata_viewer = ScanHistoryMetadataViewer(
-            parent=self, client=client, config=config, gui_id=gui_id, theme_update=theme_update
+            parent=self, client=client, config=config, gui_id=gui_id
         )
         self.scan_history_device_viewer = ScanHistoryDeviceViewer(
-            parent=self, client=client, config=config, gui_id=gui_id, theme_update=theme_update
+            parent=self, client=client, config=config, gui_id=gui_id
         )
 
         self.init_layout()

--- a/bec_widgets/widgets/utility/visual/dark_mode_button/dark_mode_button.py
+++ b/bec_widgets/widgets/utility/visual/dark_mode_button/dark_mode_button.py
@@ -22,7 +22,7 @@ class DarkModeButton(BECWidget, QWidget):
         toolbar: bool = False,
         **kwargs,
     ) -> None:
-        super().__init__(parent=parent, client=client, gui_id=gui_id, theme_update=True, **kwargs)
+        super().__init__(parent=parent, client=client, gui_id=gui_id, **kwargs)
         self.setProperty("skip_settings", True)
 
         self._dark_mode_enabled = False

--- a/tests/unit_tests/test_busy_loader.py
+++ b/tests/unit_tests/test_busy_loader.py
@@ -9,10 +9,8 @@ from .client_mocks import mocked_client
 
 
 class _TestBusyWidget(BECWidget, QWidget):
-    def __init__(
-        self, parent=None, *, start_busy: bool = False, theme_update: bool = False, **kwargs
-    ):
-        super().__init__(parent=parent, theme_update=theme_update, start_busy=start_busy, **kwargs)
+    def __init__(self, parent=None, *, start_busy: bool = False, **kwargs):
+        super().__init__(parent=parent, start_busy=start_busy, **kwargs)
         lay = QVBoxLayout(self)
         lay.setContentsMargins(0, 0, 0, 0)
         lay.addWidget(QLabel("content", self))


### PR DESCRIPTION
## Description

Some widgets were explicitely connecting to theme updates, however bec widget base class is normally taking care of it. This resolves in another layer of double subscriptions on theme updates.

Since there is no motivation to not follow the theme updates, bool kwarg `theme_update` is completely removed.

## Related Issues

related to #1244 but fixes different issue.
