### PR TITLE
Pg gpu data api

### DIFF
--- a/bec_widgets/cli/client.py
+++ b/bec_widgets/cli/client.py
@@ -2104,6 +2104,28 @@ class Heatmap(RPCBase):
         ``DEFAULT_UPDATE_RATE`` (25 Hz unless overridden).
         """
 
+    @property
+    @rpc_call
+    def use_opengl(self) -> "bool":
+        """
+        Whether the plot currently renders through an OpenGL viewport.
+
+        Reflects the live viewport rather than the requested value: setting this to
+        True is best effort, and stays False when no hardware-accelerated context is
+        available (see `bec_widgets.utils.gpu_acceleration.opengl_available`).
+        """
+
+    @use_opengl.setter
+    @rpc_call
+    def use_opengl(self) -> "bool":
+        """
+        Whether the plot currently renders through an OpenGL viewport.
+
+        Reflects the live viewport rather than the requested value: setting this to
+        True is best effort, and stays False when no hardware-accelerated context is
+        available (see `bec_widgets.utils.gpu_acceleration.opengl_available`).
+        """
+
     @rpc_timeout(None)
     @rpc_call
     def screenshot(self, file_name: "str | None" = None):
@@ -2830,6 +2852,28 @@ class Image(RPCBase):
 
         Clamped to 1-100 Hz. Each widget class defines its own default via
         ``DEFAULT_UPDATE_RATE`` (25 Hz unless overridden).
+        """
+
+    @property
+    @rpc_call
+    def use_opengl(self) -> "bool":
+        """
+        Whether the plot currently renders through an OpenGL viewport.
+
+        Reflects the live viewport rather than the requested value: setting this to
+        True is best effort, and stays False when no hardware-accelerated context is
+        available (see `bec_widgets.utils.gpu_acceleration.opengl_available`).
+        """
+
+    @use_opengl.setter
+    @rpc_call
+    def use_opengl(self) -> "bool":
+        """
+        Whether the plot currently renders through an OpenGL viewport.
+
+        Reflects the live viewport rather than the requested value: setting this to
+        True is best effort, and stays False when no hardware-accelerated context is
+        available (see `bec_widgets.utils.gpu_acceleration.opengl_available`).
         """
 
     @rpc_timeout(None)
@@ -4025,6 +4069,28 @@ class MotorMap(RPCBase):
         ``DEFAULT_UPDATE_RATE`` (25 Hz unless overridden).
         """
 
+    @property
+    @rpc_call
+    def use_opengl(self) -> "bool":
+        """
+        Whether the plot currently renders through an OpenGL viewport.
+
+        Reflects the live viewport rather than the requested value: setting this to
+        True is best effort, and stays False when no hardware-accelerated context is
+        available (see `bec_widgets.utils.gpu_acceleration.opengl_available`).
+        """
+
+    @use_opengl.setter
+    @rpc_call
+    def use_opengl(self) -> "bool":
+        """
+        Whether the plot currently renders through an OpenGL viewport.
+
+        Reflects the live viewport rather than the requested value: setting this to
+        True is best effort, and stays False when no hardware-accelerated context is
+        available (see `bec_widgets.utils.gpu_acceleration.opengl_available`).
+        """
+
     @rpc_timeout(None)
     @rpc_call
     def screenshot(self, file_name: "str | None" = None):
@@ -4515,6 +4581,28 @@ class MultiWaveform(RPCBase):
 
         Clamped to 1-100 Hz. Each widget class defines its own default via
         ``DEFAULT_UPDATE_RATE`` (25 Hz unless overridden).
+        """
+
+    @property
+    @rpc_call
+    def use_opengl(self) -> "bool":
+        """
+        Whether the plot currently renders through an OpenGL viewport.
+
+        Reflects the live viewport rather than the requested value: setting this to
+        True is best effort, and stays False when no hardware-accelerated context is
+        available (see `bec_widgets.utils.gpu_acceleration.opengl_available`).
+        """
+
+    @use_opengl.setter
+    @rpc_call
+    def use_opengl(self) -> "bool":
+        """
+        Whether the plot currently renders through an OpenGL viewport.
+
+        Reflects the live viewport rather than the requested value: setting this to
+        True is best effort, and stays False when no hardware-accelerated context is
+        available (see `bec_widgets.utils.gpu_acceleration.opengl_available`).
         """
 
     @rpc_timeout(None)
@@ -5819,6 +5907,28 @@ class ScatterWaveform(RPCBase):
         ``DEFAULT_UPDATE_RATE`` (25 Hz unless overridden).
         """
 
+    @property
+    @rpc_call
+    def use_opengl(self) -> "bool":
+        """
+        Whether the plot currently renders through an OpenGL viewport.
+
+        Reflects the live viewport rather than the requested value: setting this to
+        True is best effort, and stays False when no hardware-accelerated context is
+        available (see `bec_widgets.utils.gpu_acceleration.opengl_available`).
+        """
+
+    @use_opengl.setter
+    @rpc_call
+    def use_opengl(self) -> "bool":
+        """
+        Whether the plot currently renders through an OpenGL viewport.
+
+        Reflects the live viewport rather than the requested value: setting this to
+        True is best effort, and stays False when no hardware-accelerated context is
+        available (see `bec_widgets.utils.gpu_acceleration.opengl_available`).
+        """
+
     @rpc_timeout(None)
     @rpc_call
     def screenshot(self, file_name: "str | None" = None):
@@ -6486,6 +6596,28 @@ class Waveform(RPCBase):
 
         Clamped to 1-100 Hz. Each widget class defines its own default via
         ``DEFAULT_UPDATE_RATE`` (25 Hz unless overridden).
+        """
+
+    @property
+    @rpc_call
+    def use_opengl(self) -> "bool":
+        """
+        Whether the plot currently renders through an OpenGL viewport.
+
+        Reflects the live viewport rather than the requested value: setting this to
+        True is best effort, and stays False when no hardware-accelerated context is
+        available (see `bec_widgets.utils.gpu_acceleration.opengl_available`).
+        """
+
+    @use_opengl.setter
+    @rpc_call
+    def use_opengl(self) -> "bool":
+        """
+        Whether the plot currently renders through an OpenGL viewport.
+
+        Reflects the live viewport rather than the requested value: setting this to
+        True is best effort, and stays False when no hardware-accelerated context is
+        available (see `bec_widgets.utils.gpu_acceleration.opengl_available`).
         """
 
     @rpc_timeout(None)

--- a/bec_widgets/utils/bec_widget.py
+++ b/bec_widgets/utils/bec_widget.py
@@ -16,6 +16,7 @@ import bec_widgets.widgets.containers.qt_ads as QtAds
 from bec_widgets.utils.bec_connector import BECConnector, ConnectionConfig
 from bec_widgets.utils.busy_loader import install_busy_loader
 from bec_widgets.utils.error_popups import SafeConnect, SafeSlot
+from bec_widgets.utils.gpu_acceleration import grab_widget
 from bec_widgets.utils.rpc_decorator import rpc_timeout
 from bec_widgets.utils.rpc_register import RPCRegister
 from bec_widgets.utils.widget_io import WidgetHierarchy
@@ -280,7 +281,7 @@ class BECWidget(BECConnector):
             logger.error("Cannot take screenshot of non-QWidget instance")
             return
 
-        screenshot = self.grab()
+        screenshot = grab_widget(self)
         if file_name is None:
             file_name, _ = QFileDialog.getSaveFileName(
                 self,
@@ -321,7 +322,7 @@ class BECWidget(BECConnector):
         if not hasattr(self, "grab"):
             raise RuntimeError(f"Cannot take screenshot of non-QWidget instance: {repr(self)}")
 
-        pixmap: QPixmap = self.grab()
+        pixmap: QPixmap = grab_widget(self)
         if pixmap.isNull():
             return QByteArray()
         if max_width is not None or max_height is not None:
@@ -359,7 +360,7 @@ class BECWidget(BECConnector):
                 "SciLog is not enabled for the current client, cannot send screenshot."
             )
 
-        pixmap: QPixmap = self.grab()
+        pixmap: QPixmap = grab_widget(self)
         if pixmap.isNull():
             raise RuntimeError("Failed to capture screenshot.")
 

--- a/bec_widgets/utils/gpu_acceleration.py
+++ b/bec_widgets/utils/gpu_acceleration.py
@@ -1,0 +1,184 @@
+"""OpenGL viewport support for BEC plots.
+
+pyqtgraph 0.14 renders :class:`~pyqtgraph.PlotCurveItem` and
+:class:`~pyqtgraph.PColorMeshItem` through a shader program whenever the
+:class:`~pyqtgraph.GraphicsView` viewport is a ``QOpenGLWidget``. Every other
+item -- notably ``ImageItem``, ``ScatterPlotItem``, ``TextItem`` and the ROIs --
+keeps going through ``QPainter``, so only curve-heavy plots gain from it.
+
+Acceleration is therefore opt-in per widget, and is additionally gated on the
+context actually being hardware backed: a remote beamline session that lands on
+a software rasteriser (llvmpipe/swrast) renders *slower* through OpenGL than
+through the raster path.
+
+The ``BEC_WIDGETS_OPENGL`` environment variable overrides the decision:
+
+``auto`` (default)
+    Use OpenGL for widgets that ask for it, unless the renderer is software.
+``1`` / ``on`` / ``true``
+    Force OpenGL on, even for a software renderer.
+``0`` / ``off`` / ``false``
+    Never use OpenGL.
+"""
+
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+
+from bec_lib import bec_logger
+from pyqtgraph import GraphicsView
+from qtpy.QtCore import QPoint, QRectF, Qt
+from qtpy.QtGui import QOffscreenSurface, QOpenGLContext, QPainter, QPixmap
+from qtpy.QtOpenGLWidgets import QOpenGLWidget
+from qtpy.QtWidgets import QApplication, QWidget
+
+logger = bec_logger.logger
+
+ENV_VAR = "BEC_WIDGETS_OPENGL"
+
+# Substrings identifying a renderer that is not backed by a GPU. Mesa reports
+# these when a session has no direct rendering, which is the common case for
+# X-forwarded or VNC beamline consoles.
+_SOFTWARE_RENDERERS = ("llvmpipe", "softpipe", "swrast", "software rasterizer", "gallium, swr")
+
+_GL_VENDOR = 0x1F00
+_GL_RENDERER = 0x1F01
+_GL_VERSION = 0x1F02
+
+
+@lru_cache(maxsize=1)
+def opengl_info() -> dict[str, str] | None:
+    """Query the OpenGL implementation backing this session.
+
+    Creates a throwaway context on an offscreen surface. The result is cached,
+    so the cost is paid once per process.
+
+    Returns:
+        dict[str, str] | None: ``vendor``/``renderer``/``version`` strings, or
+        None if no usable context could be created.
+    """
+    if QApplication.instance() is None:
+        # A context needs a QApplication; asking this early is a caller bug, but
+        # it must not take the GUI down.
+        logger.warning("OpenGL probed before a QApplication exists; assuming unavailable")
+        return None
+
+    surface = QOffscreenSurface()
+    surface.create()
+    context = QOpenGLContext()
+    if not context.create() or not context.makeCurrent(surface):
+        logger.info("No usable OpenGL context; plots will use the raster viewport")
+        return None
+    try:
+        functions = context.functions()
+        info = {
+            "vendor": str(functions.glGetString(_GL_VENDOR)),
+            "renderer": str(functions.glGetString(_GL_RENDERER)),
+            "version": str(functions.glGetString(_GL_VERSION)),
+        }
+    finally:
+        context.doneCurrent()
+    logger.info(f"OpenGL renderer: {info['renderer']} ({info['vendor']}, {info['version']})")
+    return info
+
+
+def is_software_renderer() -> bool:
+    """Whether the OpenGL context is served by a software rasteriser."""
+    info = opengl_info()
+    if info is None:
+        return False
+    renderer = info["renderer"].lower()
+    return any(marker in renderer for marker in _SOFTWARE_RENDERERS)
+
+
+def _env_override() -> bool | None:
+    """Read ``BEC_WIDGETS_OPENGL``; None when unset or set to ``auto``."""
+    # Read on every call rather than caching, so tests and the launcher can flip
+    # it after bec_widgets has been imported.
+    raw = os.environ.get(ENV_VAR, "").strip().lower()
+    if raw in ("", "auto"):
+        return None
+    if raw in ("1", "on", "true", "yes"):
+        return True
+    if raw in ("0", "off", "false", "no"):
+        return False
+    logger.warning(f"Ignoring unrecognised {ENV_VAR}={raw!r}; expected auto, 1 or 0")
+    return None
+
+
+def opengl_available(requested: bool = True) -> bool:
+    """Decide whether a widget that asked for OpenGL should actually get it.
+
+    Args:
+        requested(bool): Whether the widget wants the OpenGL viewport at all.
+
+    Returns:
+        bool: True if the OpenGL viewport should be installed.
+    """
+    override = _env_override()
+    if override is False:
+        return False
+    if not requested and override is not True:
+        return False
+    if opengl_info() is None:
+        return False
+    if override is True:
+        return True
+    if is_software_renderer():
+        logger.info(
+            "OpenGL is available but software rendered; keeping the raster viewport. "
+            f"Set {ENV_VAR}=1 to override."
+        )
+        return False
+    return True
+
+
+def _accelerated_views(widget: QWidget) -> list[GraphicsView]:
+    """GraphicsView descendants of ``widget`` that are on an OpenGL viewport."""
+    views = widget.findChildren(GraphicsView)
+    if isinstance(widget, GraphicsView):
+        views.append(widget)
+    return [v for v in views if v.isVisible() and isinstance(v.viewport(), QOpenGLWidget)]
+
+
+def grab_widget(widget: QWidget) -> QPixmap:
+    """Grab ``widget`` including any plots drawn on an OpenGL viewport.
+
+    ``QWidget.grab`` renders the widget tree through ``QPainter`` and never
+    reaches a ``QOpenGLWidget``, so a plot on the OpenGL viewport comes back
+    blank. ``QOpenGLWidget.grabFramebuffer`` is not a reliable substitute
+    either -- on macOS the framebuffer is not retained after compositing.
+
+    Instead, each affected view re-renders its *scene* through ``QPainter``
+    into the grabbed pixmap. That is the same raster path the non-accelerated
+    plots already use, so the output matches, and no OpenGL state is touched.
+
+    Args:
+        widget(QWidget): The widget to capture.
+
+    Returns:
+        QPixmap: The captured pixmap, or the plain ``grab()`` result when no
+        OpenGL-backed plot is present.
+    """
+    pixmap = widget.grab()
+    views = _accelerated_views(widget)
+    if not views or pixmap.isNull():
+        return pixmap
+
+    painter = QPainter(pixmap)
+    try:
+        for view in views:
+            viewport = view.viewport()
+            # GraphicsView.render forwards to QGraphicsView.render, which stretches
+            # the scene across the whole painter unless target and source are given.
+            origin = viewport.mapTo(widget, QPoint(0, 0))
+            source = viewport.rect()
+            target = QRectF(origin.x(), origin.y(), source.width(), source.height())
+            try:
+                view.render(painter, target, source, Qt.AspectRatioMode.IgnoreAspectRatio)
+            except Exception:  # pragma: no cover - rendering must never break a screenshot
+                logger.warning(f"Failed to render {view!r} into screenshot", exc_info=True)
+    finally:
+        painter.end()
+    return pixmap

--- a/bec_widgets/utils/gpu_acceleration.py
+++ b/bec_widgets/utils/gpu_acceleration.py
@@ -134,6 +134,53 @@ def opengl_available(requested: bool = True) -> bool:
     return True
 
 
+def _release_gl_state(view: GraphicsView) -> None:
+    """Drop the cached ``OpenGLState`` of every item in ``view``'s scene.
+
+    pyqtgraph creates that state once per item and parents it to the *viewport*
+    widget. Swapping the viewport deletes it on the C++ side while the item
+    keeps a stale Python reference, so the next ``paintGL`` raises
+    ``RuntimeError: Signal source has been deleted``. ``PlotCurveItem.paint``
+    swallows it, which shows up as a silently missing curve rather than a
+    crash. Clearing the reference makes the item rebuild its state against the
+    new context.
+    """
+    scene = view.scene()
+    if scene is None:
+        return
+    for item in scene.items():
+        # PlotDataItem delegates drawing to a PlotCurveItem held in .curve, which
+        # is itself in the scene; check both so nothing is missed.
+        for target in {item, getattr(item, "curve", None)}:
+            if target is None or getattr(target, "glstate", None) is None:
+                continue
+            signal = getattr(target, "sigPlotChanged", None)
+            if signal is not None:
+                try:
+                    signal.disconnect(target.glstate.verticesChanged)
+                except (RuntimeError, TypeError):
+                    # not connected, or the C++ side is already gone
+                    pass
+            target.glstate = None
+
+
+def set_view_opengl(view: GraphicsView, enabled: bool) -> bool:
+    """Switch ``view`` between the OpenGL and raster viewport at runtime.
+
+    Args:
+        view(GraphicsView): The view whose viewport should be swapped.
+        enabled(bool): Whether the OpenGL viewport is wanted.
+
+    Returns:
+        bool: Whether the OpenGL viewport is active afterwards.
+    """
+    if isinstance(view.viewport(), QOpenGLWidget) is enabled:
+        return enabled
+    _release_gl_state(view)
+    view.useOpenGL(enabled)
+    return isinstance(view.viewport(), QOpenGLWidget)
+
+
 def _accelerated_views(widget: QWidget) -> list[GraphicsView]:
     """GraphicsView descendants of ``widget`` that are on an OpenGL viewport."""
     views = widget.findChildren(GraphicsView)

--- a/bec_widgets/widgets/plots/multi_waveform/multi_waveform.py
+++ b/bec_widgets/widgets/plots/multi_waveform/multi_waveform.py
@@ -70,6 +70,8 @@ class MultiWaveform(PlotBase):
     PLUGIN = True
     RPC = True
     ICON_NAME = "ssid_chart"
+    # Many simultaneous curves; the biggest beneficiary of the shader path.
+    USE_OPENGL = True
     USER_ACCESS = [
         *PlotBase.USER_ACCESS,
         # MultiWaveform Specific RPC Access

--- a/bec_widgets/widgets/plots/multi_waveform/multi_waveform.py
+++ b/bec_widgets/widgets/plots/multi_waveform/multi_waveform.py
@@ -70,8 +70,6 @@ class MultiWaveform(PlotBase):
     PLUGIN = True
     RPC = True
     ICON_NAME = "ssid_chart"
-    # Many simultaneous curves; the biggest beneficiary of the shader path.
-    USE_OPENGL = True
     USER_ACCESS = [
         *PlotBase.USER_ACCESS,
         # MultiWaveform Specific RPC Access

--- a/bec_widgets/widgets/plots/plot_base.py
+++ b/bec_widgets/widgets/plots/plot_base.py
@@ -14,6 +14,7 @@ from bec_widgets.utils.crosshair import Crosshair
 from bec_widgets.utils.entry_validator import EntryValidator
 from bec_widgets.utils.error_popups import SafeProperty, SafeSlot
 from bec_widgets.utils.fps_counter import FPSCounter
+from bec_widgets.utils.gpu_acceleration import opengl_available
 from bec_widgets.utils.plot_indicator_items import BECArrowItem, BECTickItem
 from bec_widgets.utils.qt_data_subscription import QtDataSubscription
 from bec_widgets.utils.round_frame import RoundedFrame
@@ -116,6 +117,13 @@ class PlotBase(BECWidget, QWidget):
     ]
     USER_ACCESS = [*BECWidget.USER_ACCESS, *BASE_USER_ACCESS]
 
+    # Whether this plot benefits from the OpenGL viewport. Only PlotCurveItem and
+    # PColorMeshItem have a shader path in pyqtgraph 0.14; image- and scatter-based
+    # plots gain nothing, so they stay on the raster viewport. Subclasses that draw
+    # curves set this to True. The final say belongs to `opengl_available`, which
+    # also honours the BEC_WIDGETS_OPENGL environment variable.
+    USE_OPENGL = False
+
     # Custom Signals
     property_changed = Signal(str, object)
     crosshair_position_changed = Signal(tuple)
@@ -160,6 +168,11 @@ class PlotBase(BECWidget, QWidget):
         self._ui_mode = UIMode.POPUP if popups else UIMode.SIDE
         self.axis_settings_dialog = None
         self.plot_widget = pg.GraphicsLayoutWidget(parent=self)
+        # GraphicsLayoutWidget forwards no viewport argument to GraphicsView, so the
+        # viewport is swapped after construction instead.
+        self._opengl_enabled = opengl_available(self.USE_OPENGL)
+        if self._opengl_enabled:
+            self.plot_widget.useOpenGL(True)
         self.plot_widget.ci.setContentsMargins(0, 0, 0, 0)
         self.plot_item = pg.PlotItem(viewBox=BECViewBox(enableMenu=True))
         self.plot_widget.addItem(self.plot_item)

--- a/bec_widgets/widgets/plots/plot_base.py
+++ b/bec_widgets/widgets/plots/plot_base.py
@@ -6,6 +6,7 @@ import numpy as np
 import pyqtgraph as pg
 from bec_lib import bec_logger
 from qtpy.QtCore import QPoint, QPointF, Qt, Signal
+from qtpy.QtOpenGLWidgets import QOpenGLWidget
 from qtpy.QtWidgets import QHBoxLayout, QLabel, QMainWindow, QVBoxLayout, QWidget
 
 from bec_widgets.utils.bec_connector import ConnectionConfig
@@ -14,7 +15,7 @@ from bec_widgets.utils.crosshair import Crosshair
 from bec_widgets.utils.entry_validator import EntryValidator
 from bec_widgets.utils.error_popups import SafeProperty, SafeSlot
 from bec_widgets.utils.fps_counter import FPSCounter
-from bec_widgets.utils.gpu_acceleration import opengl_available
+from bec_widgets.utils.gpu_acceleration import opengl_available, set_view_opengl
 from bec_widgets.utils.plot_indicator_items import BECArrowItem, BECTickItem
 from bec_widgets.utils.qt_data_subscription import QtDataSubscription
 from bec_widgets.utils.round_frame import RoundedFrame
@@ -113,16 +114,17 @@ class PlotBase(BECWidget, QWidget):
         "minimal_crosshair_precision.setter",
         "update_rate",
         "update_rate.setter",
+        "use_opengl",
+        "use_opengl.setter",
         "screenshot",
     ]
     USER_ACCESS = [*BECWidget.USER_ACCESS, *BASE_USER_ACCESS]
 
-    # Whether this plot benefits from the OpenGL viewport. Only PlotCurveItem and
-    # PColorMeshItem have a shader path in pyqtgraph 0.14; image- and scatter-based
-    # plots gain nothing, so they stay on the raster viewport. Subclasses that draw
-    # curves set this to True. The final say belongs to `opengl_available`, which
-    # also honours the BEC_WIDGETS_OPENGL environment variable.
-    USE_OPENGL = False
+    # Default for the `use_opengl` property. Curve-heavy plots gain the most, but
+    # the OpenGL viewport is no slower for the others, so it is on by default and
+    # can be toggled per widget at runtime. `opengl_available` still has the final
+    # say: it declines on a software renderer and honours BEC_WIDGETS_OPENGL.
+    USE_OPENGL = True
 
     # Custom Signals
     property_changed = Signal(str, object)
@@ -170,9 +172,7 @@ class PlotBase(BECWidget, QWidget):
         self.plot_widget = pg.GraphicsLayoutWidget(parent=self)
         # GraphicsLayoutWidget forwards no viewport argument to GraphicsView, so the
         # viewport is swapped after construction instead.
-        self._opengl_enabled = opengl_available(self.USE_OPENGL)
-        if self._opengl_enabled:
-            self.plot_widget.useOpenGL(True)
+        self.use_opengl = self.USE_OPENGL
         self.plot_widget.ci.setContentsMargins(0, 0, 0, 0)
         self.plot_item = pg.PlotItem(viewBox=BECViewBox(enableMenu=True))
         self.plot_widget.addItem(self.plot_item)
@@ -322,6 +322,31 @@ class PlotBase(BECWidget, QWidget):
                 pb_connection.axis_settings_dialog = None
             self.add_side_menus()
             self.side_panel.show()
+
+    @SafeProperty(bool, doc="Render the plot through an OpenGL viewport.")
+    def use_opengl(self) -> bool:
+        """
+        Whether the plot currently renders through an OpenGL viewport.
+
+        Reflects the live viewport rather than the requested value: setting this to
+        True is best effort, and stays False when no hardware-accelerated context is
+        available (see `bec_widgets.utils.gpu_acceleration.opengl_available`).
+        """
+        return isinstance(self.plot_widget.viewport(), QOpenGLWidget)
+
+    @use_opengl.setter
+    def use_opengl(self, value: bool) -> None:
+        """
+        Switch the plot between the OpenGL and raster viewport.
+
+        Args:
+            value(bool): Whether the OpenGL viewport is wanted.
+        """
+        if value and not opengl_available(True):
+            if self.use_opengl:
+                set_view_opengl(self.plot_widget, False)
+            return
+        set_view_opengl(self.plot_widget, value)
 
     @SafeProperty(bool, doc="Enable popups setting dialogs for the plot widget.")
     def enable_popups(self):

--- a/bec_widgets/widgets/plots/waveform/curve.py
+++ b/bec_widgets/widgets/plots/waveform/curve.py
@@ -40,6 +40,13 @@ class CurveConfig(ConnectionConfig):
         None, description="The color of the symbol of the curve."
     )
     symbol_size: int | None = Field(7, description="The size of the symbol of the curve.")
+    symbol_point_limit: int | None = Field(
+        1000,
+        description=(
+            "Hide the symbol once the curve holds more than this many points. "
+            "None keeps the symbol at every data size."
+        ),
+    )
     pen_width: int | None = Field(4, description="The width of the pen of the curve.")
     pen_style: Literal["solid", "dash", "dot", "dashdot"] | None = Field(
         "solid", description="The style of the pen of the curve."
@@ -61,6 +68,45 @@ class CurveConfig(ConnectionConfig):
 
     _validate_color = field_validator("color")(Colors.validate_color)
     _validate_symbol_color = field_validator("symbol_color")(Colors.validate_color)
+
+
+def _incoming_length(args: tuple, kwargs: dict) -> int | None:
+    """
+    Number of points a ``PlotDataItem.setData`` call is about to plot.
+
+    ``setData`` accepts several shapes -- ``(y)``, ``(x, y)``, keyword ``x``/``y``,
+    a dict, a record array or a list of dicts. Only the plain sequence forms are
+    resolved here; anything else returns None so the caller leaves the symbol as
+    it is rather than guessing.
+
+    Args:
+        args(tuple): Positional arguments passed to ``setData``.
+        kwargs(dict): Keyword arguments passed to ``setData``.
+
+    Returns:
+        int | None: The point count, or None if it cannot be determined cheaply.
+    """
+    candidate = None
+    if len(args) >= 2:
+        candidate = args[1]
+    elif len(args) == 1:
+        candidate = args[0]
+    elif "y" in kwargs:
+        candidate = kwargs["y"]
+    elif "x" in kwargs:
+        candidate = kwargs["x"]
+    elif not args and not kwargs:
+        # setData() with no arguments clears the curve
+        return 0
+
+    if isinstance(candidate, np.ndarray):
+        return candidate.shape[0] if candidate.ndim else None
+    if isinstance(candidate, (list, tuple)):
+        # a list of dicts is a spot-style record list, not a value column
+        if candidate and isinstance(candidate[0], dict):
+            return None
+        return len(candidate)
+    return None
 
 
 class Curve(BECConnector, pg.PlotDataItem):
@@ -93,6 +139,8 @@ class Curve(BECConnector, pg.PlotDataItem):
         parent_item: Waveform | None = None,
         **kwargs,
     ):
+        # Set before apply_config(), which consults it to honour the symbol limit.
+        self._symbols_suppressed = False
         if config is None:
             config = CurveConfig(label=name, widget_class=self.__class__.__name__)
             self.config = config
@@ -145,6 +193,43 @@ class Curve(BECConnector, pg.PlotDataItem):
 
             self.setSymbolBrush(brush)
             self.setSymbolSize(self.config.symbol_size)
+            # A dense curve keeps its symbol hidden; the config still records what
+            # to restore once the data drops back below the limit.
+            self.setSymbol(None if self._symbols_suppressed else self.config.symbol)
+
+    def setData(self, *args, **kwargs):
+        """
+        Set the curve data, hiding the symbol for datasets above the configured limit.
+
+        pyqtgraph draws symbols through ``ScatterPlotItem``, which builds a style
+        tuple per point in Python (``SymbolAtlas._keys``). That is linear in the
+        number of points and dominates everything else: at 50k points a ``setData``
+        costs ~90 ms with a symbol and ~0.5 ms without. Scans routinely exceed the
+        limit, so the symbol is dropped there and restored when the data shrinks.
+        """
+        # getattr guards against setData being reached before __init__ sets the field.
+        self._data_version = getattr(self, "_data_version", 0) + 1
+        self._apply_symbol_limit(_incoming_length(args, kwargs))
+        super().setData(*args, **kwargs)
+
+    def _apply_symbol_limit(self, data_length: int | None) -> None:
+        """
+        Hide or restore the symbol for the given incoming data length.
+
+        Args:
+            data_length(int | None): Length of the data about to be set, or None
+                when it could not be determined (the limit is then left alone).
+        """
+        limit = self.config.symbol_point_limit
+        if data_length is None or limit is None:
+            return
+        suppressed = data_length > limit
+        if suppressed == self._symbols_suppressed:
+            return
+        self._symbols_suppressed = suppressed
+        if suppressed:
+            self.setSymbol(None)
+        elif self.config.symbol:
             self.setSymbol(self.config.symbol)
 
     @property
@@ -200,12 +285,6 @@ class Curve(BECConnector, pg.PlotDataItem):
     def data_version(self) -> int:
         """Monotonic counter bumped on every ``setData`` call."""
         return self._data_version
-
-    def setData(self, *args, **kwargs):
-        """Wrap ``PlotDataItem.setData`` to track how often the data changes."""
-        # getattr guards against setData being reached before __init__ sets the field.
-        self._data_version = getattr(self, "_data_version", 0) + 1
-        super().setData(*args, **kwargs)
 
     def set_data(self, x: list | np.ndarray, y: list | np.ndarray):
         """
@@ -276,8 +355,11 @@ class Curve(BECConnector, pg.PlotDataItem):
             symbol(str): Symbol of the curve.
         """
         self.config.symbol = symbol
-        self.setSymbol(symbol)
-        self.updateItems()
+        # While the curve is dense the symbol stays hidden; the config keeps the
+        # request so it takes effect once the data drops below the limit.
+        if not self._symbols_suppressed:
+            self.setSymbol(symbol)
+            self.updateItems()
 
     def set_symbol_color(self, symbol_color: str):
         """

--- a/bec_widgets/widgets/plots/waveform/waveform.py
+++ b/bec_widgets/widgets/plots/waveform/waveform.py
@@ -136,6 +136,8 @@ class Waveform(PlotBase):
     PLUGIN = True
     RPC = True
     ICON_NAME = "show_chart"
+    # Curves are drawn by PlotCurveItem, which has a shader path in pyqtgraph 0.14.
+    USE_OPENGL = True
     USER_ACCESS = [
         *PlotBase.USER_ACCESS,
         "_config_dict",

--- a/bec_widgets/widgets/plots/waveform/waveform.py
+++ b/bec_widgets/widgets/plots/waveform/waveform.py
@@ -136,8 +136,6 @@ class Waveform(PlotBase):
     PLUGIN = True
     RPC = True
     ICON_NAME = "show_chart"
-    # Curves are drawn by PlotCurveItem, which has a shader path in pyqtgraph 0.14.
-    USE_OPENGL = True
     USER_ACCESS = [
         *PlotBase.USER_ACCESS,
         "_config_dict",

--- a/bec_widgets/widgets/plots/waveform/waveform.py
+++ b/bec_widgets/widgets/plots/waveform/waveform.py
@@ -2349,10 +2349,12 @@ class Waveform(PlotBase):
     ) -> None:
         """
         Based on the length of the data this method will adjust the plotting settings of
-        Curve items, by deactivating the symbol and activating downsampling auto, method='mean',
+        Curve items, by thinning the pen and activating downsampling auto, method='mean',
         if the data length exceeds N points. If the data length is less than N points, the
-        symbol will be activated and downsampling will be deactivated. Maximum points will be
-        5x the limit.
+        pen is restored and downsampling deactivated. Maximum points will be 5x the limit.
+
+        The symbol is not handled here: `Curve.setData` hides it above
+        `CurveConfig.symbol_point_limit` for every curve, sync or async.
 
         Args:
             curve(Curve): The curve to adjust.
@@ -2364,14 +2366,11 @@ class Waveform(PlotBase):
             logger.warning("Limit must be greater than 1.")
             return
         if data_length > limit:
-            if curve.config.symbol is not None:
-                curve.set_symbol(None)
             if curve.config.pen_width > 3:
                 curve.set_pen_width(3)
             curve.setDownsampling(ds=None, auto=True, method=method)
             curve.setClipToView(True)
         elif data_length <= limit:
-            curve.set_symbol("o")
             curve.set_pen_width(4)
             curve.setDownsampling(ds=1, auto=None, method=method)
             curve.setClipToView(True)

--- a/bec_widgets/widgets/utility/feedback_dialog/feedback_dialog.pyproject
+++ b/bec_widgets/widgets/utility/feedback_dialog/feedback_dialog.pyproject
@@ -1,0 +1,1 @@
+{'files': ['feedback_dialog.py']}

--- a/bec_widgets/widgets/utility/feedback_dialog/feedback_dialog_plugin.py
+++ b/bec_widgets/widgets/utility/feedback_dialog/feedback_dialog_plugin.py
@@ -1,0 +1,57 @@
+# Copyright (C) 2022 The Qt Company Ltd.
+# SPDX-License-Identifier: LicenseRef-Qt-Commercial OR BSD-3-Clause
+
+from qtpy.QtDesigner import QDesignerCustomWidgetInterface
+from qtpy.QtWidgets import QWidget
+
+from bec_widgets.utils.bec_designer import designer_material_icon
+from bec_widgets.widgets.utility.feedback_dialog.feedback_dialog import FeedbackDialog
+
+DOM_XML = """
+<ui language='c++'>
+    <widget class='FeedbackDialog' name='feedback_dialog'>
+    </widget>
+</ui>
+"""
+
+
+class FeedbackDialogPlugin(QDesignerCustomWidgetInterface):  # pragma: no cover
+    def __init__(self):
+        super().__init__()
+        self._form_editor = None
+
+    def createWidget(self, parent):
+        if parent is None:
+            return QWidget()
+        t = FeedbackDialog(parent)
+        return t
+
+    def domXml(self):
+        return DOM_XML
+
+    def group(self):
+        return ""
+
+    def icon(self):
+        return designer_material_icon(FeedbackDialog.ICON_NAME)
+
+    def includeFile(self):
+        return "feedback_dialog"
+
+    def initialize(self, form_editor):
+        self._form_editor = form_editor
+
+    def isContainer(self):
+        return False
+
+    def isInitialized(self):
+        return self._form_editor is not None
+
+    def name(self):
+        return "FeedbackDialog"
+
+    def toolTip(self):
+        return ""
+
+    def whatsThis(self):
+        return self.toolTip()

--- a/bec_widgets/widgets/utility/feedback_dialog/register_feedback_dialog.py
+++ b/bec_widgets/widgets/utility/feedback_dialog/register_feedback_dialog.py
@@ -1,0 +1,15 @@
+def main():  # pragma: no cover
+    from qtpy import PYSIDE6
+
+    if not PYSIDE6:
+        print("PYSIDE6 is not available in the environment. Cannot patch designer.")
+        return
+    from PySide6.QtDesigner import QPyDesignerCustomWidgetCollection
+
+    from bec_widgets.widgets.utility.feedback_dialog.feedback_dialog_plugin import FeedbackDialogPlugin
+
+    QPyDesignerCustomWidgetCollection.addCustomWidget(FeedbackDialogPlugin())
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/gpu_bench.py
+++ b/gpu_bench.py
@@ -1,0 +1,75 @@
+"""Benchmark the pyqtgraph 0.14 OpenGL viewport against the raster path.
+
+Measures *render* cost only: the curve data is generated up front and cycled
+frame to frame, so numpy work does not pollute the timing. vsync is disabled
+via the swap interval so the OpenGL path is not pinned to the display refresh.
+
+    python gpu_bench.py [n_points] [n_curves]
+"""
+
+import sys
+import time
+
+import numpy as np
+import pyqtgraph as pg
+from qtpy import QtCore, QtGui, QtWidgets
+
+N_POINTS = int(sys.argv[1]) if len(sys.argv) > 1 else 100_000
+N_CURVES = int(sys.argv[2]) if len(sys.argv) > 2 else 3
+FRAMES = 60
+N_PRESET = 10
+
+
+def _bench(use_opengl: bool, label: str, datasets, x) -> float:
+    pg.setConfigOption("useOpenGL", use_opengl)
+    pg.setConfigOption("enableExperimental", use_opengl)
+
+    win = pg.GraphicsLayoutWidget()
+    win.resize(1200, 800)
+    plot = win.addPlot()
+    curves = []
+    for c in range(N_CURVES):
+        curve = pg.PlotDataItem(pen=pg.mkPen(pg.intColor(c), width=1))
+        plot.addItem(curve)
+        curves.append(curve)
+    plot.enableAutoRange(False)
+    plot.setXRange(0, N_POINTS)
+    plot.setYRange(-2, 2)
+    win.show()
+
+    deadline = time.perf_counter() + 1.0
+    while time.perf_counter() < deadline:
+        QtWidgets.QApplication.processEvents()
+
+    viewport = win.viewport().__class__.__name__
+    start = time.perf_counter()
+    for i in range(FRAMES):
+        for c, curve in enumerate(curves):
+            curve.setData(x, datasets[(i + c) % N_PRESET])
+        win.viewport().repaint()
+        QtWidgets.QApplication.processEvents()
+    elapsed = time.perf_counter() - start
+
+    win.close()
+    fps = FRAMES / elapsed
+    print(f"  {label:<26} viewport={viewport:<22} {fps:7.1f} fps  ({1000 / fps:6.1f} ms/frame)")
+    return fps
+
+
+if __name__ == "__main__":
+    # disable vsync before the QApplication so QOpenGLWidget is not capped at ~60 Hz
+    fmt = QtGui.QSurfaceFormat.defaultFormat()
+    fmt.setSwapInterval(0)
+    QtGui.QSurfaceFormat.setDefaultFormat(fmt)
+
+    app = QtWidgets.QApplication(sys.argv)
+    print(f"pyqtgraph {pg.__version__}  |  Qt {QtCore.qVersion()}  |  swapInterval=0")
+    print(f"{N_CURVES} curves x {N_POINTS:,} points, {FRAMES} frames (data pre-generated)\n")
+
+    x = np.arange(N_POINTS, dtype=np.float64)
+    rng = np.random.default_rng(0)
+    datasets = [np.sin(x * 0.001 + k) + rng.normal(0, 0.1, N_POINTS) for k in range(N_PRESET)]
+
+    raster = _bench(False, "raster (QPainter)", datasets, x)
+    opengl = _bench(True, "opengl (QOpenGLWidget)", datasets, x)
+    print(f"  -> speedup {opengl / raster:.2f}x")

--- a/gpu_bench.py
+++ b/gpu_bench.py
@@ -20,7 +20,14 @@ FRAMES = 60
 N_PRESET = 10
 
 
-def _bench(use_opengl: bool, label: str, datasets, x) -> float:
+def _bench(use_opengl: bool, label: str, datasets, x) -> float | None:
+    """Time FRAMES repaints, returning fps -- or None if the frames never rendered.
+
+    An unexposed or occluded window turns `repaint()` into a no-op for the raster
+    viewport while the OpenGL viewport still renders into its own framebuffer.
+    That yields wildly optimistic raster numbers, so every curve paint is counted
+    and the result is discarded unless each curve painted once per frame.
+    """
     pg.setConfigOption("useOpenGL", use_opengl)
     pg.setConfigOption("enableExperimental", use_opengl)
 
@@ -36,21 +43,43 @@ def _bench(use_opengl: bool, label: str, datasets, x) -> float:
     plot.setXRange(0, N_POINTS)
     plot.setYRange(-2, 2)
     win.show()
+    win.raise_()
+    win.activateWindow()
 
     deadline = time.perf_counter() + 1.0
     while time.perf_counter() < deadline:
         QtWidgets.QApplication.processEvents()
 
-    viewport = win.viewport().__class__.__name__
-    start = time.perf_counter()
-    for i in range(FRAMES):
-        for c, curve in enumerate(curves):
-            curve.setData(x, datasets[(i + c) % N_PRESET])
-        win.viewport().repaint()
-        QtWidgets.QApplication.processEvents()
-    elapsed = time.perf_counter() - start
+    paints = 0
+    original_paint = pg.PlotCurveItem.paint
 
-    win.close()
+    def counting_paint(self, *args, **kwargs):
+        nonlocal paints
+        paints += 1
+        return original_paint(self, *args, **kwargs)
+
+    pg.PlotCurveItem.paint = counting_paint
+    viewport = win.viewport().__class__.__name__
+    try:
+        start = time.perf_counter()
+        for i in range(FRAMES):
+            for c, curve in enumerate(curves):
+                curve.setData(x, datasets[(i + c) % N_PRESET])
+            win.viewport().repaint()
+            QtWidgets.QApplication.processEvents()
+        elapsed = time.perf_counter() - start
+    finally:
+        pg.PlotCurveItem.paint = original_paint
+        win.close()
+
+    expected = FRAMES * N_CURVES
+    if paints < expected:
+        print(
+            f"  {label:<26} viewport={viewport:<22} INVALID "
+            f"({paints}/{expected} curve paints -- window not rendering)"
+        )
+        return None
+
     fps = FRAMES / elapsed
     print(f"  {label:<26} viewport={viewport:<22} {fps:7.1f} fps  ({1000 / fps:6.1f} ms/frame)")
     return fps
@@ -72,4 +101,7 @@ if __name__ == "__main__":
 
     raster = _bench(False, "raster (QPainter)", datasets, x)
     opengl = _bench(True, "opengl (QOpenGLWidget)", datasets, x)
+    if raster is None or opengl is None:
+        print("  -> no speedup reported: at least one run did not actually render")
+        sys.exit(1)
     print(f"  -> speedup {opengl / raster:.2f}x")

--- a/tests/unit_tests/benchmarks/test_gpu_widget_benchmark.py
+++ b/tests/unit_tests/benchmarks/test_gpu_widget_benchmark.py
@@ -1,0 +1,266 @@
+"""End-to-end render benchmark for Waveform and Image, with and without OpenGL.
+
+Drives each widget through the *real* data-entry point of whichever branch it is
+run on, so the numbers include the widget-side data handling, not just pyqtgraph:
+
+- ``data_api`` branch: a ``SubscriptionUpdate`` is handed to ``_on_data_update``,
+  which includes the columnar alignment work.
+- ``main``: ``update_sync_curves`` pulls a prepared scan-data dict (the fetch from
+  the scan item is stubbed, since that needs a live BEC), and the image widget is
+  fed through ``on_image_update_2d``.
+
+The network/Redis hop is outside the measured region on both branches -- what is
+compared is "a data snapshot is available -> pixels on screen".
+
+Run explicitly (it is excluded from the CI suite by ``--ignore``)::
+
+    QT_QPA_PLATFORM=offscreen pytest tests/unit_tests/benchmarks/test_gpu_widget_benchmark.py -s
+
+Environment knobs: ``BENCH_FRAMES`` (default 40), ``BENCH_POINTS`` (default 50000),
+``BENCH_IMAGE`` (image edge length, default 2048).
+"""
+
+import os
+import time
+
+import numpy as np
+import pyqtgraph as pg
+import pytest
+
+from bec_widgets.utils.gpu_acceleration import opengl_available, set_view_opengl
+from bec_widgets.widgets.plots.image.image import Image
+from bec_widgets.widgets.plots.waveform.waveform import Waveform
+from tests.unit_tests.client_mocks import mocked_client
+from tests.unit_tests.conftest import create_widget
+
+try:
+    from bec_lib.data_api.models import SourceData, SubscriptionUpdate
+
+    HAS_DATA_API = True
+except ImportError:  # main branch
+    HAS_DATA_API = False
+
+FRAMES = int(os.environ.get("BENCH_FRAMES", 40))
+POINTS = int(os.environ.get("BENCH_POINTS", 50_000))
+IMAGE_EDGE = int(os.environ.get("BENCH_IMAGE", 2048))
+N_PRESET = 8
+DEVICE, ENTRY = "bpm4i", "bpm4i"
+
+_results: list[tuple[str, str, float | None]] = []
+_data_path: dict[str, list[float]] = {}
+
+
+def _make_update(values: np.ndarray, ordinals: tuple[int, ...], kind: str = "monitored"):
+    """Build a single-source SubscriptionUpdate carrying `values`."""
+    source = SourceData(
+        device=DEVICE,
+        entry=ENTRY,
+        kind=kind,
+        ordinals=ordinals,
+        values=tuple(values),
+        timestamps=tuple(float(o) for o in ordinals),
+        complete=True,
+    )
+    return SubscriptionUpdate(
+        scan_id="bench-scan",
+        reason="live",
+        sources={(DEVICE, ENTRY): source},
+        aligned_ordinals=ordinals,
+        complete=True,
+    )
+
+
+def _time_frames(widget, inject, count_paint_on, qtbot) -> float | None:
+    """Run FRAMES inject-and-render cycles; None if the frames never rendered.
+
+    Each frame waits for the item to actually paint before starting the next.
+    ``repaint()`` is not usable here: on a QOpenGLWidget it defers, so a
+    synchronous count sees zero. An unexposed window also makes painting a no-op
+    for the raster viewport while OpenGL still renders, which would silently
+    flatter raster -- hence the explicit per-frame confirmation.
+    """
+    paints = 0
+    original = count_paint_on.paint
+
+    def counting_paint(self, *args, **kwargs):
+        nonlocal paints
+        paints += 1
+        return original(self, *args, **kwargs)
+
+    count_paint_on.paint = counting_paint
+    rendered = 0
+    try:
+        # The first paint after the window appears needs a generous stretch of
+        # event loop; 1 ms slices never get there. Warm up until one lands, then
+        # the per-frame polling below keeps up on its own.
+        warmup_deadline = time.perf_counter() + 10.0
+        while paints == 0 and time.perf_counter() < warmup_deadline:
+            inject(0)
+            widget.plot_widget.viewport().update()
+            try:
+                qtbot.waitUntil(lambda: paints > 0, timeout=1000)
+            except Exception:
+                pass
+        if paints == 0:
+            return None
+
+        start = time.perf_counter()
+        for i in range(FRAMES):
+            before = paints
+            inject(i)
+            widget.plot_widget.viewport().update()
+            # waitUntil spins pytest-qt's own event loop; hand-rolled
+            # processEvents()/wait() polling does not deliver these paint events.
+            try:
+                qtbot.waitUntil(lambda: paints > before, timeout=5000)
+                rendered += 1
+            except Exception:
+                pass
+        elapsed = time.perf_counter() - start
+    finally:
+        count_paint_on.paint = original
+
+    if rendered < FRAMES:
+        print(
+            f"    [diag] rendered={rendered}/{FRAMES} paints={paints} "
+            f"viewport={type(widget.plot_widget.viewport()).__name__} "
+            f"visible={widget.isVisible()} items={len(widget.plot_widget.scene().items())}"
+        )
+        return None
+    return FRAMES / elapsed
+
+
+def _time_data_path(inject, iterations: int) -> float:
+    """Time the widget-side data handling alone, in ms per update.
+
+    This is the part that differs between branches (DataAPI columnar alignment
+    vs. the scan-item dict walk) and it needs no window, so unlike the render
+    timing it is reliable regardless of whether the session composites.
+    """
+    inject(0)  # warm caches
+    start = time.perf_counter()
+    for i in range(iterations):
+        inject(i)
+    return (time.perf_counter() - start) * 1000 / iterations
+
+
+def _report(label: str, mode: str, fps: float | None) -> None:
+    _results.append((label, mode, fps))
+    if fps is None:
+        print(f"  {label:<26} {mode:<8} INVALID (frames did not render)")
+    else:
+        print(f"  {label:<26} {mode:<8} {fps:8.1f} fps  ({1000 / fps:7.2f} ms/frame)")
+
+
+def _setup_waveform(qtbot, mocked_client, use_opengl: bool):
+    wf = create_widget(qtbot, Waveform, client=mocked_client)
+    set_view_opengl(wf.plot_widget, use_opengl)
+    wf.plot(arg1=DEVICE)
+    wf.resize(1200, 800)
+    wf.show()
+    qtbot.waitExposed(wf)
+    return wf
+
+
+def _waveform_injector(wf, x, datasets):
+    """Return a per-frame injector using this branch's real data path."""
+    if HAS_DATA_API:
+        ordinals = tuple(range(POINTS))
+        updates = [_make_update(d, ordinals) for d in datasets]
+        return lambda i: wf._on_data_update(updates[i % N_PRESET])
+
+    # main: update_sync_curves() reads the scan data dict it fetches
+    payloads = [{DEVICE: {ENTRY: {"val": d}}} for d in datasets]
+    state = {"i": 0}
+
+    def fetch():
+        return payloads[state["i"] % N_PRESET], "val"
+
+    wf._fetch_scan_data_and_access = fetch
+    wf._get_x_data = lambda *a, **k: x
+
+    def inject(i):
+        state["i"] = i
+        wf.update_sync_curves()
+
+    return inject
+
+
+def _setup_image(qtbot, mocked_client, use_opengl: bool):
+    img = create_widget(qtbot, Image, client=mocked_client)
+    set_view_opengl(img.plot_widget, use_opengl)
+    img.image(DEVICE, ENTRY)
+    img.resize(1200, 800)
+    img.show()
+    qtbot.waitExposed(img)
+    return img
+
+
+def _image_injector(img, frames):
+    if HAS_DATA_API:
+        img._source_key = (DEVICE, ENTRY)
+        img.subscriptions["main"].monitor_type = "2d"
+        # a plain list keeps each frame a float32 ndarray; np.array([f], dtype=object)
+        # yields an object-dtype array and the downstream isnan() blows up
+        updates = [_make_update([f], (0,), kind="async") for f in frames]
+        return lambda i: img._on_data_update(updates[i % N_PRESET])
+
+    img.async_update = False
+    return lambda i: img.on_image_update_2d({"data": frames[i % N_PRESET]}, {})
+
+
+@pytest.mark.parametrize("use_opengl", [False, True], ids=["raster", "opengl"])
+def test_waveform_render_benchmark(qtbot, mocked_client, use_opengl):
+    if use_opengl and not opengl_available(True):
+        pytest.skip("no hardware OpenGL available")
+
+    rng = np.random.default_rng(0)
+    x = np.arange(POINTS, dtype=np.float64)
+    datasets = [np.sin(x * 0.001 + k) + rng.normal(0, 0.1, POINTS) for k in range(N_PRESET)]
+
+    wf = _setup_waveform(qtbot, mocked_client, use_opengl)
+    inject = _waveform_injector(wf, x, datasets)
+    inject(0)  # warm up the curve/GL state before timing
+    qtbot.wait(200)
+
+    ms = _time_data_path(inject, FRAMES)
+    fps = _time_frames(wf, inject, pg.PlotCurveItem, qtbot)
+    _report(f"Waveform {POINTS:,}pts", "opengl" if use_opengl else "raster", fps)
+    _data_path.setdefault(f"Waveform {POINTS:,}pts", []).append(ms)
+
+
+@pytest.mark.parametrize("use_opengl", [False, True], ids=["raster", "opengl"])
+def test_image_render_benchmark(qtbot, mocked_client, use_opengl):
+    if use_opengl and not opengl_available(True):
+        pytest.skip("no hardware OpenGL available")
+
+    rng = np.random.default_rng(0)
+    frames = [rng.normal(size=(IMAGE_EDGE, IMAGE_EDGE)).astype(np.float32) for _ in range(N_PRESET)]
+
+    img = _setup_image(qtbot, mocked_client, use_opengl)
+    inject = _image_injector(img, frames)
+    inject(0)
+    qtbot.wait(200)
+
+    ms = _time_data_path(inject, FRAMES)
+    fps = _time_frames(img, inject, pg.ImageItem, qtbot)
+    _report(f"Image {IMAGE_EDGE}x{IMAGE_EDGE}", "opengl" if use_opengl else "raster", fps)
+    _data_path.setdefault(f"Image {IMAGE_EDGE}x{IMAGE_EDGE}", []).append(ms)
+
+
+def teardown_module(module):
+    branch = "data_api" if HAS_DATA_API else "main"
+    print(f"\n==== summary ({branch} data path, {FRAMES} frames) ====")
+    by_label: dict[str, dict[str, float | None]] = {}
+    for label, mode, fps in _results:
+        by_label.setdefault(label, {})[mode] = fps
+    for label, modes in by_label.items():
+        raster, opengl = modes.get("raster"), modes.get("opengl")
+        if raster and opengl:
+            print(f"  {label:<26} render speedup {opengl / raster:5.2f}x")
+        else:
+            print(f"  {label:<26} render speedup n/a (a run did not render)")
+    print(f"---- widget-side data path ({branch}) ----")
+    for label, samples in _data_path.items():
+        best = min(samples)
+        print(f"  {label:<26} {best:8.3f} ms/update  (best of {len(samples)})")

--- a/tests/unit_tests/test_curve_symbol_limit.py
+++ b/tests/unit_tests/test_curve_symbol_limit.py
@@ -1,0 +1,119 @@
+"""The symbol is dropped for dense curves; see Curve.setData."""
+
+import numpy as np
+import pytest
+
+from bec_widgets.widgets.plots.waveform.curve import Curve, CurveConfig, _incoming_length
+from bec_widgets.widgets.plots.waveform.waveform import Waveform
+
+from .client_mocks import mocked_client
+from .conftest import create_widget
+
+LIMIT = 1000
+
+
+@pytest.fixture
+def curve(qtbot, mocked_client):
+    waveform = create_widget(qtbot, Waveform, client=mocked_client)
+    waveform.plot(arg1="bpm4i")
+    return waveform.curves[0]
+
+
+def _data(n: int):
+    x = np.arange(n, dtype=np.float64)
+    return x, np.sin(x * 0.01)
+
+
+def test_symbol_kept_at_or_below_limit(curve):
+    curve.setData(*_data(LIMIT))
+    assert curve.opts["symbol"] == "o"
+
+
+def test_symbol_hidden_above_limit(curve):
+    curve.setData(*_data(LIMIT + 1))
+    assert curve.opts["symbol"] is None
+
+
+def test_config_symbol_survives_suppression(curve):
+    """The configured symbol is a user setting, not something to overwrite."""
+    curve.setData(*_data(LIMIT + 1))
+    assert curve.config.symbol == "o"
+
+
+def test_symbol_restored_when_data_shrinks(curve):
+    curve.setData(*_data(LIMIT + 1))
+    assert curve.opts["symbol"] is None
+    curve.setData(*_data(10))
+    assert curve.opts["symbol"] == "o"
+
+
+def test_custom_symbol_restored_not_default(curve):
+    """Restoring must use the configured symbol, not a hardcoded 'o'."""
+    curve.set_symbol("t")
+    curve.setData(*_data(LIMIT + 1))
+    assert curve.opts["symbol"] is None
+    curve.setData(*_data(10))
+    assert curve.opts["symbol"] == "t"
+
+
+def test_set_symbol_while_dense_defers_until_sparse(curve):
+    curve.setData(*_data(LIMIT + 1))
+    curve.set_symbol("x")
+    # still dense: the request is recorded but not shown
+    assert curve.config.symbol == "x"
+    assert curve.opts["symbol"] is None
+    curve.setData(*_data(10))
+    assert curve.opts["symbol"] == "x"
+
+
+def test_apply_config_does_not_resurrect_symbol_while_dense(curve):
+    curve.setData(*_data(LIMIT + 1))
+    curve.apply_config()
+    assert curve.opts["symbol"] is None
+
+
+def test_limit_none_keeps_symbol_at_any_size(qtbot, mocked_client):
+    waveform = create_widget(qtbot, Waveform, client=mocked_client)
+    waveform.plot(arg1="bpm4i")
+    curve = waveform.curves[0]
+    curve.config.symbol_point_limit = None
+    curve.setData(*_data(50_000))
+    assert curve.opts["symbol"] == "o"
+
+
+def test_custom_limit_is_honoured(curve):
+    curve.config.symbol_point_limit = 10
+    curve.setData(*_data(11))
+    assert curve.opts["symbol"] is None
+    curve.setData(*_data(10))
+    assert curve.opts["symbol"] == "o"
+
+
+def test_default_limit_is_1000():
+    assert CurveConfig(widget_class="Curve").symbol_point_limit == LIMIT
+
+
+@pytest.mark.parametrize(
+    "args,kwargs,expected",
+    [
+        ((np.arange(5),), {}, 5),
+        ((np.arange(5), np.arange(5)), {}, 5),
+        (((1, 2, 3),), {}, 3),
+        (([1, 2, 3, 4],), {}, 4),
+        ((), {"y": np.arange(7)}, 7),
+        ((), {"x": np.arange(7)}, 7),
+        ((), {}, 0),
+        (({"x": [1], "y": [2]},), {}, None),
+        (([{"pos": (0, 0)}],), {}, None),
+    ],
+)
+def test_incoming_length(args, kwargs, expected):
+    assert _incoming_length(args, kwargs) == expected
+
+
+def test_unresolvable_length_leaves_symbol_untouched(curve):
+    """A shape we cannot measure must not silently flip the symbol."""
+    curve.setData(*_data(10))
+    assert curve.opts["symbol"] == "o"
+    curve.setData({"x": np.arange(5000), "y": np.arange(5000)})
+    assert curve.opts["symbol"] == "o"

--- a/tests/unit_tests/test_gpu_acceleration.py
+++ b/tests/unit_tests/test_gpu_acceleration.py
@@ -5,7 +5,12 @@ from qtpy.QtOpenGLWidgets import QOpenGLWidget
 from qtpy.QtWidgets import QLabel, QVBoxLayout, QWidget
 
 from bec_widgets.utils import gpu_acceleration
-from bec_widgets.utils.gpu_acceleration import ENV_VAR, grab_widget, opengl_available
+from bec_widgets.utils.gpu_acceleration import (
+    ENV_VAR,
+    grab_widget,
+    opengl_available,
+    set_view_opengl,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -63,6 +68,62 @@ def test_unrecognised_env_var_falls_back_to_auto(monkeypatch):
     _fake_renderer(monkeypatch, "NVIDIA GeForce RTX 3090")
     monkeypatch.setenv(ENV_VAR, "maybe")
     assert opengl_available(requested=True) is True
+
+
+def _curve_view(qtbot, use_opengl: bool):
+    pg.setConfigOption("useOpenGL", use_opengl)
+    view = pg.GraphicsLayoutWidget()
+    plot = view.addPlot()
+    x = np.arange(5_000, dtype=np.float64)
+    plot.addItem(pg.PlotDataItem(x, np.sin(x * 0.01), pen=pg.mkPen("r", width=2)))
+    view.resize(400, 300)
+    qtbot.addWidget(view)
+    view.show()
+    qtbot.waitExposed(view)
+    return view
+
+
+def test_set_view_opengl_toggles_viewport(qtbot):
+    view = _curve_view(qtbot, use_opengl=False)
+    if not gpu_acceleration.opengl_available(True):
+        pytest.skip("no hardware OpenGL available in this environment")
+
+    assert set_view_opengl(view, True) is True
+    assert isinstance(view.viewport(), QOpenGLWidget)
+    assert set_view_opengl(view, False) is False
+    assert not isinstance(view.viewport(), QOpenGLWidget)
+
+
+def test_set_view_opengl_is_idempotent(qtbot):
+    view = _curve_view(qtbot, use_opengl=False)
+    viewport = view.viewport()
+    assert set_view_opengl(view, False) is False
+    # no needless swap: the same viewport object is kept
+    assert view.viewport() is viewport
+
+
+def test_toggling_back_to_opengl_does_not_strand_gl_state(qtbot):
+    """Swapping the viewport deletes the item's OpenGLState on the C++ side.
+
+    Without clearing the stale reference, the next paintGL raises
+    'Signal source has been deleted'. PlotCurveItem.paint swallows that, so the
+    curve silently stops rendering instead of crashing.
+    """
+    view = _curve_view(qtbot, use_opengl=True)
+    if not isinstance(view.viewport(), QOpenGLWidget):
+        pytest.skip("no OpenGL viewport available in this environment")
+
+    curve = next(i for i in view.scene().items() if isinstance(i, pg.PlotCurveItem))
+    view.viewport().repaint()
+    assert curve.glstate is not None, "expected the GL path to have been taken"
+
+    set_view_opengl(view, False)
+    assert curve.glstate is None, "stale OpenGLState was not released on swap"
+
+    set_view_opengl(view, True)
+    view.viewport().repaint()
+    # rebuilt against the new context rather than reusing the deleted object
+    assert curve.glstate is not None
 
 
 def _non_background_fraction(pixmap) -> float:

--- a/tests/unit_tests/test_gpu_acceleration.py
+++ b/tests/unit_tests/test_gpu_acceleration.py
@@ -1,0 +1,116 @@
+import numpy as np
+import pyqtgraph as pg
+import pytest
+from qtpy.QtOpenGLWidgets import QOpenGLWidget
+from qtpy.QtWidgets import QLabel, QVBoxLayout, QWidget
+
+from bec_widgets.utils import gpu_acceleration
+from bec_widgets.utils.gpu_acceleration import ENV_VAR, grab_widget, opengl_available
+
+
+@pytest.fixture(autouse=True)
+def _reset_opengl_probe(monkeypatch):
+    """Keep the cached context probe and pyqtgraph's global config out of other tests."""
+    # hold on to the real cached function: monkeypatch may swap the module
+    # attribute for a stub, and it is only restored after this fixture resumes
+    probe = gpu_acceleration.opengl_info
+    probe.cache_clear()
+    monkeypatch.delenv(ENV_VAR, raising=False)
+    previous = pg.getConfigOption("useOpenGL")
+    yield
+    pg.setConfigOption("useOpenGL", previous)
+    probe.cache_clear()
+
+
+def _fake_renderer(monkeypatch, renderer: str | None):
+    info = None if renderer is None else {"vendor": "v", "renderer": renderer, "version": "4.1"}
+    monkeypatch.setattr(gpu_acceleration, "opengl_info", lambda: info)
+
+
+def test_opengl_available_requires_opt_in(monkeypatch):
+    _fake_renderer(monkeypatch, "NVIDIA GeForce RTX 3090")
+    assert opengl_available(requested=True) is True
+    assert opengl_available(requested=False) is False
+
+
+def test_opengl_refused_without_context(monkeypatch):
+    _fake_renderer(monkeypatch, None)
+    assert opengl_available(requested=True) is False
+
+
+@pytest.mark.parametrize("renderer", ["llvmpipe (LLVM 15.0.7, 256 bits)", "softpipe", "SWRast"])
+def test_opengl_refused_on_software_renderer(monkeypatch, renderer):
+    """A remote/X-forwarded session must stay on the raster viewport."""
+    _fake_renderer(monkeypatch, renderer)
+    assert opengl_available(requested=True) is False
+
+
+def test_env_var_forces_opengl_on_software_renderer(monkeypatch):
+    _fake_renderer(monkeypatch, "llvmpipe (LLVM 15.0.7, 256 bits)")
+    monkeypatch.setenv(ENV_VAR, "1")
+    assert opengl_available(requested=True) is True
+    # forcing on also overrides a widget that did not ask for it
+    assert opengl_available(requested=False) is True
+
+
+def test_env_var_disables_opengl(monkeypatch):
+    _fake_renderer(monkeypatch, "NVIDIA GeForce RTX 3090")
+    monkeypatch.setenv(ENV_VAR, "0")
+    assert opengl_available(requested=True) is False
+
+
+def test_unrecognised_env_var_falls_back_to_auto(monkeypatch):
+    _fake_renderer(monkeypatch, "NVIDIA GeForce RTX 3090")
+    monkeypatch.setenv(ENV_VAR, "maybe")
+    assert opengl_available(requested=True) is True
+
+
+def _non_background_fraction(pixmap) -> float:
+    """Fraction of pixels differing from the most common colour."""
+    image = pixmap.toImage()
+    buffer = np.frombuffer(image.constBits(), dtype=np.uint8)
+    arr = buffer.reshape(image.height(), image.bytesPerLine() // 4, 4)
+    flat = arr[:, : image.width(), :3].reshape(-1, 3)
+    colours, counts = np.unique(flat, axis=0, return_counts=True)
+    return float(np.any(flat != colours[counts.argmax()], axis=1).mean())
+
+
+def _plot_host(qtbot, use_opengl: bool):
+    pg.setConfigOption("useOpenGL", use_opengl)
+    host = QWidget()
+    layout = QVBoxLayout(host)
+    layout.addWidget(QLabel("scan 42"))
+    view = pg.GraphicsLayoutWidget()
+    layout.addWidget(view)
+    plot = view.addPlot()
+    x = np.arange(5_000, dtype=np.float64)
+    plot.addItem(pg.PlotDataItem(x, np.sin(x * 0.01), pen=pg.mkPen("r", width=2)))
+    plot.enableAutoRange(False)
+    plot.setXRange(0, 5_000)
+    plot.setYRange(-1.5, 1.5)
+    host.resize(640, 460)
+    qtbot.addWidget(host)
+    host.show()
+    qtbot.waitExposed(host)
+    return host, view
+
+
+def test_grab_widget_matches_plain_grab_without_opengl(qtbot):
+    host, view = _plot_host(qtbot, use_opengl=False)
+    assert not isinstance(view.viewport(), QOpenGLWidget)
+    assert _non_background_fraction(grab_widget(host)) == pytest.approx(
+        _non_background_fraction(host.grab())
+    )
+
+
+def test_grab_widget_recovers_plot_on_opengl_viewport(qtbot):
+    """QWidget.grab() alone returns a blank plot area over an OpenGL viewport."""
+    host, view = _plot_host(qtbot, use_opengl=True)
+    if not isinstance(view.viewport(), QOpenGLWidget):
+        pytest.skip("no OpenGL viewport available in this environment")
+
+    plain = _non_background_fraction(host.grab())
+    composited = _non_background_fraction(grab_widget(host))
+    assert composited > plain
+    # the plot fills most of the host, so a correct capture is far from empty
+    assert composited > 0.05

--- a/tests/unit_tests/test_plot_base_next_gen.py
+++ b/tests/unit_tests/test_plot_base_next_gen.py
@@ -1,5 +1,9 @@
 import numpy as np
+import pytest
+from qtpy.QtOpenGLWidgets import QOpenGLWidget
 
+import bec_widgets.widgets.plots.plot_base as plot_base_module
+from bec_widgets.utils.gpu_acceleration import opengl_available
 from bec_widgets.widgets.plots.plot_base import PlotBase, UIMode
 
 from .client_mocks import mocked_client
@@ -588,3 +592,35 @@ def test_update_rate_widget_defaults():
     assert Waveform.DEFAULT_UPDATE_RATE == 15.0
     assert Heatmap.DEFAULT_UPDATE_RATE == 5.0
     assert Image.DEFAULT_UPDATE_RATE == 25.0
+
+
+def test_use_opengl_defaults_to_true_when_available(qtbot, mocked_client):
+    """PlotBase opts into the OpenGL viewport by default."""
+    pb = create_widget(qtbot, PlotBase, client=mocked_client)
+    assert pb.USE_OPENGL is True
+    assert pb.use_opengl is opengl_available(True)
+
+
+def test_use_opengl_can_be_toggled_at_runtime(qtbot, mocked_client):
+    """The viewport can be swapped after the widget is built."""
+    pb = create_widget(qtbot, PlotBase, client=mocked_client)
+    if not opengl_available(True):
+        pytest.skip("no hardware OpenGL available in this environment")
+
+    pb.use_opengl = False
+    assert pb.use_opengl is False
+    assert not isinstance(pb.plot_widget.viewport(), QOpenGLWidget)
+
+    pb.use_opengl = True
+    assert pb.use_opengl is True
+    assert isinstance(pb.plot_widget.viewport(), QOpenGLWidget)
+
+
+def test_use_opengl_declines_without_hardware_context(qtbot, mocked_client, monkeypatch):
+    """Requesting OpenGL on a software renderer leaves the raster viewport in place."""
+    pb = create_widget(qtbot, PlotBase, client=mocked_client)
+    monkeypatch.setattr(plot_base_module, "opengl_available", lambda requested=True: False)
+
+    pb.use_opengl = True
+    assert pb.use_opengl is False
+    assert not isinstance(pb.plot_widget.viewport(), QOpenGLWidget)


### PR DESCRIPTION
## Description

GPU-accelerated plotting via the pyqtgraph 0.14 OpenGL viewport, plus the CPU-side fixes that
dominated waveform updates (per-point symbol rendering).

Stacked on **DataAPI** — merge that first.

## Related Issues

- closes #392 

## Type of Change

- `PlotBase.use_opengl` property (default on, runtime switchable, falls back to raster without
  hardware OpenGL)

## How to test

- Run unit tests
- Open a Waveform in DockArea toggle `use_opengl`, compare performance with/without.
- Plot a scan with >1000 points: markers drop out, curve stays responsive

## Potential side effects

- Curves above 1000 points no longer show markers by default (`symbol_point_limit = None` opts out)
- Line antialiasing is not pixel-identical to the raster path

## Screenshots / GIFs (if applicable)

<!-- optional -->

## Additional Comments

Tested on macOS and on Linux virtual consoles. Images gain nothing (no shader path for `ImageItem`);
the win is curves — roughly break-even below ~5k points, ~16x at 100k.

