### PR TITLE
fix(scan_control): restore last scan parameters without blocking the GUI

### DIFF
--- a/bec_widgets/utils/bec_connector.py
+++ b/bec_widgets/utils/bec_connector.py
@@ -390,8 +390,18 @@ class BECConnector:
         # Keep a reference to the worker so it is not garbage collected.
         self._workers.append(worker)
 
-        # When the worker is done (success or failure), remove it from our list.
+        # When the worker is done (success or failure), remove it from our
+        # list. The closure must disconnect itself from both signals before
+        # returning: the Qt connection holds the closure strongly from C++,
+        # and the closure captures self and worker — without the disconnect
+        # this forms a reference cycle anchored in C++ that Python's GC
+        # cannot break, keeping the owning widget alive forever.
         def _discard_worker(*_):
+            for signal in (worker.signals.completed, worker.signals.failed):
+                try:
+                    signal.disconnect(_discard_worker)
+                except (RuntimeError, TypeError):
+                    pass
             try:
                 self._workers.remove(worker)
             except ValueError:

--- a/bec_widgets/utils/bec_connector.py
+++ b/bec_widgets/utils/bec_connector.py
@@ -51,11 +51,16 @@ class ConnectionConfig(BaseModel):
 class WorkerSignals(QObject):
     progress = Signal(dict)
     completed = Signal()
+    failed = Signal(str)
 
 
 class Worker(QRunnable):
     """
     Worker class to run a function in a separate thread.
+
+    On success, ``signals.completed`` is emitted. If the function raises,
+    the exception is logged and ``signals.failed`` is emitted with the
+    formatted traceback instead; it never propagates into the thread pool.
     """
 
     def __init__(self, func, *args, **kwargs):
@@ -69,8 +74,16 @@ class Worker(QRunnable):
         """
         Run the specified function in the thread.
         """
-        self.func(*self.args, **self.kwargs)
-        self.signals.completed.emit()
+        try:
+            self.func(*self.args, **self.kwargs)
+        except Exception:
+            error_msg = traceback.format_exc()
+            logger.error(
+                f"Worker task {getattr(self.func, '__qualname__', self.func)} failed:\n{error_msg}"
+            )
+            self.signals.failed.emit(error_msg)
+        else:
+            self.signals.completed.emit()
 
 
 class BECConnector:
@@ -224,8 +237,9 @@ class BECConnector:
                 return None
             connector_parent = self._get_rpc_parent_ancestor()
             return connector_parent.gui_id if connector_parent else None
-        except:
-            logger.error(f"Error getting parent_id for {self.__class__.__name__}")
+        except Exception as e:
+            logger.error(f"Error getting parent_id for {self.__class__.__name__}: {e}")
+            return None
 
     def _get_rpc_parent_ancestor(self) -> BECConnector | None:
         """
@@ -375,8 +389,16 @@ class BECConnector:
             worker.signals.completed.connect(on_complete)
         # Keep a reference to the worker so it is not garbage collected.
         self._workers.append(worker)
-        # When the worker is done, remove it from our list.
-        worker.signals.completed.connect(lambda: self._workers.remove(worker))
+
+        # When the worker is done (success or failure), remove it from our list.
+        def _discard_worker(*_):
+            try:
+                self._workers.remove(worker)
+            except ValueError:
+                pass
+
+        worker.signals.completed.connect(_discard_worker)
+        worker.signals.failed.connect(_discard_worker)
         self._thread_pool.start(worker)
         return worker
 

--- a/bec_widgets/utils/bec_connector.py
+++ b/bec_widgets/utils/bec_connector.py
@@ -356,7 +356,9 @@ class BECConnector:
             self.rpc_register.mark_broadcast_pending()
             self.rpc_register.broadcast()
 
-    def submit_task(self, fn, *args, on_complete: SafeSlot = None, **kwargs) -> Worker:
+    def submit_task(
+        self, fn, *args, on_complete: SafeSlot = None, on_failed: SafeSlot = None, **kwargs
+    ) -> Worker:
         """
         Submit a task to run in a separate thread. The task will run the specified
         function with the provided arguments and emit the completed signal when done.
@@ -367,7 +369,11 @@ class BECConnector:
         Args:
             fn: Function to run in a separate thread.
             *args: Arguments for the function.
-            on_complete: Slot to run when the task is complete.
+            on_complete: Slot to run when the task completes successfully.
+            on_failed: Slot to run when the task raises; receives the formatted traceback
+                string. Pass it here rather than connecting to ``worker.signals.failed``
+                after this method returns: the worker starts before this method returns,
+                so a late connection can miss the emission of a fast-failing task.
             **kwargs: Keyword arguments for the function.
 
         Returns:
@@ -387,6 +393,8 @@ class BECConnector:
         worker = Worker(fn, *args, **kwargs)
         if on_complete:
             worker.signals.completed.connect(on_complete)
+        if on_failed:
+            worker.signals.failed.connect(on_failed)
         # Keep a reference to the worker so it is not garbage collected.
         self._workers.append(worker)
 

--- a/bec_widgets/widgets/control/scan_control/scan_control.py
+++ b/bec_widgets/widgets/control/scan_control/scan_control.py
@@ -1,12 +1,14 @@
 from collections import defaultdict
-from types import NoneType, SimpleNamespace
+from functools import partial
+from types import NoneType
 from typing import Optional
 
 from bec_lib.endpoints import MessageEndpoints
+from bec_lib.logger import bec_logger
+from bec_lib.scan_history import ScanHistory
 from bec_qthemes import material_icon
 from pydantic import BaseModel, Field
-from qtpy.QtCore import QSignalBlocker, Qt, Signal
-from qtpy.QtGui import QColor
+from qtpy.QtCore import QSignalBlocker, Qt, QTimer, Signal
 from qtpy.QtWidgets import (
     QApplication,
     QComboBox,
@@ -23,7 +25,7 @@ from qtpy.QtWidgets import (
 
 from bec_widgets.utils.bec_connector import ConnectionConfig
 from bec_widgets.utils.bec_widget import BECWidget
-from bec_widgets.utils.colors import apply_theme, get_accent_colors
+from bec_widgets.utils.colors import apply_theme
 from bec_widgets.utils.error_popups import SafeProperty, SafeSlot
 from bec_widgets.widgets.control.buttons.stop_button.stop_button import StopButton
 from bec_widgets.widgets.control.scan_control.scan_docstring import render_scan_tooltip_html
@@ -32,6 +34,8 @@ from bec_widgets.widgets.control.scan_control.scan_info_adapter import ScanInfoA
 from bec_widgets.widgets.control.scan_control.scan_info_dialog import ScanInfoDialog
 from bec_widgets.widgets.control.scan_control.scan_selection_dialog import ScanSelectionDialog
 from bec_widgets.widgets.editors.scan_metadata.scan_metadata import ScanMetadata
+
+logger = bec_logger.logger
 
 
 class ScanParameterConfig(BaseModel):
@@ -56,11 +60,15 @@ class ScanControl(BECWidget, QWidget):
     ICON_NAME = "tune"
     ARG_BOX_POSITION: int = 2
     SUPPORTED_SCAN_BASE_CLASSES = {"ScanBase", "SyncFlyScanBase", "AsyncFlyScanBase", "ScanBaseV4"}
+    RECENT_SCAN_HISTORY_COUNT = 50
+    MAX_HISTORY_LOOKBACK = 500
+    LAST_SCAN_FETCH_TIMEOUT_MS = 30_000
 
     scan_started = Signal()
     scan_selected = Signal(str)
     device_selected = Signal(str)
     scan_args = Signal(list)
+    _last_scan_parameters_received = Signal(int, str, object)
 
     def __init__(
         self,
@@ -108,6 +116,14 @@ class ScanControl(BECWidget, QWidget):
         self._hide_scan_selector_settings_button = False
         self._scan_info_adapter = ScanInfoAdapter()
         self._scan_info_dialog: ScanInfoDialog | None = None
+        self._last_scan_parameters_received.connect(self._apply_last_scan_parameters)
+        self._last_scan_lookup_memo: dict[str, tuple[str | None, tuple[list, dict] | None]] = {}
+        # Generation counter to discard results of superseded or timed-out fetches
+        self._last_scan_fetch_generation = 0
+        self._last_scan_fetch_watchdog = QTimer(self)
+        self._last_scan_fetch_watchdog.setSingleShot(True)
+        self._last_scan_fetch_watchdog.setInterval(self.LAST_SCAN_FETCH_TIMEOUT_MS)
+        self._last_scan_fetch_watchdog.timeout.connect(self._on_last_scan_parameters_timeout)
 
         # Create and set main layout
         self._init_UI()
@@ -116,14 +132,6 @@ class ScanControl(BECWidget, QWidget):
         """
         Initializes the UI of the scan control widget. Create the top box for scan selection and populate scans to main combobox.
         """
-        palette = get_accent_colors()
-        if palette is None:
-            palette = SimpleNamespace(
-                default=QColor("blue"),
-                success=QColor("green"),
-                warning=QColor("orange"),
-                emergency=QColor("red"),
-            )
         # Scan selection box
         self.scan_selection_group = QWidget(self)
         QVBoxLayout(self.scan_selection_group)
@@ -346,34 +354,162 @@ class ScanControl(BECWidget, QWidget):
         """
         Requests the last executed scan parameters from BEC and restores them to the scan control widget.
         """
+        if not self.last_scan_button.isEnabled():
+            return
         current_scan = self.comboBox_scan_selection.currentText()
-        history = (
-            self.client.connector.xread(
-                MessageEndpoints.scan_history(), from_start=True, user_id=self.object_name
+        self.last_scan_button.setEnabled(False)
+        self._last_scan_fetch_generation += 1
+        generation = self._last_scan_fetch_generation
+        self._last_scan_fetch_watchdog.start()
+        try:
+            # ``completed`` is success-only; ``failed`` carries a traceback string, which
+            # _on_last_scan_parameters_finished does not take, so bind the generation instead.
+            self.submit_task(
+                self._fetch_last_executed_scan_parameters,
+                generation,
+                current_scan,
+                on_complete=partial(self._on_last_scan_parameters_finished, generation),
+                on_failed=lambda _msg, gen=generation: self._on_last_scan_parameters_finished(gen),
             )
-            or []
-        )
+        except Exception:
+            self._on_last_scan_parameters_finished(generation)
+            raise
 
+    def _fetch_last_executed_scan_parameters(self, generation: int, scan_name: str):
+        """Fetch the latest parameters for ``scan_name`` without touching the Qt UI."""
+        try:
+            parameters = self._lookup_last_scan_parameters(scan_name)
+            if parameters is not None:
+                self._last_scan_parameters_received.emit(generation, scan_name, parameters)
+        except Exception:
+            logger.exception(f"Failed to fetch parameters for scan {scan_name}")
+
+    def _lookup_last_scan_parameters(self, scan_name: str) -> tuple[list, dict] | None:
+        """
+        Find the newest parameters for ``scan_name`` in the client-side scan-history cache or
+        in a strictly bounded window of the scan-history stream.
+
+        There is deliberately no full-stream path: decoding an entry allocates hundreds of
+        GC-tracked objects, and the resulting stop-the-world collections stall the Qt event
+        loop from any thread.
+        """
+        parameters = self._find_parameters_in_history_cache(scan_name)
+        if parameters is not None:
+            return parameters
+
+        endpoint = MessageEndpoints.scan_history()
+        # The stream is append-only, so an unchanged newest entry means an unchanged
+        # window: repeat lookups (e.g. clicking again for a scan that was never
+        # measured) are answered from the memo for the cost of a single decode.
+        tip = self._read_history_window(endpoint, 1)
+        tip_id = getattr(tip[0].get("data"), "scan_id", None) if tip else None
+        memo = self._last_scan_lookup_memo.get(scan_name)
+        if memo is not None and memo[0] == tip_id:
+            logger.debug(f"Scan history unchanged; reusing memoized lookup for {scan_name}")
+            return memo[1]
+
+        parameters = self._search_history_windows(endpoint, scan_name)
+        self._last_scan_lookup_memo[scan_name] = (tip_id, parameters)
+        return parameters
+
+    def _search_history_windows(self, endpoint, scan_name: str) -> tuple[list, dict] | None:
+        """Search the recent, then the deep, stream window for ``scan_name``."""
+        history = self._read_history_window(endpoint, self.RECENT_SCAN_HISTORY_COUNT)
+        parameters = self._find_last_scan_parameters(scan_name, history)
+        if parameters is not None or len(history) < self.RECENT_SCAN_HISTORY_COUNT:
+            # fewer entries than requested means the whole stream was already searched
+            return parameters
+        if self.MAX_HISTORY_LOOKBACK <= self.RECENT_SCAN_HISTORY_COUNT:
+            return None
+
+        history = self._read_history_window(endpoint, self.MAX_HISTORY_LOOKBACK)
+        parameters = self._find_last_scan_parameters(scan_name, history)
+        if parameters is None and len(history) >= self.MAX_HISTORY_LOOKBACK:
+            logger.warning(
+                f"No execution of {scan_name} found within the last "
+                f"{self.MAX_HISTORY_LOOKBACK} scans; older history is not searched."
+            )
+        return parameters
+
+    def _read_history_window(self, endpoint, count: int) -> list[dict]:
+        """Read at most ``count`` newest scan-history entries, oldest-first."""
+        history = self.client.connector.get_last(endpoint, count=count)
+        if isinstance(history, dict):
+            # get_last returns a single message dict instead of a list for count == 1
+            history = [history]
+        return history or []
+
+    def _find_parameters_in_history_cache(self, scan_name: str) -> tuple[list, dict] | None:
+        """Search the in-memory scan history (newest first) for ``scan_name``."""
+        history = getattr(self.client, "history", None)
+        if not isinstance(history, ScanHistory):
+            # not available before the client services are started (e.g. in Qt Designer)
+            return None
+        # iterate by index from the end instead of slicing to avoid copying the whole cache
+        for index in range(len(history) - 1, -1, -1):
+            msg = getattr(history[index], "_msg", None)
+            if msg is not None and msg.scan_name == scan_name:
+                return self._parameters_from_request_inputs(msg.request_inputs)
+        return None
+
+    @staticmethod
+    def _parameters_from_request_inputs(request_inputs: dict | None) -> tuple[list, dict]:
+        """Split ``request_inputs`` into the argument bundle and merged keyword arguments."""
+        ri = request_inputs or {}
+        return ri.get("arg_bundle", []), {**ri.get("inputs", {}), **ri.get("kwargs", {})}
+
+    @staticmethod
+    def _find_last_scan_parameters(scan_name: str, history: list[dict]) -> tuple[list, dict] | None:
+        """Return the newest matching argument and keyword bundles from ``history``."""
         for scan in reversed(history):
             scan_data = scan.get("data")
             if not scan_data:
                 continue
 
-            if scan_data.scan_name != current_scan:
+            if scan_data.scan_name != scan_name:
                 continue
 
-            ri = getattr(scan_data, "request_inputs", {}) or {}
-            args_list = ri.get("arg_bundle", [])
-            if args_list and self.arg_box:
-                self.arg_box.set_parameters(args_list)
+            return ScanControl._parameters_from_request_inputs(
+                getattr(scan_data, "request_inputs", None)
+            )
+        return None
 
-            inputs = ri.get("inputs", {})
-            kwargs = ri.get("kwargs", {})
-            merged = {**inputs, **kwargs}
-            if merged and self.kwarg_boxes:
-                for box in self.kwarg_boxes:
-                    box.set_parameters(merged)
-            break
+    @SafeSlot(int, str, object)
+    def _apply_last_scan_parameters(
+        self, generation: int, scan_name: str, parameters: tuple[list, dict]
+    ):
+        """Apply asynchronously fetched parameters on the GUI thread."""
+        if generation != self._last_scan_fetch_generation:
+            # result of a timed-out or superseded fetch
+            return
+        if self.comboBox_scan_selection.currentText() != scan_name:
+            logger.debug(f"Discarding fetched parameters for {scan_name}: scan selection changed")
+            return
+
+        args_list, kwargs = parameters
+        if args_list and self.arg_box:
+            self.arg_box.set_parameters(args_list)
+
+        if kwargs and self.kwarg_boxes:
+            for box in self.kwarg_boxes:
+                box.set_parameters(kwargs)
+
+    @SafeSlot()
+    def _on_last_scan_parameters_finished(self, generation: int | None = None):
+        """Re-enable parameter restoration after the background request finishes."""
+        if generation is not None and generation != self._last_scan_fetch_generation:
+            # a stale fetch finished after a timeout or a newer request; leave the UI state alone
+            return
+        self._last_scan_fetch_watchdog.stop()
+        self.last_scan_button.setEnabled(True)
+
+    @SafeSlot()
+    def _on_last_scan_parameters_timeout(self):
+        """Recover the UI if the background fetch hangs (e.g. unreachable Redis)."""
+        logger.warning("Timed out while fetching the last executed scan parameters")
+        # invalidate the in-flight fetch so a late result is not applied
+        self._last_scan_fetch_generation += 1
+        self.last_scan_button.setEnabled(True)
 
     @SafeProperty(str)
     def current_scan(self):

--- a/bec_widgets/widgets/services/bec_queue/bec_queue.py
+++ b/bec_widgets/widgets/services/bec_queue/bec_queue.py
@@ -4,6 +4,7 @@ import json
 
 from bec_lib import messages
 from bec_lib.endpoints import MessageEndpoints
+from bec_lib.logger import bec_logger
 from bec_qthemes import material_icon
 from qtpy.QtCore import Property, Qt, Signal, Slot
 from qtpy.QtGui import QColor
@@ -19,6 +20,8 @@ from bec_widgets.widgets.control.buttons.button_abort.button_abort import AbortB
 from bec_widgets.widgets.control.buttons.button_reset.button_reset import ResetButton
 from bec_widgets.widgets.control.buttons.button_resume.button_resume import ResumeButton
 from bec_widgets.widgets.control.buttons.stop_button.stop_button import StopButton
+
+logger = bec_logger.logger
 
 
 class BECQueue(BECWidget, CompactPopupWidget):
@@ -243,8 +246,8 @@ class BECQueue(BECWidget, CompactPopupWidget):
             try:
                 color = self.status_colors.get(content, "black")  # Default to black if not found
                 item.setForeground(QColor(color))
-            except:
-                return item
+            except Exception as e:
+                logger.warning(f"Could not apply status color for queue item '{content}': {e}")
         return item
 
     def set_row(

--- a/tests/unit_tests/test_bec_connector.py
+++ b/tests/unit_tests/test_bec_connector.py
@@ -293,3 +293,21 @@ def test_bec_connector_worker_completion_does_not_retain_owner(qtbot, mocked_cli
         gc.collect()
 
     assert ref() is None, "connector kept alive by worker completion closure"
+
+
+def test_bec_connector_on_failed_never_misses_fast_failures(bec_connector, qtbot):
+    """``on_failed`` passed to submit_task is connected before the worker starts, so
+    even a task that raises immediately cannot emit ``failed`` before the connection
+    exists. Connecting to ``worker.signals.failed`` after submit_task returns cannot
+    give this guarantee."""
+    failures = []
+
+    def boom():
+        raise RuntimeError("instant failure")
+
+    for _ in range(20):
+        bec_connector.submit_task(boom, on_failed=lambda msg: failures.append(msg))
+
+    qtbot.waitUntil(lambda: len(failures) == 20, timeout=5000)
+    qtbot.waitUntil(lambda: not bec_connector._workers, timeout=5000)
+    assert all("instant failure" in msg for msg in failures)

--- a/tests/unit_tests/test_bec_connector.py
+++ b/tests/unit_tests/test_bec_connector.py
@@ -243,3 +243,30 @@ def test_bec_connector_terminate_registered_once_qapp_exists(qtbot):
         handler = BECConnector.EXIT_HANDLERS.pop(fresh_client, None)
         if handler is not None:
             QApplication.instance().aboutToQuit.disconnect(handler)
+
+
+def test_bec_connector_submit_task_failure_removes_worker(bec_connector, qtbot):
+    """Regression test for BW-006: a task that raises must not leak the worker
+    reference, must emit failed, and must not call on_complete."""
+    failures = []
+    completed = []
+
+    def boom():
+        raise RuntimeError("task failed on purpose")
+
+    worker = bec_connector.submit_task(boom, on_complete=lambda: completed.append(True))
+    worker.signals.failed.connect(lambda msg: failures.append(msg))
+
+    qtbot.waitUntil(lambda: worker not in bec_connector._workers, timeout=5000)
+    qtbot.waitUntil(lambda: len(failures) == 1, timeout=5000)
+    assert completed == []
+    assert "task failed on purpose" in failures[0]
+
+
+def test_bec_connector_parent_id_returns_none_on_error(bec_connector):
+    """Regression test for BW-007: parent_id must swallow only Exception and
+    return None explicitly."""
+    with mock.patch.object(
+        bec_connector, "_get_rpc_parent_ancestor", side_effect=ValueError("broken hierarchy")
+    ):
+        assert bec_connector.parent_id is None

--- a/tests/unit_tests/test_bec_connector.py
+++ b/tests/unit_tests/test_bec_connector.py
@@ -270,3 +270,26 @@ def test_bec_connector_parent_id_returns_none_on_error(bec_connector):
         bec_connector, "_get_rpc_parent_ancestor", side_effect=ValueError("broken hierarchy")
     ):
         assert bec_connector.parent_id is None
+
+
+def test_bec_connector_worker_completion_does_not_retain_owner(qtbot, mocked_client):
+    """Regression test for BW-015: the worker-discard closure is held strongly
+    by the Qt signal connection and captures the owner; without disconnecting
+    itself it forms a C++-anchored reference cycle that keeps the owner (and
+    widget) alive forever."""
+    import gc
+    import weakref
+
+    connector = _CleanupBroadcastWidget(client=mocked_client)
+    connector.submit_task(lambda: None)
+    qtbot.waitUntil(lambda: not connector._workers, timeout=5000)
+
+    ref = weakref.ref(connector)
+    connector.close()
+    connector.deleteLater()
+    qtbot.wait(20)
+    del connector
+    for _ in range(3):
+        gc.collect()
+
+    assert ref() is None, "connector kept alive by worker completion closure"

--- a/tests/unit_tests/test_scan_control.py
+++ b/tests/unit_tests/test_scan_control.py
@@ -1,10 +1,12 @@
 # pylint: disable = no-name-in-module,missing-class-docstring, missing-module-docstring
+from threading import Event, get_ident
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 from bec_lib.endpoints import MessageEndpoints
 from bec_lib.messages import AvailableResourceMessage, ScanHistoryMessage
+from bec_lib.scan_history import ScanHistory
 from qtpy.QtCore import QModelIndex, QPoint, Qt
 from qtpy.QtWidgets import QCheckBox, QDialog, QStyle
 
@@ -12,6 +14,7 @@ from bec_widgets.utils.forms_from_types.items import StrFormItem
 from bec_widgets.utils.widget_io import WidgetIO
 from bec_widgets.widgets.control.device_input.device_combobox.device_combobox import DeviceComboBox
 from bec_widgets.widgets.control.scan_control import ScanControl
+from bec_widgets.widgets.control.scan_control import scan_control as scan_control_module
 from bec_widgets.widgets.control.scan_control.scan_control import ScanControlConfig
 from bec_widgets.widgets.control.scan_control.scan_info_adapter import ScanInfoAdapter
 from bec_widgets.widgets.control.scan_control.scan_selection_dialog import ScanSelectionDialog
@@ -1178,32 +1181,43 @@ def test_changing_scans_remember_parameters(scan_control, mocked_client):
 def test_scan_selection_does_not_fetch_last_scan_parameters(
     scan_control, mocked_client, monkeypatch
 ):
-    xread = MagicMock(wraps=mocked_client.connector.xread)
-    monkeypatch.setattr(mocked_client.connector, "xread", xread)
+    get_last = MagicMock(wraps=mocked_client.connector.get_last)
+    xrange = MagicMock(wraps=mocked_client.connector.xrange)
+    monkeypatch.setattr(mocked_client.connector, "get_last", get_last)
+    monkeypatch.setattr(mocked_client.connector, "xrange", xrange)
 
     scan_control.comboBox_scan_selection.setCurrentText("line_scan")
     assert scan_control.comboBox_scan_selection.currentText() == "line_scan"
 
     scan_control.comboBox_scan_selection.setCurrentText("grid_scan")
 
-    xread.assert_not_called()
+    get_last.assert_not_called()
+    xrange.assert_not_called()
 
 
 def test_restore_last_scan_parameters_button_fetches_on_demand(
-    scan_control, mocked_client, monkeypatch
+    scan_control, mocked_client, monkeypatch, qtbot
 ):
-    xread = MagicMock(wraps=mocked_client.connector.xread)
-    monkeypatch.setattr(mocked_client.connector, "xread", xread)
+    get_last = MagicMock(wraps=mocked_client.connector.get_last)
+    xrange = MagicMock(wraps=mocked_client.connector.xrange)
+    monkeypatch.setattr(mocked_client.connector, "get_last", get_last)
+    monkeypatch.setattr(mocked_client.connector, "xrange", xrange)
 
     scan_control.comboBox_scan_selection.setCurrentText("grid_scan")
     scan_control.comboBox_scan_selection.setCurrentText("line_scan")
-    xread.assert_not_called()
+    get_last.assert_not_called()
+    xrange.assert_not_called()
 
     scan_control.last_scan_button.click()
 
-    xread.assert_called_once_with(
-        MessageEndpoints.scan_history(), from_start=True, user_id=scan_control.object_name
-    )
+    qtbot.waitUntil(lambda: get_last.call_count == 2)
+    # a one-entry tip probe (memo validity check), then the recent window
+    assert get_last.call_args_list == [
+        call(MessageEndpoints.scan_history(), count=1),
+        call(MessageEndpoints.scan_history(), count=scan_control.RECENT_SCAN_HISTORY_COUNT),
+    ]
+    qtbot.waitUntil(scan_control.last_scan_button.isEnabled)
+    xrange.assert_not_called()
     args, kwargs = scan_control.get_scan_parameters(bec_object=False)
     assert args == ["samx", 0.0, 2.0]
     assert kwargs["steps"] == 10
@@ -1211,11 +1225,319 @@ def test_restore_last_scan_parameters_button_fetches_on_demand(
     assert kwargs["exp_time"] == 2
 
 
-def test_get_scan_parameters_from_redis(scan_control):
+def test_restore_last_scan_parameters_does_not_block_gui(
+    scan_control, mocked_client, monkeypatch, qtbot
+):
+    original_get_last = mocked_client.connector.get_last
+    fetch_started = Event()
+    allow_fetch_to_finish = Event()
+    fetch_thread_ids = []
+    apply_thread_ids = []
+
+    original_set_parameters = scan_control.arg_box.set_parameters
+
+    def tracking_set_parameters(*args, **kwargs):
+        apply_thread_ids.append(get_ident())
+        return original_set_parameters(*args, **kwargs)
+
+    def blocking_get_last(*args, **kwargs):
+        fetch_thread_ids.append(get_ident())
+        fetch_started.set()
+        allow_fetch_to_finish.wait(timeout=5)
+        return original_get_last(*args, **kwargs)
+
+    monkeypatch.setattr(mocked_client.connector, "get_last", blocking_get_last)
+    monkeypatch.setattr(scan_control.arg_box, "set_parameters", tracking_set_parameters)
+    gui_thread_id = get_ident()
+
+    scan_control.comboBox_scan_selection.setCurrentText("line_scan")
+    scan_control.last_scan_button.click()
+
+    try:
+        qtbot.waitUntil(fetch_started.is_set)
+        assert len(fetch_thread_ids) == 1
+        assert fetch_thread_ids[0] != gui_thread_id
+        assert not scan_control.last_scan_button.isEnabled()
+    finally:
+        allow_fetch_to_finish.set()
+
+    qtbot.waitUntil(scan_control.last_scan_button.isEnabled)
+    assert apply_thread_ids == [gui_thread_id]
+    args, kwargs = scan_control.get_scan_parameters(bec_object=False)
+    assert args == ["samx", 0.0, 2.0]
+    assert kwargs["steps"] == 10
+
+
+def test_restore_last_scan_parameters_reenables_button_after_fetch_failure(
+    scan_control, mocked_client, monkeypatch, qtbot
+):
+    get_last = MagicMock(side_effect=RuntimeError("history unavailable"))
+    monkeypatch.setattr(mocked_client.connector, "get_last", get_last)
+
+    scan_control.last_scan_button.click()
+
+    qtbot.waitUntil(lambda: get_last.call_count == 1)
+    qtbot.waitUntil(scan_control.last_scan_button.isEnabled)
+
+
+def test_restore_last_scan_parameters_reenables_button_when_worker_task_raises(
+    scan_control, monkeypatch, qtbot
+):
+    # bypass the fetch's own error handling: the worker emits ``failed`` instead of
+    # ``completed``, so the button must recover from that signal, not from the watchdog
+    monkeypatch.setattr(
+        scan_control._last_scan_fetch_watchdog, "start", MagicMock(name="watchdog_disabled")
+    )
+    monkeypatch.setattr(
+        scan_control,
+        "_fetch_last_executed_scan_parameters",
+        MagicMock(side_effect=RuntimeError("worker exploded")),
+    )
+
+    scan_control.last_scan_button.click()
+
+    qtbot.waitUntil(scan_control.last_scan_button.isEnabled)
+
+
+def test_restore_last_scan_parameters_escalates_to_bounded_history_window(
+    scan_control, mocked_client, monkeypatch, qtbot
+):
+    recent_scan = scan_history.model_copy(update={"scan_name": "grid_scan"})
+    # a full window means older entries may exist, so the deeper - but still capped - read runs
+    full_window = [{"data": recent_scan}] * scan_control.RECENT_SCAN_HISTORY_COUNT
+    # responses for: tip probe, recent window, deep window
+    get_last = MagicMock(
+        side_effect=[[{"data": recent_scan}], full_window, [{"data": scan_history}]]
+    )
+    xrange = MagicMock(wraps=mocked_client.connector.xrange)
+    monkeypatch.setattr(mocked_client.connector, "get_last", get_last)
+    monkeypatch.setattr(mocked_client.connector, "xrange", xrange)
+
+    scan_control.comboBox_scan_selection.setCurrentText("line_scan")
+    scan_control.last_scan_button.click()
+
+    qtbot.waitUntil(lambda: get_last.call_count == 3)
+    qtbot.waitUntil(scan_control.last_scan_button.isEnabled)
+    assert get_last.call_args_list == [
+        call(MessageEndpoints.scan_history(), count=1),
+        call(MessageEndpoints.scan_history(), count=scan_control.RECENT_SCAN_HISTORY_COUNT),
+        call(MessageEndpoints.scan_history(), count=scan_control.MAX_HISTORY_LOOKBACK),
+    ]
+    # the unbounded full-stream read is gone: it stalled the event loop from any thread
+    xrange.assert_not_called()
+    args, kwargs = scan_control.get_scan_parameters(bec_object=False)
+    assert args == ["samx", 0.0, 2.0]
+    assert kwargs["steps"] == 10
+
+
+def test_restore_last_scan_parameters_never_reads_unbounded_stream(
+    scan_control, mocked_client, monkeypatch, qtbot
+):
+    recent_scan = scan_history.model_copy(update={"scan_name": "grid_scan"})
+    # every window comes back full, so the lookup can never conclude the stream is exhausted
+    get_last = MagicMock(
+        side_effect=lambda _endpoint, count: [{"data": recent_scan}] * count  # noqa: ARG005
+    )
+    xrange = MagicMock(wraps=mocked_client.connector.xrange)
+    monkeypatch.setattr(mocked_client.connector, "get_last", get_last)
+    monkeypatch.setattr(mocked_client.connector, "xrange", xrange)
+
+    scan_control.comboBox_scan_selection.setCurrentText("line_scan")
+    scan_control.last_scan_button.click()
+
+    qtbot.waitUntil(scan_control.last_scan_button.isEnabled)
+    xrange.assert_not_called()
+    assert (
+        max(call_args.kwargs["count"] for call_args in get_last.call_args_list)
+        == scan_control.MAX_HISTORY_LOOKBACK
+    )
+
+
+def test_restore_last_scan_parameters_logs_when_lookback_exhausted(
+    scan_control, mocked_client, monkeypatch, qtbot
+):
+    recent_scan = scan_history.model_copy(update={"scan_name": "grid_scan"})
+    get_last = MagicMock(side_effect=lambda _endpoint, count: [{"data": recent_scan}] * count)
+    monkeypatch.setattr(mocked_client.connector, "get_last", get_last)
+    # bec_logger is loguru-based, so caplog does not see it
+    warning = MagicMock()
+    monkeypatch.setattr(scan_control_module.logger, "warning", warning)
+
+    scan_control.comboBox_scan_selection.setCurrentText("line_scan")
+    scan_control.last_scan_button.click()
+    qtbot.waitUntil(scan_control.last_scan_button.isEnabled)
+
+    assert any("older history is not searched" in c.args[0] for c in warning.call_args_list)
+
+
+def test_restore_last_scan_parameters_skips_deeper_read_when_stream_exhausted(
+    scan_control, mocked_client, monkeypatch, qtbot
+):
+    recent_scan = scan_history.model_copy(update={"scan_name": "grid_scan"})
+    # a partial window proves the whole stream was searched; no deeper read is allowed
+    get_last = MagicMock(return_value=[{"data": recent_scan}])
+    xrange = MagicMock(wraps=mocked_client.connector.xrange)
+    monkeypatch.setattr(mocked_client.connector, "get_last", get_last)
+    monkeypatch.setattr(mocked_client.connector, "xrange", xrange)
+
+    scan_control.comboBox_scan_selection.setCurrentText("line_scan")
+    scan_control.last_scan_button.click()
+
+    qtbot.waitUntil(lambda: get_last.call_count == 2)
+    qtbot.waitUntil(scan_control.last_scan_button.isEnabled)
+    assert get_last.call_args_list == [
+        call(MessageEndpoints.scan_history(), count=1),
+        call(MessageEndpoints.scan_history(), count=scan_control.RECENT_SCAN_HISTORY_COUNT),
+    ]
+    xrange.assert_not_called()
+
+
+def test_restore_last_scan_parameters_memoizes_missing_scan_lookups(
+    scan_control, mocked_client, monkeypatch, qtbot
+):
+    recent_scan = scan_history.model_copy(update={"scan_name": "grid_scan"})
+    get_last = MagicMock(side_effect=lambda _endpoint, count: [{"data": recent_scan}] * count)
+    monkeypatch.setattr(mocked_client.connector, "get_last", get_last)
+
+    scan_control.comboBox_scan_selection.setCurrentText("line_scan")
+    scan_control.last_scan_button.click()
+    qtbot.waitUntil(scan_control.last_scan_button.isEnabled)
+    calls_after_first = get_last.call_count  # tip probe + recent window + deep window
+
+    scan_control.last_scan_button.click()
+    qtbot.waitUntil(scan_control.last_scan_button.isEnabled)
+
+    # the repeat click for a never-measured scan costs one tip probe, no window reads
+    assert get_last.call_count == calls_after_first + 1
+    assert get_last.call_args_list[-1] == call(MessageEndpoints.scan_history(), count=1)
+
+
+def test_restore_last_scan_parameters_memo_reapplies_and_invalidates(
+    scan_control, mocked_client, monkeypatch, qtbot
+):
+    get_last = MagicMock(wraps=mocked_client.connector.get_last)
+    monkeypatch.setattr(mocked_client.connector, "get_last", get_last)
+    scan_control.comboBox_scan_selection.setCurrentText("line_scan")
+
+    scan_control.last_scan_button.click()
+    qtbot.waitUntil(scan_control.last_scan_button.isEnabled)
+    calls_after_first = get_last.call_count  # tip probe + recent window (hit)
+
+    # user edits the form; restoring again is answered from the memo with one probe read
+    scan_control.arg_box.set_parameters(["samx", 1.0, 5.0])
+    scan_control.last_scan_button.click()
+    qtbot.waitUntil(scan_control.last_scan_button.isEnabled)
+    args, _ = scan_control.get_scan_parameters(bec_object=False)
+    assert args == ["samx", 0.0, 2.0]
+    assert get_last.call_count == calls_after_first + 1
+    assert get_last.call_args_list[-1] == call(MessageEndpoints.scan_history(), count=1)
+
+    # a new history entry moves the stream tip and invalidates the memo
+    new_msg = scan_history.model_copy(update={"scan_name": "grid_scan", "scan_id": "memo_tip"})
+    mocked_client.connector.xadd(topic=MessageEndpoints.scan_history(), msg_dict={"data": new_msg})
+    scan_control.last_scan_button.click()
+    qtbot.waitUntil(scan_control.last_scan_button.isEnabled)
+    # tip probe plus a fresh recent-window read
+    assert get_last.call_count == calls_after_first + 3
+
+
+def test_restore_last_scan_parameters_handles_single_entry_window(
+    scan_control, mocked_client, monkeypatch, qtbot
+):
+    # get_last returns a bare dict (not a list) for count == 1
+    monkeypatch.setattr(scan_control, "RECENT_SCAN_HISTORY_COUNT", 1)
+
+    scan_control.comboBox_scan_selection.setCurrentText("line_scan")
+    scan_control.last_scan_button.click()
+
+    qtbot.waitUntil(scan_control.last_scan_button.isEnabled)
+    args, kwargs = scan_control.get_scan_parameters(bec_object=False)
+    assert args == ["samx", 0.0, 2.0]
+    assert kwargs["steps"] == 10
+
+
+def test_restore_last_scan_parameters_uses_history_cache(
+    scan_control, mocked_client, monkeypatch, qtbot
+):
+    history = ScanHistory(mocked_client, load_threaded=False)
+    history._scan_data[scan_history.scan_id] = scan_history
+    history._scan_ids.append(scan_history.scan_id)
+    monkeypatch.setattr(mocked_client, "history", history, raising=False)
+    get_last = MagicMock(wraps=mocked_client.connector.get_last)
+    monkeypatch.setattr(mocked_client.connector, "get_last", get_last)
+
+    scan_control.comboBox_scan_selection.setCurrentText("line_scan")
+    scan_control.last_scan_button.click()
+
+    qtbot.waitUntil(scan_control.last_scan_button.isEnabled)
+    get_last.assert_not_called()
+    args, kwargs = scan_control.get_scan_parameters(bec_object=False)
+    assert args == ["samx", 0.0, 2.0]
+    assert kwargs["steps"] == 10
+
+
+def test_restore_last_scan_parameters_discards_result_on_scan_switch(
+    scan_control, mocked_client, monkeypatch, qtbot
+):
+    original_get_last = mocked_client.connector.get_last
+    fetch_started = Event()
+    allow_fetch_to_finish = Event()
+
+    def blocking_get_last(*args, **kwargs):
+        fetch_started.set()
+        allow_fetch_to_finish.wait(timeout=5)
+        return original_get_last(*args, **kwargs)
+
+    monkeypatch.setattr(mocked_client.connector, "get_last", blocking_get_last)
+
+    scan_control.comboBox_scan_selection.setCurrentText("line_scan")
+    scan_control.last_scan_button.click()
+    qtbot.waitUntil(fetch_started.is_set)
+    scan_control.comboBox_scan_selection.setCurrentText("grid_scan")
+    allow_fetch_to_finish.set()
+
+    qtbot.waitUntil(scan_control.last_scan_button.isEnabled)
+    # the fetched line_scan parameters must not leak into the grid_scan form
+    args, _ = scan_control.get_scan_parameters(bec_object=False)
+    assert args != ["samx", 0.0, 2.0]
+
+
+def test_restore_last_scan_parameters_watchdog_recovers_from_hanging_fetch(
+    scan_control, mocked_client, monkeypatch, qtbot
+):
+    original_get_last = mocked_client.connector.get_last
+    fetch_started = Event()
+    allow_fetch_to_finish = Event()
+
+    def blocking_get_last(*args, **kwargs):
+        fetch_started.set()
+        allow_fetch_to_finish.wait(timeout=5)
+        return original_get_last(*args, **kwargs)
+
+    monkeypatch.setattr(mocked_client.connector, "get_last", blocking_get_last)
+    scan_control._last_scan_fetch_watchdog.setInterval(50)
+
+    scan_control.comboBox_scan_selection.setCurrentText("line_scan")
+    original_args, _ = scan_control.get_scan_parameters(bec_object=False)
+    scan_control.last_scan_button.click()
+    qtbot.waitUntil(fetch_started.is_set)
+
+    # the watchdog re-enables the button while the fetch is still hanging
+    qtbot.waitUntil(scan_control.last_scan_button.isEnabled)
+    allow_fetch_to_finish.set()
+
+    # the late result must be discarded once the watchdog has given up on the fetch
+    qtbot.wait(200)
+    args, _ = scan_control.get_scan_parameters(bec_object=False)
+    assert args == original_args
+
+
+def test_get_scan_parameters_from_redis(scan_control, qtbot):
     scan_name = "line_scan"
     scan_control.comboBox_scan_selection.setCurrentText(scan_name)
 
     scan_control.last_scan_button.click()
+    qtbot.waitUntil(scan_control.last_scan_button.isEnabled)
 
     args, kwargs = scan_control.get_scan_parameters(bec_object=False)
 
@@ -1295,7 +1617,7 @@ def test_scan_metadata_is_passed_to_scan_function(scan_control: ScanControl):
     scans.grid_scan.assert_called_once_with(metadata=TEST_MD)
 
 
-def test_restore_parameters_with_fewer_arg_bundles(scan_control):
+def test_restore_parameters_with_fewer_arg_bundles(scan_control, qtbot):
     """
     Ensure that when more argument bundles are present than exist in the
     stored history, restoring parameters regenerates the arg box to the
@@ -1312,6 +1634,7 @@ def test_restore_parameters_with_fewer_arg_bundles(scan_control):
 
     # Trigger restore of parameters from history
     scan_control.last_scan_button.click()
+    qtbot.waitUntil(scan_control.last_scan_button.isEnabled)
 
     # After restore, arg_box should have only one bundle (the history size)
     assert scan_control.arg_box.count_arg_rows() == 1


### PR DESCRIPTION
## Description

Fetching parameters from history was freezing gui, now fetched async + optimization.