### PR TITLE
Fix general/dispatcher v2

### DIFF
--- a/bec_widgets/utils/bec_dispatcher.py
+++ b/bec_widgets/utils/bec_dispatcher.py
@@ -308,8 +308,11 @@ class BECDispatcher:
             *args: Arbitrary positional arguments
             **kwargs: Arbitrary keyword arguments
         """
-        # pylint: disable=protected-access
-        self.disconnect_topics(self.client.connector._topics_cb)
+        topics = set()
+        for connected_slot in self._registered_slots.values():
+            topics.update(connected_slot.topics)
+        if topics:
+            self.disconnect_topics(list(topics))
 
     def disconnect_owner(self, owner: BECWidget) -> int:
         """

--- a/bec_widgets/utils/bec_dispatcher.py
+++ b/bec_widgets/utils/bec_dispatcher.py
@@ -4,8 +4,9 @@ import collections
 import random
 import string
 import time
+import weakref
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any, DefaultDict, Hashable, Union
+from typing import TYPE_CHECKING, Any, DefaultDict, Hashable
 
 import louie
 import redis
@@ -63,26 +64,49 @@ def _log_rpc_dispatcher_receive(msg_content: Any, metadata: Any) -> None:
 
 
 class QtThreadSafeCallback(QObject):
-    """QtThreadSafeCallback is a wrapper around a callback function to make it thread-safe for Qt."""
+    """
+    QtThreadSafeCallback is a wrapper around a callback function to make it thread-safe for Qt.
+
+    Bound methods are held only through weak references: the dispatcher must never keep
+    the owning widget alive. Non-method callables (lambdas, partials, module functions)
+    have no owning object whose lifetime could be tracked, so they are kept alive by the
+    wrapper itself; pass ``owner=`` to ``connect_slot`` to bind their lifetime to a widget.
+    """
 
     cb_signal = pyqtSignal(dict, dict)
 
-    def __init__(self, cb: Callable, cb_info: dict | None = None):
+    def __init__(self, cb: Callable, cb_info: dict | None = None, owner: object | None = None):
         """
         Initialize the QtThreadSafeCallback.
 
         Args:
             cb (Callable): The callback function to be wrapped.
             cb_info (dict, optional): Additional information about the callback. Defaults to None.
+            owner (object, optional): Lifetime anchor for non-method callables. Ignored for
+                bound methods (their ``__self__`` is the owner). Defaults to None.
         """
         super().__init__()
         self.cb_info = cb_info
 
-        self.cb = cb
-        self.cb_owner = louie.saferef.safe_ref(cb.__self__) if hasattr(cb, "__self__") else None
+        if hasattr(cb, "__self__"):
+            # Bound method: the owner is the method's instance; hold NO strong reference
+            # anywhere so the dispatcher can never keep a widget alive.
+            self.cb_owner = louie.saferef.safe_ref(cb.__self__)
+            self._strong_cb = None
+        else:
+            # No trackable owner on the callable itself: keep it alive explicitly,
+            # released together with this wrapper (disconnect_owner / dead-slot sweep
+            # when owner is given, disconnect_slot otherwise).
+            self.cb_owner = louie.saferef.safe_ref(owner) if owner is not None else None
+            self._strong_cb = cb
         self.cb_ref = louie.saferef.safe_ref(cb)
-        self.cb_signal.connect(self.cb)
+        self.cb_signal.connect(cb)
         self.topics = set()
+
+    @property
+    def cb(self) -> Callable | None:
+        """The wrapped callback, or None if it has been garbage collected."""
+        return self.cb_ref()
 
     def __hash__(self):
         # make 2 differents QtThreadSafeCallback to look
@@ -197,6 +221,7 @@ class BECDispatcher:
         slot: Callable,
         topics: EndpointInfo | str | list[EndpointInfo] | list[str],
         cb_info: dict | None = None,
+        owner: object | None = None,
         **kwargs,
     ) -> None:
         """Connect widget's qt slot, so that it is called on new pub/sub topic message.
@@ -206,8 +231,17 @@ class BECDispatcher:
                 the corresponding pub/sub message
             topics EndpointInfo | str | list[EndpointInfo] | list[str]: A topic or list of topics that can typically be acquired via bec_lib.MessageEndpoints
             cb_info (dict | None): A dictionary containing information about the callback. Defaults to None.
+            owner (object | None): Lifetime anchor for non-method callables (lambdas, partials,
+                module functions): the subscription is released when the owner is cleaned up or
+                destroyed. Bound methods already carry their owner and ignore this. Defaults to None.
         """
-        qt_slot = QtThreadSafeCallback(cb=slot, cb_info=cb_info)
+        if not hasattr(slot, "__self__") and owner is None:
+            logger.warning(
+                f"connect_slot({slot!r}) on {topics}: the callable has no owner, so it cannot be "
+                "released automatically and stays subscribed until disconnect_slot is called. "
+                "Pass owner=<widget> to bind its lifetime to a widget."
+            )
+        qt_slot = QtThreadSafeCallback(cb=slot, cb_info=cb_info, owner=owner)
         if not self.client.connector.any_stream_is_registered(topics, qt_slot):
             if qt_slot not in self._registered_slots:
                 self._registered_slots[qt_slot] = qt_slot

--- a/bec_widgets/utils/bec_dispatcher.py
+++ b/bec_widgets/utils/bec_dispatcher.py
@@ -25,6 +25,7 @@ logger = bec_logger.logger
 if TYPE_CHECKING:  # pragma: no cover
     from bec_lib.endpoints import EndpointInfo
 
+    from bec_widgets.utils.bec_widget import BECWidget
     from bec_widgets.utils.rpc_server import RPCServer
 
 
@@ -78,6 +79,7 @@ class QtThreadSafeCallback(QObject):
         self.cb_info = cb_info
 
         self.cb = cb
+        self.cb_owner = louie.saferef.safe_ref(cb.__self__) if hasattr(cb, "__self__") else None
         self.cb_ref = louie.saferef.safe_ref(cb)
         self.cb_signal.connect(self.cb)
         self.topics = set()
@@ -270,6 +272,22 @@ class BECDispatcher:
         """
         # pylint: disable=protected-access
         self.disconnect_topics(self.client.connector._topics_cb)
+
+    def disconnect_owner(self, owner: BECWidget):
+        """
+        Disconnect all slots owned by a particular widget.
+
+        Args:
+            owner(BECWidget): The owner widget whose slots should be disconnected
+        """
+        slots_to_disconnect = []
+        for connected_slot in self._registered_slots.values():
+            if connected_slot.cb_owner is not None and connected_slot.cb_owner() == owner:
+                slots_to_disconnect.append(connected_slot)
+        for slot in slots_to_disconnect:
+            topics = slot.topics.copy()
+            for topic in topics:
+                self.disconnect_slot(slot.cb, topic)
 
     def start_cli_server(self, gui_id: str | None = None):
         """

--- a/bec_widgets/utils/bec_dispatcher.py
+++ b/bec_widgets/utils/bec_dispatcher.py
@@ -307,21 +307,41 @@ class BECDispatcher:
         # pylint: disable=protected-access
         self.disconnect_topics(self.client.connector._topics_cb)
 
-    def disconnect_owner(self, owner: BECWidget):
+    def disconnect_owner(self, owner: BECWidget) -> int:
         """
         Disconnect all slots owned by a particular widget.
 
+        Called by ``BECWidget.cleanup``, so widgets never need to disconnect their own
+        slots at teardown. Idempotent: calling it again (or for an owner without
+        subscriptions) is a no-op.
+
         Args:
             owner(BECWidget): The owner widget whose slots should be disconnected
+
+        Returns:
+            int: The number of released slot wrappers.
         """
-        slots_to_disconnect = []
-        for connected_slot in self._registered_slots.values():
-            if connected_slot.cb_owner is not None and connected_slot.cb_owner() == owner:
-                slots_to_disconnect.append(connected_slot)
-        for slot in slots_to_disconnect:
-            topics = slot.topics.copy()
-            for topic in topics:
-                self.disconnect_slot(slot.cb, topic)
+        slots_to_disconnect = [
+            connected_slot
+            for connected_slot in list(self._registered_slots.values())
+            if connected_slot.cb_owner is not None and connected_slot.cb_owner() is owner
+        ]
+        for qt_slot in slots_to_disconnect:
+            self._release_slot(qt_slot)
+        if slots_to_disconnect:
+            logger.info(
+                f"Released {len(slots_to_disconnect)} dispatcher slot(s) owned by "
+                f"{type(owner).__name__}"
+            )
+        return len(slots_to_disconnect)
+
+    def _release_slot(self, qt_slot: QtThreadSafeCallback) -> None:
+        """Unregister all topics of a slot wrapper and drop it from the registry."""
+        topics = list(qt_slot.topics)
+        if topics:
+            self.client.connector.unregister(topics, cb=qt_slot)
+        qt_slot.topics.clear()
+        self._registered_slots.pop(qt_slot, None)
 
     def start_cli_server(self, gui_id: str | None = None):
         """

--- a/bec_widgets/utils/bec_dispatcher.py
+++ b/bec_widgets/utils/bec_dispatcher.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any, DefaultDict, Hashable
 
 import louie
 import redis
+import shiboken6
 from bec_lib.client import BECClient
 from bec_lib.logger import bec_logger
 from bec_lib.redis_connector import MessageObject, RedisConnector
@@ -241,6 +242,9 @@ class BECDispatcher:
                 "released automatically and stays subscribed until disconnect_slot is called. "
                 "Pass owner=<widget> to bind its lifetime to a widget."
             )
+        # Self-healing: reap subscriptions whose owners died without any close event
+        # before adding new ones, so stale registrations never accumulate.
+        self.cleanup_dead_slots()
         qt_slot = QtThreadSafeCallback(cb=slot, cb_info=cb_info, owner=owner)
         if not self.client.connector.any_stream_is_registered(topics, qt_slot):
             if qt_slot not in self._registered_slots:
@@ -342,6 +346,41 @@ class BECDispatcher:
             self.client.connector.unregister(topics, cb=qt_slot)
         qt_slot.topics.clear()
         self._registered_slots.pop(qt_slot, None)
+
+    def cleanup_dead_slots(self) -> int:
+        """
+        Release subscriptions whose callback or owner no longer exists.
+
+        Covers every death path that never delivers a close event: widgets destroyed
+        together with a parent, C++ objects deleted while a Python reference lingers,
+        and owners that were simply garbage collected. Runs automatically whenever a
+        BECWidget is destroyed and on every connect_slot, so stale subscriptions never
+        accumulate.
+
+        Returns:
+            int: The number of released slot wrappers.
+        """
+        dead_slots = []
+        for qt_slot in list(self._registered_slots.values()):
+            cb = qt_slot.cb
+            if cb is None:
+                # The callback itself was garbage collected.
+                dead_slots.append(qt_slot)
+                continue
+            owner = qt_slot.cb_owner() if qt_slot.cb_owner is not None else None
+            if qt_slot.cb_owner is not None and owner is None:
+                # The owner was garbage collected (also anchors owner-bound lambdas).
+                dead_slots.append(qt_slot)
+                continue
+            if isinstance(owner, QObject) and not shiboken6.isValid(owner):
+                # The owner's C++ object was destroyed (e.g. with its parent) while a
+                # Python reference keeps the wrapper alive.
+                dead_slots.append(qt_slot)
+        for qt_slot in dead_slots:
+            self._release_slot(qt_slot)
+        if dead_slots:
+            logger.info(f"Released {len(dead_slots)} dispatcher slot(s) with dead owners")
+        return len(dead_slots)
 
     def start_cli_server(self, gui_id: str | None = None):
         """

--- a/bec_widgets/utils/bec_dispatcher.py
+++ b/bec_widgets/utils/bec_dispatcher.py
@@ -257,7 +257,10 @@ class BECDispatcher:
             logger.warning(f"Attempted to create duplicate stream subscription for {topics=}")
 
     def disconnect_slot(
-        self, slot: Callable, topics: EndpointInfo | str | list[EndpointInfo] | list[str]
+        self,
+        slot: Callable,
+        topics: EndpointInfo | str | list[EndpointInfo] | list[str],
+        cb_info: dict | None = None,
     ):
         """
         Disconnect a slot from a topic.
@@ -265,13 +268,20 @@ class BECDispatcher:
         Args:
             slot(Callable): The slot to disconnect
             topics EndpointInfo | str | list[EndpointInfo] | list[str]: A topic or list of topics to unsub from.
+            cb_info(dict | None): When the same slot was registered multiple times with
+                different cb_info payloads (e.g. per-signal async subscriptions), pass the
+                payload to select the exact registration; without it the first wrapper
+                matching the callback is used.
         """
         # find the right slot to disconnect from ;
         # slot callbacks are wrapped in QtThreadSafeCallback objects,
         # but the slot we receive here is the original callable
         for connected_slot in self._registered_slots.values():
-            if connected_slot.cb == slot:
-                break
+            if connected_slot.cb != slot:
+                continue
+            if cb_info is not None and connected_slot.cb_info != cb_info:
+                continue
+            break
         else:
             return
         self.client.connector.unregister(topics, cb=connected_slot)

--- a/bec_widgets/utils/bec_widget.py
+++ b/bec_widgets/utils/bec_widget.py
@@ -406,6 +406,7 @@ class BECWidget(BECConnector):
         try:
             if not self._destroyed:
                 self._destroyed = True
+                self.bec_dispatcher.disconnect_owner(self)
                 self.cleanup()
         finally:
             super().closeEvent(event)  # pylint: disable=no-member

--- a/bec_widgets/utils/bec_widget.py
+++ b/bec_widgets/utils/bec_widget.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 import os
 import tempfile
 from datetime import datetime
+from functools import partial
 from typing import TYPE_CHECKING
 
 import shiboken6
 from bec_lib.logger import bec_logger
-from qtpy.QtCore import QBuffer, QByteArray, QIODevice, QObject, Qt
+from qtpy.QtCore import QBuffer, QByteArray, QEvent, QIODevice, QObject, Qt
 from qtpy.QtGui import QFont, QPixmap
 from qtpy.QtWidgets import QApplication, QFileDialog, QLabel, QVBoxLayout, QWidget
 
@@ -24,6 +25,35 @@ if TYPE_CHECKING:  # pragma: no cover
     from bec_widgets.utils.busy_loader import BusyLoaderOverlay
 
 logger = bec_logger.logger
+
+
+def _forget_destroyed_widget(gui_id: str, *_args) -> None:
+    """
+    Purge registry and dispatcher state of a widget whose QObject was destroyed.
+
+    Connected to ``QObject.destroyed`` with the gui_id captured as a plain string:
+    when this runs, the Python wrapper is already invalid, so nothing here may touch
+    the widget itself. This is the safety net for destruction paths that never deliver
+    a close event (parent destruction, deleteLater without close).
+    """
+    # pylint: disable=import-outside-toplevel
+    from bec_widgets.utils.bec_dispatcher import BECDispatcher
+
+    # A destroyed handler runs in destructor context and must never raise: during late
+    # application shutdown the client/connector may already be gone, making the registry
+    # broadcast or the unregister fail. Guard each step independently so a failing
+    # broadcast never prevents the dispatcher sweep.
+    try:
+        RPCRegister().remove_rpc_by_id(gui_id)
+    except Exception as exc:
+        logger.warning(f"Registry purge for destroyed widget {gui_id} failed: {exc}")
+    # Only sweep an already-running singleton dispatcher; never construct one during teardown.
+    dispatcher = BECDispatcher._instance
+    if dispatcher is not None and getattr(dispatcher, "_initialized", False):
+        try:
+            dispatcher.cleanup_dead_slots()
+        except Exception as exc:
+            logger.warning(f"Dead-slot sweep for destroyed widget {gui_id} failed: {exc}")
 
 
 class BECWidget(BECConnector):
@@ -62,6 +92,10 @@ class BECWidget(BECConnector):
         super().__init__(client=client, config=config, gui_id=gui_id, **kwargs)
         if not isinstance(self, QObject):
             raise RuntimeError(f"{repr(self)} is not a subclass of QWidget")
+        # Safety net for destruction without a close event (e.g. destroyed together with
+        # a parent): purge registry and dispatcher state by gui_id. The partial captures
+        # only the string, never the widget.
+        self.destroyed.connect(partial(_forget_destroyed_widget, self.gui_id))
         self._connect_to_theme_change()
 
         # Initialize optional busy loader overlay utility (lazy by default)
@@ -371,6 +405,9 @@ class BECWidget(BECConnector):
         with RPCRegister.delayed_broadcast():
             # All widgets need to call super().cleanup() in their cleanup method
             logger.info(f"Registry cleanup for widget {self.__class__.__name__}")
+            # Release every dispatcher subscription owned by this widget; subclasses
+            # do not need to disconnect their own slots at teardown.
+            self.bec_dispatcher.disconnect_owner(self)
             self.rpc_register.remove_rpc(self)
             children = self.findChildren(BECWidget)
             for child in children:
@@ -401,12 +438,26 @@ class BECWidget(BECConnector):
                 except Exception as exc:
                     logger.warning(f"Failed to delete busy overlay: {exc}")
 
+    def event(self, event):
+        """
+        Run cleanup when the widget is deleted via deleteLater without ever being
+        closed: the DeferredDelete event is the last point where the widget is still
+        fully alive. Together with closeEvent (explicit close) and the destroyed hook
+        (parent destruction), every destruction path releases the widget's resources.
+        """
+        if event.type() == QEvent.Type.DeferredDelete and not self._destroyed:
+            try:
+                self.cleanup()
+                self._destroyed = True
+            except Exception:
+                logger.exception(f"Cleanup on deferred delete failed for {self.__class__.__name__}")
+        return super().event(event)  # pylint: disable=no-member
+
     def closeEvent(self, event):
-        """Wrap the close even to ensure the rpc_register is cleaned up."""
+        """Wrap the close event to ensure the widget is cleaned up."""
         try:
             if not self._destroyed:
                 self._destroyed = True
-                self.bec_dispatcher.disconnect_owner(self)
                 self.cleanup()
         finally:
             super().closeEvent(event)  # pylint: disable=no-member

--- a/bec_widgets/utils/bec_widget.py
+++ b/bec_widgets/utils/bec_widget.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 
 import shiboken6
 from bec_lib.logger import bec_logger
-from qtpy.QtCore import QBuffer, QByteArray, QEvent, QIODevice, QObject, Qt
+from qtpy.QtCore import QBuffer, QByteArray, QIODevice, QObject, Qt
 from qtpy.QtGui import QFont, QPixmap
 from qtpy.QtWidgets import QApplication, QFileDialog, QLabel, QVBoxLayout, QWidget
 
@@ -438,20 +438,30 @@ class BECWidget(BECConnector):
                 except Exception as exc:
                     logger.warning(f"Failed to delete busy overlay: {exc}")
 
-    def event(self, event):
+    def deleteLater(self):
         """
-        Run cleanup when the widget is deleted via deleteLater without ever being
-        closed: the DeferredDelete event is the last point where the widget is still
-        fully alive. Together with closeEvent (explicit close) and the destroyed hook
-        (parent destruction), every destruction path releases the widget's resources.
+        Run cleanup when the widget is discarded via deleteLater without ever being
+        closed, then schedule the deletion. Together with closeEvent (explicit close)
+        and the destroyed hook (parent destruction), every destruction path releases
+        the widget's resources.
+
+        NOTE: deliberately a ``deleteLater`` override, not an ``event()`` override
+        intercepting DeferredDelete: routing every event through Python makes
+        shiboken wrap each C++ QEvent, and a stale pointer-cache entry of a
+        non-QObject (e.g. a QStandardItem freed by a combo box model) at a recycled
+        address then raises a TypeError inside the binding layer. Qt-internal (C++)
+        deleteLater calls bypass this override; those paths are covered by the
+        destroyed-signal safety net.
         """
-        if event.type() == QEvent.Type.DeferredDelete and not self._destroyed:
+        if not self._destroyed:
+            # Flag first (matching closeEvent): the widget counts as destroyed while its
+            # own cleanup runs, so nothing re-enters cleanup on this path.
+            self._destroyed = True
             try:
                 self.cleanup()
-                self._destroyed = True
             except Exception:
-                logger.exception(f"Cleanup on deferred delete failed for {self.__class__.__name__}")
-        return super().event(event)  # pylint: disable=no-member
+                logger.exception(f"Cleanup on deleteLater failed for {self.__class__.__name__}")
+        super().deleteLater()  # pylint: disable=no-member
 
     def closeEvent(self, event):
         """Wrap the close event to ensure the widget is cleaned up."""

--- a/bec_widgets/utils/redis_message_waiter.py
+++ b/bec_widgets/utils/redis_message_waiter.py
@@ -11,7 +11,9 @@ class QtRedisMessageWaiter:
         self.response = None
         self.connector = redis_connector
         self.message_to_wait = message_to_wait
-        self.pubsub = redis_connector._redis_conn.pubsub()
+        # Access the managed (buffered) connection directly; the connector-level
+        # _redis_conn accessor is deprecated in bec_lib.
+        self.pubsub = redis_connector._managed_connection._redis_conn.pubsub()
         self.pubsub.subscribe(self.message_to_wait.endpoint)
         fd = self.pubsub.connection._sock.fileno()
         self.notifier = QSocketNotifier(fd, QSocketNotifier.Read)

--- a/bec_widgets/utils/rpc_register.py
+++ b/bec_widgets/utils/rpc_register.py
@@ -87,6 +87,19 @@ class RPCRegister:
             raise ValueError(f"RPC object {rpc} must have a 'gui_id' attribute.")
         self._rpc_register.pop(rpc.gui_id, None)
 
+    @broadcast_update
+    def remove_rpc_by_id(self, gui_id: str):
+        """
+        Remove an RPC object from the register by its gui_id.
+
+        Unlike remove_rpc, this does not need the object itself, so it is safe to call
+        from a QObject.destroyed handler where the object is no longer accessible.
+
+        Args:
+            gui_id(str): The gui_id of the RPC object to be removed.
+        """
+        self._rpc_register.pop(gui_id, None)
+
     def get_rpc_by_id(self, gui_id: str) -> QObject | None:
         """
         Get an RPC object by its ID.

--- a/bec_widgets/widgets/plots/image/image.py
+++ b/bec_widgets/widgets/plots/image/image.py
@@ -1068,8 +1068,7 @@ class Image(ImageBase):
         except Exception:  # noqa: BLE001
             pass
 
-        self.bec_dispatcher.disconnect_slot(self.on_scan_status, MessageEndpoints.scan_status())
-        self.bec_dispatcher.disconnect_slot(self.on_scan_progress, MessageEndpoints.scan_progress())
+        # Dispatcher slots are released by BECWidget.cleanup via disconnect_owner.
         super().cleanup()
 
 

--- a/bec_widgets/widgets/plots/scatter_waveform/scatter_waveform.py
+++ b/bec_widgets/widgets/plots/scatter_waveform/scatter_waveform.py
@@ -740,8 +740,7 @@ class ScatterWaveform(PlotBase):
             self.scatter_dialog.deleteLater()
         if self.scatter_curve_settings is not None:
             self.scatter_curve_settings.cleanup()
-        self.bec_dispatcher.disconnect_slot(self.on_scan_status, MessageEndpoints.scan_status())
-        self.bec_dispatcher.disconnect_slot(self.on_scan_progress, MessageEndpoints.scan_progress())
+        # Dispatcher slots are released by BECWidget.cleanup via disconnect_owner.
         self.plot_item.removeItem(self._main_curve)
         self._main_curve = None
         super().cleanup()

--- a/bec_widgets/widgets/progress/ring_progress_bar/ring.py
+++ b/bec_widgets/widgets/progress/ring_progress_bar/ring.py
@@ -639,11 +639,10 @@ class Ring(BECWidget, QWidget):
     def cleanup(self):
         """
         Cleanup the ring widget.
-        Disconnect any registered slots.
         """
-        if self.registered_slot is not None:
-            self.bec_dispatcher.disconnect_slot(*self.registered_slot)
-            self.registered_slot = None
+        # Dispatcher slots are released by BECWidget.cleanup via disconnect_owner;
+        # no per-widget disconnect is needed at teardown.
+        self.registered_slot = None
         self.progress_tracker.cleanup()
         self._hover_animation.stop()
         super().cleanup()

--- a/tests/unit_tests/test_bec_dispatcher.py
+++ b/tests/unit_tests/test_bec_dispatcher.py
@@ -85,7 +85,7 @@ def test_dispatcher_disconnect_all(bec_dispatcher_w_connector, qtbot, send_msg_e
     bec_dispatcher.connect_slot(cb1, "topic2")
     bec_dispatcher.connect_slot(cb2, "topic2")
     bec_dispatcher.connect_slot(cb2, "topic3")
-    assert len(bec_dispatcher.client.connector._topics_cb) == 3
+    assert len(bec_dispatcher.client.connector._managed_connection._topics_cb) == 3
     send_msg_event.set()
     qtbot.wait(10)
     assert cb1.call_count == 2
@@ -93,7 +93,7 @@ def test_dispatcher_disconnect_all(bec_dispatcher_w_connector, qtbot, send_msg_e
 
     bec_dispatcher.disconnect_all()
 
-    assert len(bec_dispatcher.client.connector._topics_cb) == 0
+    assert len(bec_dispatcher.client.connector._managed_connection._topics_cb) == 0
 
 
 @pytest.mark.parametrize("topics_msg_list", [(("topic1", dummy_msg), ("topic2", dummy_msg))])
@@ -104,9 +104,9 @@ def test_dispatcher_disconnect_one(bec_dispatcher_w_connector, qtbot, send_msg_e
 
     bec_dispatcher.connect_slot(cb1, "topic1")
     bec_dispatcher.connect_slot(cb2, "topic2")
-    assert len(bec_dispatcher.client.connector._topics_cb) == 2
+    assert len(bec_dispatcher.client.connector._managed_connection._topics_cb) == 2
     bec_dispatcher.disconnect_slot(cb1, "topic1")
-    assert len(bec_dispatcher.client.connector._topics_cb) == 1
+    assert len(bec_dispatcher.client.connector._managed_connection._topics_cb) == 1
 
     send_msg_event.set()
     qtbot.wait(10)
@@ -127,10 +127,10 @@ def test_dispatcher_2_cb_same_topic(bec_dispatcher_w_connector, qtbot, send_msg_
     bec_dispatcher.connect_slot(cb2, "topic1")
 
     # The redis connector should only subscribe once to the topic
-    assert len(bec_dispatcher.client.connector._topics_cb) == 1
+    assert len(bec_dispatcher.client.connector._managed_connection._topics_cb) == 1
 
     # The the given topic, two callbacks should be registered
-    assert len(bec_dispatcher.client.connector._topics_cb["topic1"]) == 2
+    assert len(bec_dispatcher.client.connector._managed_connection._topics_cb["topic1"]) == 2
 
     # The dispatcher should have two slots
     assert len(bec_dispatcher._registered_slots) == num_slots + 2
@@ -150,7 +150,7 @@ def test_dispatcher_2_cb_same_topic_same_slot(bec_dispatcher_w_connector, qtbot,
 
     bec_dispatcher.connect_slot(cb1, "topic1")
     bec_dispatcher.connect_slot(cb1, "topic1")
-    assert len(bec_dispatcher.client.connector._topics_cb) == 1
+    assert len(bec_dispatcher.client.connector._managed_connection._topics_cb) == 1
     assert (
         len(list(filter(lambda slot: slot.cb == cb1, bec_dispatcher._registered_slots.values())))
         == 1
@@ -173,9 +173,9 @@ def test_dispatcher_2_topic_same_cb(bec_dispatcher_w_connector, qtbot, send_msg_
 
     bec_dispatcher.connect_slot(cb1, "topic1")
     bec_dispatcher.connect_slot(cb1, "topic2")
-    assert len(bec_dispatcher.client.connector._topics_cb) == 2
+    assert len(bec_dispatcher.client.connector._managed_connection._topics_cb) == 2
     bec_dispatcher.disconnect_slot(cb1, "topic1")
-    assert len(bec_dispatcher.client.connector._topics_cb) == 1
+    assert len(bec_dispatcher.client.connector._managed_connection._topics_cb) == 1
 
     send_msg_event.set()
     qtbot.wait(10)
@@ -205,10 +205,10 @@ def test_dispatcher_2_topic_same_cb_with_boundmethod(
             )
         )
 
-    assert len(bec_dispatcher.client.connector._topics_cb) == 1
+    assert len(bec_dispatcher.client.connector._managed_connection._topics_cb) == 1
     assert len(_get_slots()) == 1
     bec_dispatcher.disconnect_slot(cb1.mock_slot, "topic1")
-    assert len(bec_dispatcher.client.connector._topics_cb) == 0
+    assert len(bec_dispatcher.client.connector._managed_connection._topics_cb) == 0
     assert len(_get_slots()) == 0
 
     send_msg_event.set()

--- a/tests/unit_tests/test_bec_widget_lifecycle.py
+++ b/tests/unit_tests/test_bec_widget_lifecycle.py
@@ -1,0 +1,231 @@
+# pylint: disable = no-name-in-module,missing-class-docstring, missing-module-docstring
+import shiboken6
+from bec_lib.endpoints import MessageEndpoints
+from qtpy.QtCore import QEvent, QObject
+from qtpy.QtWidgets import QApplication, QVBoxLayout, QWidget
+
+from bec_widgets.utils.bec_widget import BECWidget
+from bec_widgets.utils.rpc_register import RPCRegister
+
+from .client_mocks import mocked_client
+
+
+class LifecycleWidget(BECWidget, QWidget):
+    def __init__(self, parent=None, client=None, **kwargs):
+        super().__init__(parent=parent, client=client, **kwargs)
+        self.cleanup_calls = 0
+
+    def on_message(self, msg_content, metadata):
+        pass
+
+    def cleanup(self):
+        self.cleanup_calls += 1
+        super().cleanup()
+
+
+def _flush_deferred_deletes(qtbot):
+    QApplication.sendPostedEvents(None, QEvent.Type.DeferredDelete)
+    QApplication.processEvents()
+
+
+def test_close_runs_cleanup_once(qtbot, mocked_client):
+    widget = LifecycleWidget(client=mocked_client)
+    gui_id = widget.gui_id
+    assert RPCRegister().get_rpc_by_id(gui_id) is widget
+
+    widget.close()
+    assert widget.cleanup_calls == 1
+    assert widget._destroyed is True
+    assert RPCRegister().get_rpc_by_id(gui_id) is None
+
+    # a second close must not re-run cleanup
+    widget.close()
+    assert widget.cleanup_calls == 1
+
+    widget.deleteLater()
+    _flush_deferred_deletes(qtbot)
+
+
+def test_delete_later_without_close_runs_cleanup(qtbot, mocked_client):
+    widget = LifecycleWidget(client=mocked_client)
+    gui_id = widget.gui_id
+    assert RPCRegister().get_rpc_by_id(gui_id) is widget
+
+    # destruction path that never delivers a close event
+    widget.deleteLater()
+    _flush_deferred_deletes(qtbot)
+
+    assert widget.cleanup_calls == 1
+    assert RPCRegister().get_rpc_by_id(gui_id) is None
+
+
+def test_close_then_delete_later_runs_cleanup_once(qtbot, mocked_client):
+    widget = LifecycleWidget(client=mocked_client)
+
+    widget.close()
+    widget.deleteLater()
+    _flush_deferred_deletes(qtbot)
+
+    assert widget.cleanup_calls == 1
+
+
+def test_parent_destruction_removes_registry_entry(qtbot, mocked_client):
+    # A BECWidget embedded in a plain (non-BECWidget) parent: destroying the parent
+    # delivers neither a close event nor a DeferredDelete event to the child, so
+    # cleanup() cannot run — the destroyed-signal hook must still remove the child
+    # from the RPC registry by gui_id.
+    parent = QWidget()
+    layout = QVBoxLayout(parent)
+    child = LifecycleWidget(parent=parent, client=mocked_client)
+    layout.addWidget(child)
+    gui_id = child.gui_id
+    assert RPCRegister().get_rpc_by_id(gui_id) is child
+
+    cleanup_calls_seen = []
+    child.destroyed.connect(lambda *_: cleanup_calls_seen.append(child.cleanup_calls))
+
+    parent.deleteLater()
+    _flush_deferred_deletes(qtbot)
+
+    # cleanup itself could not run on this path (documented limitation) ...
+    assert cleanup_calls_seen == [0]
+    # ... but the registry entry is gone
+    assert RPCRegister().get_rpc_by_id(gui_id) is None
+
+
+def test_delete_later_without_close_releases_dispatcher_subscriptions(
+    qtbot, mocked_client, bec_dispatcher
+):
+    # End-to-end: the DeferredDelete hook runs cleanup(), which releases the widget's
+    # dispatcher subscriptions via disconnect_owner — no close(), no manual disconnect,
+    # no message traffic needed.
+    widget = LifecycleWidget(client=mocked_client)
+    bec_dispatcher.connect_slot(widget.on_message, MessageEndpoints.scan_status())
+    slots_before = len(bec_dispatcher._registered_slots)
+
+    widget.deleteLater()
+    _flush_deferred_deletes(qtbot)
+
+    assert widget.cleanup_calls == 1
+    assert len(bec_dispatcher._registered_slots) == slots_before - 1
+
+
+def test_lambda_without_owner_warns_and_stays(qtbot, mocked_client, bec_dispatcher):
+    # A lambda has no trackable owner: connect_slot must warn loudly, and the
+    # subscription stays alive (working) until disconnect_slot is called.
+    from unittest import mock
+
+    from bec_widgets.utils import bec_dispatcher as bd_module
+
+    received = []
+    cb = lambda content, metadata: received.append(content)  # noqa: E731
+    with mock.patch.object(bd_module, "logger") as mock_logger:
+        bec_dispatcher.connect_slot(cb, MessageEndpoints.scan_status())
+    slots_before = len(bec_dispatcher._registered_slots)
+
+    assert any(
+        "cannot be released automatically" in str(call.args[0])
+        for call in mock_logger.warning.call_args_list
+    )
+
+    # not reaped by the sweep: nothing marks it dead
+    bec_dispatcher.cleanup_dead_slots()
+    assert len(bec_dispatcher._registered_slots) == slots_before
+
+    bec_dispatcher.disconnect_slot(cb, MessageEndpoints.scan_status())
+    assert len(bec_dispatcher._registered_slots) == slots_before - 1
+
+
+def test_lambda_with_owner_released_with_widget(qtbot, mocked_client, bec_dispatcher):
+    # owner= binds a lambda's lifetime to a widget: cleanup of the widget releases it.
+    widget = LifecycleWidget(client=mocked_client)
+    received = []
+    bec_dispatcher.connect_slot(
+        lambda content, metadata: received.append(content),
+        MessageEndpoints.scan_status(),
+        owner=widget,
+    )
+    slots_before = len(bec_dispatcher._registered_slots)
+
+    widget.close()
+    assert len(bec_dispatcher._registered_slots) == slots_before - 1
+
+    widget.deleteLater()
+    _flush_deferred_deletes(qtbot)
+
+
+def test_dead_slot_sweep_reaps_garbage_collected_owners(qtbot, mocked_client, bec_dispatcher):
+    # An owner that is garbage collected (never closed, never deleted via Qt) leaves a
+    # wrapper whose weak callback ref is dead; cleanup_dead_slots must reap it without
+    # waiting for the next message on the topic.
+    import gc
+
+    class PlainOwner:
+        def on_message(self, msg_content, metadata):
+            pass
+
+    owner = PlainOwner()
+    bec_dispatcher.connect_slot(owner.on_message, MessageEndpoints.scan_status())
+    slots_before = len(bec_dispatcher._registered_slots)
+
+    del owner
+    gc.collect()
+
+    bec_dispatcher.cleanup_dead_slots()
+    assert len(bec_dispatcher._registered_slots) == slots_before - 1
+
+
+def test_destroyed_hook_survives_registry_failure(qtbot, mocked_client, bec_dispatcher):
+    # During late application shutdown the registry broadcast can fail (the client and
+    # its connector may already be shut down). The destroyed hook runs in destructor
+    # context and must never raise: it logs, still purges the registry entry (popped
+    # before the broadcast), and still runs the dispatcher sweep.
+    from unittest import mock
+
+    from bec_widgets.utils import bec_widget as bw_module
+
+    parent = QWidget()
+    layout = QVBoxLayout(parent)
+    child = LifecycleWidget(parent=parent, client=mocked_client)
+    layout.addWidget(child)
+    gui_id = child.gui_id
+    bec_dispatcher.connect_slot(child.on_message, MessageEndpoints.scan_status())
+    slots_before = len(bec_dispatcher._registered_slots)
+
+    with (
+        mock.patch.object(RPCRegister, "broadcast", side_effect=RuntimeError("client gone")),
+        mock.patch.object(bw_module, "logger") as mock_logger,
+    ):
+        parent.deleteLater()
+        _flush_deferred_deletes(qtbot)
+
+    assert any(
+        "Registry purge for destroyed widget" in str(call.args[0])
+        for call in mock_logger.warning.call_args_list
+    )
+    assert RPCRegister().get_rpc_by_id(gui_id) is None
+    assert len(bec_dispatcher._registered_slots) == slots_before - 1
+
+
+def test_parent_destruction_purges_dead_dispatcher_slots(qtbot, mocked_client, bec_dispatcher):
+    parent = QWidget()
+    layout = QVBoxLayout(parent)
+    child = LifecycleWidget(parent=parent, client=mocked_client)
+    layout.addWidget(child)
+
+    bec_dispatcher.connect_slot(child.on_message, MessageEndpoints.scan_status())
+    assert any(
+        getattr(slot.cb, "__self__", None) is child
+        for slot in bec_dispatcher._registered_slots.values()
+    )
+    slots_before = len(bec_dispatcher._registered_slots)
+
+    parent.deleteLater()
+    _flush_deferred_deletes(qtbot)
+
+    # the destroyed hook purged the redis subscription of the dead receiver ...
+    assert len(bec_dispatcher._registered_slots) == slots_before - 1
+    # ... and every remaining slot has a live (or non-Qt) owner
+    for slot in bec_dispatcher._registered_slots.values():
+        owner = getattr(slot.cb, "__self__", None)
+        assert not isinstance(owner, QObject) or shiboken6.isValid(owner)


### PR DESCRIPTION
## Description

Dispatcher and BECWidget lifecycle rework: the dispatcher never keeps widgets alive, and widget cleanup runs on
every destruction path (close, deleteLater, parent destruction) — widgets no longer need bespoke dispatcher
disconnects at teardown.

## Type of Change

- Bound-method callbacks held weakly; ownerless callables (lambdas/partials) need `owner=` and warn otherwise
- `BECDispatcher.disconnect_owner(widget)` releases all subscriptions of a widget; called from `BECWidget.cleanup()`
- Dead-slot sweep (`cleanup_dead_slots`) reaps subscriptions of gc'd / C++-destroyed owners; runs on every
  `connect_slot` and from a `QObject.destroyed` hook (hook also purges the RPC registry by gui_id and never raises)
- Cleanup on all destruction paths via `closeEvent` + `DeferredDelete` + `destroyed` hooks
- Deprecated bec_lib connector internals (`_topics_cb`) replaced; `disconnect_slot` honors `cb_info`
- Teardown disconnects dropped from `image.py`, `scatter_waveform.py`, `ring.py` (now redundant)

## How to test

- `tests/unit_tests/test_bec_widget_lifecycle.py` and `tests/unit_tests/test_bec_dispatcher.py`
- Proof the bugs exist on main: copy `test_bec_widget_lifecycle.py` onto main → 7/9 fail (leaked subscriptions,
  ghost registry entries, no cleanup on deleteLater/parent destruction)
- GUI: open/close plots repeatedly in a dock area; `len(BECDispatcher()._registered_slots)` returns to baseline

## Potential side effects

- The dispatcher no longer pins subscriber objects: a subscriber kept alive only by its subscription is now
  collected and silently unsubscribed (no such call site in the repo; new code must hold its owners)
- Parent-destruction guarantees infrastructure release (dispatcher + RPC registry) only; bespoke `cleanup()`
  overrides still need close()/deleteLater or a BECWidget-parent sweep
- Until the https://github.com/bec-project/bec_widgets/pull/1249 , app shutdown logs WARNING `Registry purge for destroyed widget … failed` —
  harmless (a stale launcher registry callback, fixed there)

## Additional Comments

- merge before https://github.com/bec-project/bec_widgets/pull/1249 and  https://github.com/bec-project/bec_widgets/pull/1250