### PR TITLE
Fix/pascal widget title

### DIFF
--- a/bec_widgets/utils/name_utils.py
+++ b/bec_widgets/utils/name_utils.py
@@ -16,6 +16,20 @@ def pascal_to_snake(name: str) -> str:
     return s2.lower()
 
 
+def pascal_to_title(name: str) -> str:
+    """
+    Convert PascalCase to a space-separated title.
+
+    Args:
+        name (str): The name to be converted.
+
+    Returns:
+        str: The converted name.
+    """
+    s1 = re.sub(r"([a-z0-9])([A-Z])", r"\1 \2", name)
+    return re.sub(r"([A-Z]+)([A-Z][a-z])", r"\1 \2", s1)
+
+
 def sanitize_namespace(namespace: str | None) -> str | None:
     """
     Clean user-provided namespace labels for filesystem compatibility.

--- a/bec_widgets/widgets/containers/dock_area/dock_area.py
+++ b/bec_widgets/widgets/containers/dock_area/dock_area.py
@@ -26,6 +26,7 @@ from bec_widgets.utils.bec_plugin_helper import (
     get_plugin_widget_icons,
 )
 from bec_widgets.utils.colors import apply_theme
+from bec_widgets.utils.name_utils import pascal_to_title
 from bec_widgets.utils.plugin_utils import get_rpc_widget_registry
 from bec_widgets.utils.rpc_decorator import rpc_timeout
 from bec_widgets.utils.rpc_widget_handler import widget_handler
@@ -88,7 +89,11 @@ def _plugin_toolbar_actions() -> dict[str, tuple[str, str, str]]:
     plugin_icons = get_plugin_widget_icons()
 
     return {
-        widget_name: (plugin_icons.get(widget_name, "widgets"), f"Add {widget_name}", widget_name)
+        widget_name: (
+            plugin_icons.get(widget_name, "widgets"),
+            pascal_to_title(widget_name),
+            widget_name,
+        )
         for widget_name in sorted(plugin_registry)
         if widget_name not in internal_registry
     }

--- a/tests/unit_tests/test_dock_area.py
+++ b/tests/unit_tests/test_dock_area.py
@@ -1083,7 +1083,7 @@ class TestToolbarFunctionality:
             plugin_actions = dock_area_module._plugin_toolbar_actions()
 
         assert plugin_actions == {
-            "FakePluginWidget": ("star", "Add FakePluginWidget", "FakePluginWidget")
+            "FakePluginWidget": ("star", "Fake Plugin Widget", "FakePluginWidget")
         }
 
     def test_plugin_toolbar_actions_ignore_builtin_name_collisions(

--- a/tests/unit_tests/test_name_utils.py
+++ b/tests/unit_tests/test_name_utils.py
@@ -1,9 +1,14 @@
-from bec_widgets.utils.name_utils import pascal_to_snake, sanitize_namespace
+from bec_widgets.utils.name_utils import pascal_to_snake, pascal_to_title, sanitize_namespace
 
 
 def test_pascal_to_snake():
     assert pascal_to_snake("DeviceWithinLimitsState") == "device_within_limits_state"
     assert pascal_to_snake("BECStatusWidget") == "bec_status_widget"
+
+
+def test_pascal_to_title():
+    assert pascal_to_title("DigitalTwin") == "Digital Twin"
+    assert pascal_to_title("BECStatusWidget") == "BEC Status Widget"
 
 
 def test_sanitize_namespace():


### PR DESCRIPTION
## Related Issues

closes #1280 

## Type of Change

- Remove the "add" prefix from sub menu entries
- Split Pascal-cased class names into separate words for the title

