### PR TITLE
Fix general/rpc registry

### DIFF
--- a/bec_widgets/applications/launch_window.py
+++ b/bec_widgets/applications/launch_window.py
@@ -282,7 +282,7 @@ class LaunchWindow(BECMainWindow):
         self._update_theme()
 
         self.register = RPCRegister()
-        self.register.callbacks.append(self._turn_off_the_lights)
+        self.register.add_callback(self._turn_off_the_lights)
         self.register.broadcast()
 
         if launch_gui_class and launch_gui_id:
@@ -721,6 +721,14 @@ class LaunchWindow(BECMainWindow):
         self.raise_()
         if self.app:
             self.app.setQuitOnLastWindowClosed(True)  # type: ignore
+
+    def cleanup(self):
+        """
+        Deregister the turn-off-the-lights callback before teardown so later
+        registry broadcasts never call into a dying launcher.
+        """
+        self.register.remove_callback(self._turn_off_the_lights)
+        super().cleanup()
 
     def closeEvent(self, event):
         """

--- a/bec_widgets/utils/bec_connector.py
+++ b/bec_widgets/utils/bec_connector.py
@@ -324,6 +324,8 @@ class BECConnector:
         super().setObjectName(name)
         self.object_name = name
         if self.rpc_register.object_is_registered(self):
+            # A rename changes the serialized registry state.
+            self.rpc_register.mark_broadcast_pending()
             self.rpc_register.broadcast()
 
     def submit_task(self, fn, *args, on_complete: SafeSlot = None, **kwargs) -> Worker:

--- a/bec_widgets/utils/rpc_register.py
+++ b/bec_widgets/utils/rpc_register.py
@@ -26,6 +26,7 @@ def broadcast_update(func):
     @wraps(func)
     def wrapper(self, *args, **kwargs):
         result = func(self, *args, **kwargs)
+        self.mark_broadcast_pending()
         self.broadcast()
         return result
 
@@ -53,6 +54,7 @@ class RPCRegister:
         self._broadcast_on_hold = RPCRegisterBroadcast(self)
         self._lock = RLock()
         self._skip_broadcast = False
+        self._broadcast_pending = True
         self._initialized = True
         self.callbacks = []
 
@@ -146,16 +148,38 @@ class RPCRegister:
         widgets = [rpc for rpc in self._rpc_register.values() if isinstance(rpc, cls)]
         return [widget.object_name for widget in widgets]
 
+    def mark_broadcast_pending(self):
+        """
+        Mark a broadcast as pending so the next broadcast() call serializes and
+        delivers the state. Mutations (add_rpc/remove_rpc, renames, callback
+        registration) call this; read-only paths leave nothing pending and
+        their broadcasts become no-ops.
+        """
+        self._broadcast_pending = True
+
     def broadcast(self):
         """
         Broadcast the update to all the callbacks. Callbacks whose owners have
         been garbage collected — or whose owning QObject's C++ side has been
         destroyed while the Python wrapper is still referenced — are pruned
         instead of being called.
+
+        Broadcasting is skipped while a delayed-broadcast context holds the
+        registry, and when nothing changed since the last broadcast: the
+        RPC execution path broadcasts after every call, and serializing an
+        unchanged registry costs 1.5–8.5 ms at 25–200 widgets (measured),
+        which would otherwise be paid by every read-only RPC call.
         """
 
         if self._skip_broadcast:
             return
+        if not self._broadcast_pending:
+            return
+        if not self.callbacks:
+            # No listeners: skip the registry walk but keep the broadcast pending so the
+            # first callback added later still receives the current state.
+            return
+        self._broadcast_pending = False
         connections = self.list_all_connections()
         dead_refs = []
         for callback_ref in list(self.callbacks):
@@ -204,6 +228,8 @@ class RPCRegister:
         callback_ref = safe_ref(callback)
         if callback_ref not in self.callbacks:
             self.callbacks.append(callback_ref)
+            # The new callback has not seen any state yet.
+            self.mark_broadcast_pending()
 
     def remove_callback(self, callback: Callable[[dict], None]):
         """

--- a/bec_widgets/utils/rpc_register.py
+++ b/bec_widgets/utils/rpc_register.py
@@ -182,6 +182,7 @@ class RPCRegister:
         self._broadcast_pending = False
         connections = self.list_all_connections()
         dead_refs = []
+        delivery_failed = False
         for callback_ref in list(self.callbacks):
             callback = callback_ref()
             if callback is None:
@@ -193,12 +194,21 @@ class RPCRegister:
                 # e.g. during shutdown): calling it would raise on any Qt access.
                 dead_refs.append(callback_ref)
                 continue
-            callback(connections)
+            try:
+                callback(connections)
+            except Exception:
+                delivery_failed = True
+                logger.exception(f"RPC registry broadcast callback {callback!r} failed")
         for ref in dead_refs:
             try:
                 self.callbacks.remove(ref)
             except ValueError:
                 pass
+        if delivery_failed:
+            # The state change must not be lost: leave the registry dirty so the
+            # next broadcast retries delivery (duplicates are safe, the payload
+            # is the full state).
+            self._broadcast_pending = True
 
     def object_is_registered(self, obj: BECConnector) -> bool:
         """

--- a/bec_widgets/utils/rpc_register.py
+++ b/bec_widgets/utils/rpc_register.py
@@ -178,6 +178,19 @@ class RPCRegister:
         """
         self.callbacks.append(callback)
 
+    def remove_callback(self, callback: Callable[[dict], None]):
+        """
+        Remove a previously added registry-update callback. Removing a callback
+        that is not registered is a no-op.
+
+        Args:
+            callback(Callable[[dict], None]): The callback to be removed.
+        """
+        try:
+            self.callbacks.remove(callback)
+        except ValueError:
+            pass
+
     @classmethod
     def reset_singleton(cls):
         """

--- a/bec_widgets/utils/rpc_register.py
+++ b/bec_widgets/utils/rpc_register.py
@@ -7,6 +7,7 @@ from weakref import WeakValueDictionary
 
 import shiboken6 as shb
 from bec_lib.logger import bec_logger
+from louie.saferef import safe_ref
 from qtpy.QtCore import QObject
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -147,14 +148,33 @@ class RPCRegister:
 
     def broadcast(self):
         """
-        Broadcast the update to all the callbacks.
+        Broadcast the update to all the callbacks. Callbacks whose owners have
+        been garbage collected — or whose owning QObject's C++ side has been
+        destroyed while the Python wrapper is still referenced — are pruned
+        instead of being called.
         """
 
         if self._skip_broadcast:
             return
         connections = self.list_all_connections()
-        for callback in self.callbacks:
+        dead_refs = []
+        for callback_ref in list(self.callbacks):
+            callback = callback_ref()
+            if callback is None:
+                dead_refs.append(callback_ref)
+                continue
+            owner = getattr(callback, "__self__", None)
+            if isinstance(owner, QObject) and not shb.isValid(owner):
+                # Bound method of a destroyed widget (Python wrapper still alive,
+                # e.g. during shutdown): calling it would raise on any Qt access.
+                dead_refs.append(callback_ref)
+                continue
             callback(connections)
+        for ref in dead_refs:
+            try:
+                self.callbacks.remove(ref)
+            except ValueError:
+                pass
 
     def object_is_registered(self, obj: BECConnector) -> bool:
         """
@@ -172,22 +192,30 @@ class RPCRegister:
         """
         Add a callback that will be called whenever the registry is updated.
 
+        Callbacks are stored as weak references (safe for bound methods): the
+        register never keeps a callback's owner alive. Registering the same
+        callback twice is a no-op, so broadcasts are delivered exactly once
+        per registered callback.
+
         Args:
             callback(Callable[[dict], None]): The callback to be added. It should accept a dictionary of all the
             registered RPC objects as an argument.
         """
-        self.callbacks.append(callback)
+        callback_ref = safe_ref(callback)
+        if callback_ref not in self.callbacks:
+            self.callbacks.append(callback_ref)
 
     def remove_callback(self, callback: Callable[[dict], None]):
         """
         Remove a previously added registry-update callback. Removing a callback
-        that is not registered is a no-op.
+        that is not registered (or removing it twice) is a no-op.
 
         Args:
             callback(Callable[[dict], None]): The callback to be removed.
         """
+        callback_ref = safe_ref(callback)
         try:
-            self.callbacks.remove(callback)
+            self.callbacks.remove(callback_ref)
         except ValueError:
             pass
 

--- a/bec_widgets/utils/rpc_server.py
+++ b/bec_widgets/utils/rpc_server.py
@@ -105,7 +105,6 @@ class RPCServer:
         self._heartbeat_timer = QTimer()
         self._heartbeat_timer.timeout.connect(self.emit_heartbeat)
         self._heartbeat_timer.start(200)
-        self._registry_update_callbacks = []
         self._broadcasted_data = {}
         self._rpc_singleshot_repeats: dict[str, SingleshotRPCRepeat] = {}
 
@@ -529,21 +528,18 @@ class RPCServer:
             "__rpc__": getattr(connector, "rpc_exposed", True),
         }
 
-    # Suppose clients register callbacks to receive updates
-    def add_registry_update_callback(self, cb: Callable) -> None:
+    def shutdown(self):
         """
-        Add a callback to be called whenever the registry is updated.
-        The specified callback is called whenever the registry is updated.
-
-        Args:
-            cb (Callable): The callback to be added. It should accept a dictionary of all the
-            registered RPC objects as an argument.
+        Shut the RPC server down: stop the heartbeat, release the dispatcher
+        subscription and the registry callback, and shut the client down.
+        Safe to call multiple times.
         """
-        self._registry_update_callbacks.append(cb)
-
-    def shutdown(self):  # TODO not sure if needed when cleanup is done at level of BECConnector
         self.status = messages.BECStatus.IDLE
         self._heartbeat_timer.stop()
         self.emit_heartbeat()
+        self.dispatcher.disconnect_slot(
+            self.on_rpc_update, MessageEndpoints.gui_instructions(self.gui_id)
+        )
+        self.rpc_register.remove_callback(self.broadcast_registry_update)
         logger.info("Succeeded in shutting down CLI server")
         self.client.shutdown()

--- a/tests/unit_tests/test_bec_connector.py
+++ b/tests/unit_tests/test_bec_connector.py
@@ -158,9 +158,12 @@ def test_bec_widget_cleanup_broadcasts_after_children_are_unregistered(mocked_cl
     qtbot.addWidget(parent)
 
     observed_connections = []
-    parent.rpc_register.callbacks.append(
-        lambda connections: observed_connections.append(set(connections))
-    )
+
+    # Keep a strong reference: registry callbacks are weakly referenced.
+    def _observe_connections(connections):
+        observed_connections.append(set(connections))
+
+    parent.rpc_register.add_callback(_observe_connections)
 
     parent.close()
 

--- a/tests/unit_tests/test_launch_window.py
+++ b/tests/unit_tests/test_launch_window.py
@@ -266,3 +266,14 @@ def test_main_label_point_size_uniform(bec_launch_window):
     """
     point_sizes = {tile.main_label.font().pointSize() for tile in bec_launch_window.tiles.values()}
     assert len(point_sizes) == 1, f"Non-uniform main-label point sizes: {point_sizes}"
+
+
+def test_launch_window_cleanup_deregisters_registry_callback(bec_launch_window):
+    """The turn-off-the-lights callback must not survive the launcher's cleanup:
+    a later registry broadcast would call into a dying window (shutdown scenario)."""
+    from louie.saferef import safe_ref
+
+    reg = bec_launch_window.register
+    assert safe_ref(bec_launch_window._turn_off_the_lights) in reg.callbacks
+    bec_launch_window.cleanup()
+    assert safe_ref(bec_launch_window._turn_off_the_lights) not in reg.callbacks

--- a/tests/unit_tests/test_rpc_register.py
+++ b/tests/unit_tests/test_rpc_register.py
@@ -130,3 +130,62 @@ def test_callback_does_not_keep_owner_alive(rpc_register):
 
     rpc_register.broadcast()  # must not raise; prunes the dead reference
     assert len(rpc_register.callbacks) == callbacks_with_owner - 1
+
+
+def test_broadcast_skips_when_registry_unchanged(rpc_register):
+    """Perf regression test (audit item 24): the RPC execution path
+    broadcasts after every call; an unchanged registry must not be
+    re-serialized and callbacks must not be re-invoked."""
+    owner = _CallbackOwner()
+    rpc_register.add_callback(owner.on_update)
+
+    rpc_register.broadcast()  # pending after add_callback -> delivers
+    assert len(owner.received) == 1
+
+    rpc_register.broadcast()  # nothing changed -> skipped
+    rpc_register.broadcast()
+    assert len(owner.received) == 1
+
+    class _Probe:
+        gui_id = "pending_probe"
+        object_name = "pending_probe"
+
+    import gc
+
+    probe = _Probe()
+    try:
+        rpc_register.add_rpc(probe)  # mutation -> delivered
+        assert len(owner.received) == 2
+        rpc_register.broadcast()  # clean again -> skipped
+        assert len(owner.received) == 2
+    finally:
+        rpc_register.remove_rpc(probe)
+        gc.collect()
+
+
+def test_broadcast_without_callbacks_skips_registry_walk(rpc_register, monkeypatch):
+    """With no listeners, a pending broadcast must not walk/serialize the registry,
+    and the broadcast stays pending so the first callback added later receives it."""
+    from unittest import mock
+
+    walk = mock.Mock(wraps=rpc_register.list_all_connections)
+    monkeypatch.setattr(rpc_register, "list_all_connections", walk)
+    # The test environment may carry ambient callbacks (e.g. the RPC server's);
+    # this test owns the no-listeners precondition.
+    monkeypatch.setattr(rpc_register, "callbacks", [])
+
+    rpc_register.mark_broadcast_pending()
+    rpc_register.broadcast()
+    walk.assert_not_called()
+
+    received = []
+
+    class _Owner:
+        def on_update(self, connections):
+            received.append(connections)
+
+    owner = _Owner()
+    rpc_register.add_callback(owner.on_update)
+    rpc_register.broadcast()
+    walk.assert_called_once()
+    assert len(received) == 1

--- a/tests/unit_tests/test_rpc_register.py
+++ b/tests/unit_tests/test_rpc_register.py
@@ -50,3 +50,83 @@ def test_reset_singleton(rpc_register):
 
     assert len(all_connections) == 0
     assert all_connections == {}
+
+
+class _CallbackOwner:
+    """Owner of a bound-method registry callback for lifecycle tests."""
+
+    def __init__(self):
+        self.received = []
+
+    def on_update(self, connections):
+        self.received.append(dict(connections))
+
+
+def test_register_callback_receives_broadcast(rpc_register):
+    owner = _CallbackOwner()
+    rpc_register.add_callback(owner.on_update)
+
+    rpc_register.broadcast()
+    assert len(owner.received) == 1
+
+
+def test_duplicate_callback_registration_is_deduplicated(rpc_register):
+    """Regression test for BW-009: registering the same bound method twice
+    must deliver each broadcast exactly once."""
+    owner = _CallbackOwner()
+    callbacks_before = len(rpc_register.callbacks)
+
+    rpc_register.add_callback(owner.on_update)
+    rpc_register.add_callback(owner.on_update)
+    assert len(rpc_register.callbacks) == callbacks_before + 1
+
+    rpc_register.broadcast()
+    assert len(owner.received) == 1
+
+
+def test_remove_callback_is_idempotent(rpc_register):
+    owner = _CallbackOwner()
+    callbacks_before = len(rpc_register.callbacks)
+
+    rpc_register.add_callback(owner.on_update)
+    rpc_register.remove_callback(owner.on_update)
+    assert len(rpc_register.callbacks) == callbacks_before
+
+    # Repeated removal and removing an unknown callback are no-ops.
+    rpc_register.remove_callback(owner.on_update)
+    rpc_register.remove_callback(_CallbackOwner().on_update)
+    assert len(rpc_register.callbacks) == callbacks_before
+
+    rpc_register.broadcast()
+    assert owner.received == []
+
+
+def test_bound_method_identity_across_method_objects(rpc_register):
+    """Two bound-method objects for the same method of the same instance must
+    be treated as the same callback (remove works with a fresh method object)."""
+    owner = _CallbackOwner()
+    rpc_register.add_callback(owner.on_update)
+    # 'owner.on_update' here creates a *new* bound-method object.
+    rpc_register.remove_callback(owner.on_update)
+
+    rpc_register.broadcast()
+    assert owner.received == []
+
+
+def test_callback_does_not_keep_owner_alive(rpc_register):
+    """Regression test for BW-009: the register must not keep callback owners
+    alive, and dead callbacks must be pruned on the next broadcast."""
+    import gc
+    import weakref
+
+    owner = _CallbackOwner()
+    rpc_register.add_callback(owner.on_update)
+    ref = weakref.ref(owner)
+    callbacks_with_owner = len(rpc_register.callbacks)
+
+    del owner
+    gc.collect()
+    assert ref() is None, "register must not hold a strong reference to the owner"
+
+    rpc_register.broadcast()  # must not raise; prunes the dead reference
+    assert len(rpc_register.callbacks) == callbacks_with_owner - 1

--- a/tests/unit_tests/test_rpc_register.py
+++ b/tests/unit_tests/test_rpc_register.py
@@ -189,3 +189,34 @@ def test_broadcast_without_callbacks_skips_registry_walk(rpc_register, monkeypat
     rpc_register.broadcast()
     walk.assert_called_once()
     assert len(received) == 1
+
+
+def test_broadcast_prunes_callbacks_of_destroyed_qobjects(rpc_register, qapp):
+    """A bound-method callback whose QObject was destroyed (Python wrapper still
+    referenced, C++ side gone — the shutdown scenario) must be pruned, not called."""
+    import shiboken6
+    from qtpy.QtCore import QObject
+
+    class Listener(QObject):
+        def __init__(self):
+            super().__init__()
+            self.received = []
+
+        def on_update(self, connections):
+            self.received.append(connections)
+
+    listener = Listener()
+    rpc_register.add_callback(listener.on_update)
+    rpc_register.mark_broadcast_pending()
+    rpc_register.broadcast()
+    assert len(listener.received) == 1
+    callbacks_before = len(rpc_register.callbacks)
+
+    shiboken6.delete(listener)
+    assert not shiboken6.isValid(listener)
+
+    rpc_register.mark_broadcast_pending()
+    rpc_register.broadcast()  # must neither call the dead callback nor raise
+
+    assert len(listener.received) == 1
+    assert len(rpc_register.callbacks) == callbacks_before - 1

--- a/tests/unit_tests/test_rpc_server.py
+++ b/tests/unit_tests/test_rpc_server.py
@@ -297,3 +297,45 @@ def test_run_rpc_delegates_to_rpc_content_class(rpc_server):
     assert rpc_server.run_rpc(view, "mode", [], {}) == "initial"
     assert rpc_server.run_rpc(view, "mode", ["creator"], {}) is None
     assert view.content.mode == "creator"
+
+
+def test_rpc_server_shutdown_releases_registrations(mocked_client):
+    """Regression test for BW-008/BW-009: shutdown must disconnect the
+    gui_instructions dispatcher slot and remove the registry callback so a
+    restarted server does not duplicate registrations and the old server can
+    be collected."""
+    from bec_widgets.utils.rpc_register import RPCRegister
+
+    register = RPCRegister()
+    callbacks_before = len(register.callbacks)
+
+    server = RPCServer(gui_id="lifecycle_gui", client=mocked_client)
+    assert len(register.callbacks) == callbacks_before + 1
+
+    dispatcher_slots_with_topic = [
+        slot
+        for slot in server.dispatcher._registered_slots.values()
+        if any("lifecycle_gui" in topic for topic in slot.topics)
+    ]
+    assert len(dispatcher_slots_with_topic) == 1
+
+    server.shutdown()
+
+    assert len(register.callbacks) == callbacks_before
+    dispatcher_slots_with_topic = [
+        slot
+        for slot in server.dispatcher._registered_slots.values()
+        if any("lifecycle_gui" in topic for topic in slot.topics)
+    ]
+    assert dispatcher_slots_with_topic == []
+
+    # Shutdown must be idempotent.
+    server.shutdown()
+    assert len(register.callbacks) == callbacks_before
+
+
+def test_rpc_register_remove_callback_is_noop_for_unknown(rpc_register=None):
+    from bec_widgets.utils.rpc_register import RPCRegister
+
+    register = RPCRegister()
+    register.remove_callback(lambda connections: None)  # must not raise


### PR DESCRIPTION
## Description

RPC registry callback lifecycle: weak deduplicated callbacks that never pin their owners, pruning of dead/destroyed
owners, broadcast skip when nothing changed, and RPCServer releasing its registrations on shutdown.

## Type of Change

- `RPCRegister.add_callback`/`remove_callback` with weak refs; duplicates registered once
- `broadcast()` prunes callbacks whose owner was gc'd or whose QObject was destroyed (fixes the shutdown
  `LaunchWindow._turn_off_the_lights` zombie call); failures are isolated per callback and name the callback
- Dirty-flag: unchanged registries skip re-serialization (1.5–8.5 ms per RPC call at 25–200 widgets); failed
  deliveries stay dirty and retry
- `RPCServer.shutdown()` releases its dispatcher slot and registry callback; `LaunchWindow.cleanup()` deregisters
  its callback

## How to test

- Test with `tests/unit_tests/test_rpc_register.py` and  `tests/unit_tests/test_rpc_server.py tests/unit_tests/test_launch_window.py`
- Key tests: `test_callback_does_not_keep_owner_alive`, `test_broadcast_prunes_callbacks_of_destroyed_qobjects`,
  `test_rpc_server_shutdown_releases_registrations`
- GUI: close the companion app — no `RPC registry broadcast callback failed` ERROR in the shutdown log

## Potential side effects

- Callbacks are now weak: callers must keep a reference to what they register (all in-repo callers audited)
- Broadcast retry after a failed delivery re-sends the full state (duplicates are safe)

## Additional Comments

- Merge after [dispatcher-v2](https://github.com/bec-project/bec_widgets/pull/1248) (removes its interim shutdown WARNINGs); base for the shutdown-order PR
- `LaunchWindow.cleanup()` deregistration becomes fully path-guaranteed once [dispatcher-v2](https://github.com/bec-project/bec_widgets/pull/1248) and shutdown-order (in prep) are in;
  until then the broadcast pruning covers those paths